### PR TITLE
[codex] add ModelOpt diffusion quant skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ skills/
 │   └── references/
 │       ├── playbook.md
 │       └── pr-history.md
+├── sglang-diffusion-modelopt-quant/
+│   ├── SKILL.md
+│   └── agents/
+│       └── openai.yaml
 ├── sglang-minimax-m2-m25-optimization/
 │   ├── SKILL.md
 │   └── references/
@@ -52,4 +56,7 @@ The `h100` and `h100-sglang-diffusion` skills use placeholder values. Replace th
 cp -r skills/h100 ~/.codex/skills/h100
 # or
 cp -r skills/h100 ~/.cursor/skills/h100
+
+# ModelOpt diffusion quant skill
+cp -r skills/sglang-diffusion-modelopt-quant ~/.codex/skills/sglang-diffusion-modelopt-quant
 ```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ skills/
 │       └── pr-history.md
 ├── sglang-diffusion-modelopt-quant/
 │   ├── SKILL.md
+│   ├── scripts/
+│   │   ├── compare_diffusion_trajectory_similarity.py
+│   │   └── convert_modelopt_fp8_checkpoint.py
 │   └── agents/
 │       └── openai.yaml
 ├── sglang-minimax-m2-m25-optimization/

--- a/skills/sglang-diffusion-modelopt-quant/SKILL.md
+++ b/skills/sglang-diffusion-modelopt-quant/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: sglang-diffusion-modelopt-quant
+description: Use when quantizing a diffusion DiT with NVIDIA ModelOpt and making the resulting FP8 or NVFP4 checkpoint loadable, verifiable, and benchmarkable in SGLang Diffusion. This is the right skill for ModelOpt export conversion, BF16-vs-quant validation, multi-transformer override wiring, and remote GPU bring-up with skills such as `rtx5090`.
+---
+
+# SGLang Diffusion ModelOpt Quant
+
+## Overview
+
+Use this skill when the task is to take a diffusion transformer through the full ModelOpt workflow: quantize it, adapt the export to SGLang, verify that quality holds up, and check whether the quantized checkpoint is actually faster.
+
+Run commands from the SGLang repo root unless the task explicitly says otherwise. When the work needs real CUDA validation, pair this skill with a remote GPU skill such as `rtx5090` or `h100-sglang-diffusion`.
+
+## Core Rules
+
+- Use ModelOpt's official diffusion quantization entrypoint as the PTQ source of truth.
+- Keep the workflow generic. Put model-specific fallback logic in small isolated branches, not in the main conversion path.
+- Benchmark only when the BF16 and quantized commands are identical except for the checkpoint override being tested.
+- For diffusion FP8, pin `dit_cpu_offload=false` and `dit_layerwise_offload=false`.
+- For multi-transformer pipelines, prefer per-component overrides when different backbones need different checkpoints.
+- If the active SGLang branch does not yet contain the expected conversion or validation tool, add it under `python/sglang/multimodal_gen/tools/` instead of inventing one-off scripts elsewhere.
+
+## Read First
+
+Read these sources before changing code:
+
+- NVIDIA ModelOpt diffusion guide:
+  - `examples/diffusers/README.md`
+  - `examples/diffusers/quantization/quantize.py`
+  - `examples/diffusers/quantization/config.py`
+- SGLang diffusion quantization and loading paths:
+  - `python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py`
+  - `python/sglang/multimodal_gen/runtime/utils/quantization_utils.py`
+  - `python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py`
+- SGLang diffusion tools:
+  - `python/sglang/multimodal_gen/tools/convert_modelopt_fp8_checkpoint.py`
+  - `python/sglang/multimodal_gen/tools/compare_diffusion_trajectory_similarity.py`
+
+If you are working on a new model family, inspect the model's transformer config and tensor naming before changing the generic converter.
+
+## What This Skill Owns
+
+This skill is for the ModelOpt-to-SGLang bridge:
+
+- quantizing a diffusion DiT with ModelOpt
+- converting or adapting the export so SGLang can load it
+- validating BF16 versus quantized quality with fixed prompt and seed
+- benchmarking under matched settings
+- adding or refining model-specific fallback logic only when the generic path is insufficient
+
+It is not a general kernel-tuning or diffusion architecture design skill.
+
+## FP8 Vs NVFP4
+
+FP8 and NVFP4 usually need different treatment.
+
+FP8:
+- the validated ModelOpt diffusion export typically still needs an extra SGLang-side conversion step
+- SGLang expects explicit `weight_scale` and `input_scale`
+- the validated path usually materializes SGLang-native `float8_e4m3fn` weights from `backbone.pt`
+
+NVFP4:
+- the export often already contains packed FP4 weights, scale tensors, and enough metadata for SGLang to reconstruct the quant config
+- in that case SGLang mainly needs the right loader detection and tensor layout handling
+- packed-QKV families still need special care
+
+"Often" does not mean "always". The exact load path depends on the checkpoint family and tensor layout.
+
+## Workflow
+
+### 1. Verify The BF16 Baseline First
+
+Before quantizing anything:
+
+- run the original BF16 model in SGLang
+- fix the prompt, seed, size, step count, and GPU topology
+- save the output plus timing or `perf.json`
+
+Do not start ModelOpt work until the BF16 path is already healthy.
+
+### 2. Quantize With Official ModelOpt
+
+Generic template:
+
+```bash
+python quantize.py \
+  --model <model-name> \
+  --override-model-path <hf-repo-or-local-model> \
+  --model-dtype <Half|BFloat16> \
+  --format <fp8|nvfp4> \
+  --batch-size 1 \
+  --calib-size <calib-size> \
+  --n-steps <calib-steps> \
+  --quantize-mha \
+  --prompts-file <prompt-file> \
+  --quantized-torch-ckpt-save-path <out>/ckpt \
+  --hf-ckpt-dir <out>/hf
+```
+
+For multi-transformer models:
+- quantize each backbone deliberately
+- keep each output directory separate
+- save both `backbone.pt` and the matching `hf/<component>` export
+
+### 3. Convert FP8 Exports For SGLang
+
+FP8 usually needs an extra conversion step:
+
+```bash
+PYTHONPATH=python python3 -m sglang.multimodal_gen.tools.convert_modelopt_fp8_checkpoint \
+  --modelopt-hf-dir <out>/hf \
+  --modelopt-backbone-ckpt <out>/ckpt/backbone.pt \
+  --base-transformer-dir <base-model-transformer-dir> \
+  --output-dir <out>/sglang_transformer \
+  --overwrite
+```
+
+The converter should:
+- read `weight_quantizer._amax` and `input_quantizer._amax` from `backbone.pt`
+- write `weight_scale` and `input_scale`
+- materialize eligible FP8 weights as `float8_e4m3fn`
+- preserve ModelOpt `ignore` layers as BF16
+
+For multi-transformer pipelines, run the converter once per exported backbone.
+
+### 4. Load The Quantized Checkpoint In SGLang
+
+Single-transformer example:
+
+```bash
+sglang generate \
+  --model-path <base-model> \
+  --transformer-path <quantized-transformer> \
+  --prompt "<prompt>" \
+  --seed <seed> \
+  --save-output
+```
+
+Multi-transformer example:
+
+```bash
+sglang generate \
+  --model-path <base-model> \
+  --transformer-path <quantized-transformer> \
+  --transformer-2-path <another-transformer-or-bf16-override> \
+  --prompt "<prompt>" \
+  --seed <seed> \
+  --save-output
+```
+
+Guidelines:
+- use global `--transformer-path` only when one transformer override is enough
+- use `--<component>-path` when components differ
+- if a config-expanded form also works, keep the CLI readable in examples
+
+### 5. Validate Accuracy
+
+Use two levels of validation.
+
+Reduced deterministic validation:
+- keep prompt, seed, resolution, and step count fixed
+- compare BF16 and quantized runs
+- capture denoising trajectories
+- inspect per-step latent cosine similarity plus MAE or RMSE
+- compare final frames with image metrics such as PSNR or MAE
+
+Tool:
+
+```bash
+PYTHONPATH=python python3 -m sglang.multimodal_gen.tools.compare_diffusion_trajectory_similarity \
+  --model-path <base-model> \
+  --prompt "<prompt>" \
+  --width <w> \
+  --height <h> \
+  --num-inference-steps <steps> \
+  --guidance-scale <cfg> \
+  --seed <seed> \
+  --candidate-transformer-path <quantized-transformer> \
+  --output-json <report.json>
+```
+
+Full-output validation:
+- run the real user-facing generation config in both BF16 and quantized mode
+- inspect images or representative video frames visually
+- only claim "quality preserved" for the exact scope you actually checked
+
+### 6. Benchmark Correctly
+
+Benchmark only when these match between BF16 and quantized runs:
+
+- prompt
+- seed
+- width and height
+- frame count
+- inference step count
+- GPU count and topology
+- offload flags
+- compile settings
+- profiler settings
+
+Only the checkpoint override should differ.
+
+Interpretation rule:
+- the main expected gain is usually in denoising
+- do not over-attribute wins in unrelated stages unless those components were also quantized
+
+### 7. Add Model-Specific Fallbacks Only When Needed
+
+If the generic FP8 path fails on a new model family:
+
+- inspect which modules are numerically sensitive or loader-incompatible
+- keep fallback patterns small and explicit
+- isolate them in the converter instead of scattering ad-hoc exceptions
+- re-run deterministic trajectory checks after every fallback change
+
+Do not turn one validated model quirk into a generic rule unless another family also needs it.
+
+## FP8 Offload Constraint
+
+Current diffusion ModelOpt FP8 support requires:
+
+- `dit_cpu_offload=false`
+- `dit_layerwise_offload=false`
+
+Reason:
+- the FP8 linear path depends on a CUTLASS-compatible weight layout after loading
+- offload and restore paths do not reliably preserve that layout
+- layerwise offload in particular can rebuild weights in a way that breaks the column-major contract expected by the FP8 GEMM path
+
+Keep those flags pinned explicitly in benchmark commands even if the runtime also guards them.
+
+## Reference Models
+
+Useful validated references:
+
+- `black-forest-labs/FLUX.2-dev`
+- `Wan-AI/Wan2.2-T2V-A14B-Diffusers`
+
+Use them as sanity checks for workflow shape, not as proof that a new model family needs the same fallback profile.
+
+## Current Code Areas
+
+These are the first places to inspect when wiring a new quantized diffusion model:
+
+- `python/sglang/multimodal_gen/runtime/layers/quantization/__init__.py`
+- `python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py`
+- `python/sglang/multimodal_gen/runtime/utils/quantization_utils.py`
+- `python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py`
+- `python/sglang/multimodal_gen/runtime/models/dits/`
+- `python/sglang/multimodal_gen/tools/convert_modelopt_fp8_checkpoint.py`
+- `python/sglang/multimodal_gen/tools/compare_diffusion_trajectory_similarity.py`
+
+## Claim Discipline
+
+When documenting results:
+
+- claim only scopes that were actually validated end to end
+- do not collapse "primary-transformer FP8" into "full-model FP8"
+- do not call it a fair benchmark if BF16 and quantized runs used different offload behavior

--- a/skills/sglang-diffusion-modelopt-quant/SKILL.md
+++ b/skills/sglang-diffusion-modelopt-quant/SKILL.md
@@ -18,7 +18,7 @@ Run commands from the SGLang repo root unless the task explicitly says otherwise
 - Benchmark only when the BF16 and quantized commands are identical except for the checkpoint override being tested.
 - For diffusion FP8, pin `dit_cpu_offload=false` and `dit_layerwise_offload=false`.
 - For multi-transformer pipelines, prefer per-component overrides when different backbones need different checkpoints.
-- If the active SGLang branch does not yet contain the expected conversion or validation tool, add it under `python/sglang/multimodal_gen/tools/` instead of inventing one-off scripts elsewhere.
+- If the active SGLang branch does not yet contain the expected conversion or validation tool, start from this skill's bundled `scripts/` copy and add it under `python/sglang/multimodal_gen/tools/` instead of inventing one-off scripts elsewhere.
 
 ## Read First
 
@@ -32,9 +32,9 @@ Read these sources before changing code:
   - `python/sglang/multimodal_gen/runtime/layers/quantization/modelopt_quant.py`
   - `python/sglang/multimodal_gen/runtime/utils/quantization_utils.py`
   - `python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py`
-- SGLang diffusion tools:
-  - `python/sglang/multimodal_gen/tools/convert_modelopt_fp8_checkpoint.py`
-  - `python/sglang/multimodal_gen/tools/compare_diffusion_trajectory_similarity.py`
+- Bundled helper scripts in this skill:
+  - `scripts/convert_modelopt_fp8_checkpoint.py`
+  - `scripts/compare_diffusion_trajectory_similarity.py`
 
 If you are working on a new model family, inspect the model's transformer config and tensor naming before changing the generic converter.
 

--- a/skills/sglang-diffusion-modelopt-quant/agents/openai.yaml
+++ b/skills/sglang-diffusion-modelopt-quant/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SGLang Diffusion ModelOpt Quant"
+  short_description: "ModelOpt FP8/NVFP4 quantization workflow for SGLang Diffusion"
+  default_prompt: "Quantize a diffusion DiT with NVIDIA ModelOpt and make the resulting FP8 or NVFP4 checkpoint loadable, verifiable, and benchmarkable in SGLang Diffusion."

--- a/skills/sglang-diffusion-modelopt-quant/scripts/compare_diffusion_trajectory_similarity.py
+++ b/skills/sglang-diffusion-modelopt-quant/scripts/compare_diffusion_trajectory_similarity.py
@@ -1,0 +1,452 @@
+"""Compare diffusion BF16 and quantized runs via trajectory-latent similarity.
+
+This tool runs two SGLang diffusion variants with the same prompt and seed,
+captures intermediate denoising latents via `return_trajectory_latents`, and
+reports cosine / error metrics for each timestep plus final frame metrics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any, Sequence
+
+import imageio.v3 as iio
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+
+def parse_component_overrides(entries: Sequence[str] | None) -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    for entry in entries or []:
+        if "=" not in entry:
+            raise ValueError(
+                f"Invalid component override '{entry}'. Expected format component=path."
+            )
+        component, path = entry.split("=", 1)
+        component = component.strip().replace("-", "_")
+        path = path.strip()
+        if not component or not path:
+            raise ValueError(
+                f"Invalid component override '{entry}'. Expected format component=path."
+            )
+        overrides[component] = path
+    return overrides
+
+
+def _cosine_similarity(flat_a: torch.Tensor, flat_b: torch.Tensor) -> float:
+    norm_a = torch.linalg.vector_norm(flat_a).item()
+    norm_b = torch.linalg.vector_norm(flat_b).item()
+    if norm_a == 0.0 and norm_b == 0.0:
+        return 1.0
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return float(F.cosine_similarity(flat_a, flat_b, dim=0).item())
+
+
+def compute_tensor_metrics(lhs: Any, rhs: Any) -> dict[str, float]:
+    lhs_tensor = torch.as_tensor(lhs).detach().cpu().float()
+    rhs_tensor = torch.as_tensor(rhs).detach().cpu().float()
+    if lhs_tensor.shape != rhs_tensor.shape:
+        raise ValueError(
+            f"Metric shape mismatch: {tuple(lhs_tensor.shape)} vs {tuple(rhs_tensor.shape)}"
+        )
+
+    diff = lhs_tensor - rhs_tensor
+    mse = float(diff.square().mean().item())
+    rmse = float(math.sqrt(mse))
+    mae = float(diff.abs().mean().item())
+    max_abs = float(diff.abs().max().item())
+    l2 = float(torch.linalg.vector_norm(diff).item())
+    cosine = _cosine_similarity(lhs_tensor.reshape(-1), rhs_tensor.reshape(-1))
+    return {
+        "cosine_similarity": cosine,
+        "mae": mae,
+        "mse": mse,
+        "rmse": rmse,
+        "max_abs": max_abs,
+        "l2": l2,
+    }
+
+
+def compute_uint8_frame_metrics(lhs: Any, rhs: Any) -> dict[str, float]:
+    metrics = compute_tensor_metrics(lhs, rhs)
+    mse = metrics["mse"]
+    metrics["psnr_db"] = (
+        float("inf") if mse == 0.0 else 20 * math.log10(255.0) - 10 * math.log10(mse)
+    )
+    return metrics
+
+
+def _normalize_step_index(step_index: int, num_steps: int) -> int:
+    if num_steps <= 0:
+        raise ValueError("num_steps must be positive.")
+    if step_index < 0:
+        step_index += num_steps
+    if step_index < 0 or step_index >= num_steps:
+        raise IndexError(
+            f"Requested step index {step_index} is outside the valid range [0, {num_steps})."
+        )
+    return step_index
+
+
+def _maybe_scalar(timestep: torch.Tensor | None, index: int) -> float | None:
+    if timestep is None:
+        return None
+    value = timestep[index]
+    if isinstance(value, torch.Tensor):
+        value = value.detach().cpu()
+        if value.numel() == 1:
+            return float(value.item())
+    return float(value)
+
+
+def summarize_trajectory_metrics(
+    reference_latents: Any,
+    candidate_latents: Any,
+    *,
+    reference_timesteps: Any = None,
+    candidate_timesteps: Any = None,
+    step_index: int = -1,
+) -> dict[str, Any]:
+    ref = torch.as_tensor(reference_latents).detach().cpu().float()
+    cand = torch.as_tensor(candidate_latents).detach().cpu().float()
+    if ref.shape != cand.shape:
+        raise ValueError(
+            f"Trajectory shape mismatch: {tuple(ref.shape)} vs {tuple(cand.shape)}"
+        )
+    if ref.ndim < 2:
+        raise ValueError(
+            f"Expected trajectory latents with an explicit timestep dimension, got {tuple(ref.shape)}"
+        )
+
+    num_steps = ref.shape[1]
+    selected_step = _normalize_step_index(step_index, num_steps)
+    ref_t = (
+        torch.as_tensor(reference_timesteps).detach().cpu()
+        if reference_timesteps is not None
+        else None
+    )
+    cand_t = (
+        torch.as_tensor(candidate_timesteps).detach().cpu()
+        if candidate_timesteps is not None
+        else None
+    )
+
+    per_step: list[dict[str, Any]] = []
+    for idx in range(num_steps):
+        metrics = compute_tensor_metrics(ref[:, idx], cand[:, idx])
+        metrics["step_index"] = idx
+        metrics["reference_timestep"] = _maybe_scalar(ref_t, idx)
+        metrics["candidate_timestep"] = _maybe_scalar(cand_t, idx)
+        per_step.append(metrics)
+
+    return {
+        "trajectory_shape": list(ref.shape),
+        "num_steps": num_steps,
+        "selected_step_index": selected_step,
+        "selected_step_metrics": per_step[selected_step],
+        "per_step_metrics": per_step,
+    }
+
+
+def summarize_output_frame_metrics(
+    reference_frames: Sequence[Any],
+    candidate_frames: Sequence[Any],
+) -> dict[str, Any]:
+    if len(reference_frames) != len(candidate_frames):
+        raise ValueError(
+            f"Output frame count mismatch: {len(reference_frames)} vs {len(candidate_frames)}"
+        )
+    if not reference_frames:
+        raise ValueError("No output frames available for comparison.")
+
+    ref_stack = np.stack([np.asarray(frame) for frame in reference_frames], axis=0)
+    cand_stack = np.stack([np.asarray(frame) for frame in candidate_frames], axis=0)
+
+    frame0_metrics = compute_uint8_frame_metrics(ref_stack[0], cand_stack[0])
+    mid_index = len(reference_frames) // 2
+    mid_metrics = compute_uint8_frame_metrics(
+        ref_stack[mid_index], cand_stack[mid_index]
+    )
+    all_metrics = compute_uint8_frame_metrics(ref_stack, cand_stack)
+
+    return {
+        "num_frames": len(reference_frames),
+        "frame0_metrics": frame0_metrics,
+        "mid_frame_index": mid_index,
+        "mid_frame_metrics": mid_metrics,
+        "all_frames_metrics": all_metrics,
+    }
+
+
+def extract_result_frames(result: Any) -> list[np.ndarray]:
+    if result.frames is not None:
+        return [np.asarray(frame) for frame in result.frames]
+
+    sample = result.samples
+    if sample is None:
+        if result.output_file_path:
+            output_path = Path(result.output_file_path)
+            if not output_path.exists():
+                raise ValueError(
+                    "GenerationResult did not contain frames or samples, and its "
+                    f"output_file_path does not exist: {output_path}"
+                )
+            if output_path.suffix.lower() in {".png", ".jpg", ".jpeg", ".webp"}:
+                return [np.asarray(iio.imread(output_path))]
+            return [np.asarray(frame) for frame in iio.imiter(output_path)]
+        raise ValueError(
+            "GenerationResult did not contain frames, samples, or a readable output_file_path."
+        )
+
+    if isinstance(sample, torch.Tensor):
+        tensor = sample.detach().cpu().float()
+        if tensor.ndim == 3:
+            tensor = tensor.unsqueeze(1)
+        if tensor.ndim != 4:
+            raise ValueError(
+                f"Unsupported tensor sample shape for frame extraction: {tuple(tensor.shape)}"
+            )
+        tensor = (tensor * 255).clamp(0, 255).to(torch.uint8)
+        frames = tensor.permute(1, 2, 3, 0).contiguous().numpy()
+        return [frame for frame in frames]
+
+    array = np.asarray(sample)
+    if array.ndim == 2:
+        array = array[..., None]
+    if array.ndim == 3:
+        if array.shape[-1] in (1, 3, 4):
+            array = array[None, ...]
+        else:
+            array = array[..., None]
+    if array.ndim != 4:
+        raise ValueError(
+            f"Unsupported numpy sample shape for frame extraction: {tuple(array.shape)}"
+        )
+    if array.dtype != np.uint8:
+        array = (np.clip(array, 0.0, 1.0) * 255.0).astype(np.uint8)
+    return [frame for frame in array]
+
+
+def build_server_kwargs(args: argparse.Namespace, *, variant: str) -> dict[str, Any]:
+    component_paths = parse_component_overrides(
+        getattr(args, f"{variant}_component_path") or []
+    )
+    transformer_path = getattr(args, f"{variant}_transformer_path")
+
+    kwargs: dict[str, Any] = {
+        "model_path": args.model_path,
+        "backend": args.backend,
+        "num_gpus": args.num_gpus,
+        "dit_cpu_offload": args.dit_cpu_offload,
+        "dit_layerwise_offload": args.dit_layerwise_offload,
+        "text_encoder_cpu_offload": args.text_encoder_cpu_offload,
+        "vae_cpu_offload": args.vae_cpu_offload,
+        "pin_cpu_memory": args.pin_cpu_memory,
+        "enable_cfg_parallel": args.enable_cfg_parallel,
+        "ulysses_degree": args.ulysses_degree,
+    }
+    if args.sp_degree is not None:
+        kwargs["sp_degree"] = args.sp_degree
+    if transformer_path is not None:
+        kwargs["transformer_weights_path"] = transformer_path
+    if component_paths:
+        kwargs["component_paths"] = component_paths
+    return kwargs
+
+
+def build_sampling_kwargs(
+    args: argparse.Namespace, *, output_dir: str | None = None
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "prompt": args.prompt,
+        "width": args.width,
+        "height": args.height,
+        "num_inference_steps": args.num_inference_steps,
+        "guidance_scale": args.guidance_scale,
+        "seed": args.seed,
+        "return_frames": True,
+        "return_trajectory_latents": True,
+        "return_trajectory_decoded": args.return_trajectory_decoded,
+        "save_output": output_dir is not None,
+    }
+    if output_dir is not None:
+        kwargs["output_path"] = output_dir
+    if args.num_frames is not None:
+        kwargs["num_frames"] = args.num_frames
+    if args.guidance_scale_2 is not None:
+        kwargs["guidance_scale_2"] = args.guidance_scale_2
+    return kwargs
+
+
+def run_variant(
+    *,
+    server_kwargs: dict[str, Any],
+    sampling_kwargs: dict[str, Any],
+):
+    from sglang.multimodal_gen.runtime.entrypoints.diffusion_generator import (
+        DiffGenerator,
+    )
+
+    with DiffGenerator.from_pretrained(local_mode=True, **server_kwargs) as generator:
+        result = generator.generate(sampling_params_kwargs=sampling_kwargs)
+
+    if isinstance(result, list):
+        if len(result) != 1:
+            raise ValueError(
+                f"Expected a single generation result, got {len(result)} results."
+            )
+        result = result[0]
+    if result is None:
+        raise RuntimeError("Generation returned no result.")
+    return result
+
+
+def _to_jsonable(result: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(result, allow_nan=True))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument("--backend", default="sglang")
+    parser.add_argument("--prompt", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--width", type=int, required=True)
+    parser.add_argument("--height", type=int, required=True)
+    parser.add_argument("--num-frames", type=int)
+    parser.add_argument("--num-inference-steps", type=int, required=True)
+    parser.add_argument("--guidance-scale", type=float, required=True)
+    parser.add_argument("--guidance-scale-2", type=float)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--num-gpus", type=int, default=1)
+    parser.add_argument("--ulysses-degree", type=int, default=1)
+    parser.add_argument("--sp-degree", type=int)
+    parser.add_argument("--trajectory-step-index", type=int, default=-1)
+    parser.add_argument("--reference-transformer-path")
+    parser.add_argument("--candidate-transformer-path")
+    parser.add_argument(
+        "--reference-component-path",
+        action="append",
+        default=[],
+        help="Repeatable component override in the form component=path.",
+    )
+    parser.add_argument(
+        "--candidate-component-path",
+        action="append",
+        default=[],
+        help="Repeatable component override in the form component=path.",
+    )
+    parser.add_argument("--save-output-dir")
+    parser.add_argument(
+        "--return-trajectory-decoded",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument(
+        "--dit-cpu-offload",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument(
+        "--dit-layerwise-offload",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument(
+        "--text-encoder-cpu-offload",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument(
+        "--vae-cpu-offload",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    parser.add_argument(
+        "--pin-cpu-memory",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
+    parser.add_argument(
+        "--enable-cfg-parallel",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
+    args = parser.parse_args()
+
+    save_output_dir = None
+    if args.save_output_dir is not None:
+        save_output_dir = Path(args.save_output_dir).expanduser().resolve()
+        save_output_dir.mkdir(parents=True, exist_ok=True)
+
+    reference_server_kwargs = build_server_kwargs(args, variant="reference")
+    candidate_server_kwargs = build_server_kwargs(args, variant="candidate")
+    reference_sampling_kwargs = build_sampling_kwargs(
+        args,
+        output_dir=(
+            str(save_output_dir / "reference") if save_output_dir is not None else None
+        ),
+    )
+    candidate_sampling_kwargs = build_sampling_kwargs(
+        args,
+        output_dir=(
+            str(save_output_dir / "candidate") if save_output_dir is not None else None
+        ),
+    )
+
+    reference_result = run_variant(
+        server_kwargs=reference_server_kwargs,
+        sampling_kwargs=reference_sampling_kwargs,
+    )
+    candidate_result = run_variant(
+        server_kwargs=candidate_server_kwargs,
+        sampling_kwargs=candidate_sampling_kwargs,
+    )
+
+    trajectory_metrics = summarize_trajectory_metrics(
+        reference_result.trajectory_latents,
+        candidate_result.trajectory_latents,
+        reference_timesteps=getattr(reference_result, "timesteps", None),
+        candidate_timesteps=getattr(candidate_result, "timesteps", None),
+        step_index=args.trajectory_step_index,
+    )
+    frame_metrics = summarize_output_frame_metrics(
+        extract_result_frames(reference_result),
+        extract_result_frames(candidate_result),
+    )
+
+    report = {
+        "model_path": args.model_path,
+        "prompt": args.prompt,
+        "seed": args.seed,
+        "width": args.width,
+        "height": args.height,
+        "num_frames": args.num_frames,
+        "num_inference_steps": args.num_inference_steps,
+        "guidance_scale": args.guidance_scale,
+        "guidance_scale_2": args.guidance_scale_2,
+        "reference_server_kwargs": reference_server_kwargs,
+        "candidate_server_kwargs": candidate_server_kwargs,
+        "trajectory_metrics": trajectory_metrics,
+        "frame_metrics": frame_metrics,
+        "reference_output_file_path": reference_result.output_file_path,
+        "candidate_output_file_path": candidate_result.output_file_path,
+    }
+
+    output_json = Path(args.output_json).expanduser().resolve()
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(
+        json.dumps(_to_jsonable(report), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+    print(json.dumps(_to_jsonable(report), indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/sglang-diffusion-modelopt-quant/scripts/convert_modelopt_fp8_checkpoint.py
+++ b/skills/sglang-diffusion-modelopt-quant/scripts/convert_modelopt_fp8_checkpoint.py
@@ -1,0 +1,465 @@
+"""Convert a ModelOpt diffusion FP8 export into an SGLang-loadable checkpoint.
+
+The core conversion path is model-agnostic:
+- read the ModelOpt diffusers transformer export
+- rebuild per-layer `weight_scale` / `input_scale` tensors from `backbone.pt`
+- materialize SGLang-native `float8_e4m3fn` weights
+- preserve ModelOpt `ignore` layers in their original dtype
+
+Some models still benefit from a small validated BF16 fallback set. Those
+fallback profiles are intentionally isolated so the generic FP8 conversion path
+remains reusable across future diffusion backbones.
+
+Example:
+
+    python -m sglang.multimodal_gen.tools.convert_modelopt_fp8_checkpoint \
+        --modelopt-hf-dir /tmp/modelopt_flux2_fp8/hf \
+        --modelopt-backbone-ckpt /tmp/modelopt_flux2_fp8/ckpt/backbone.pt \
+        --base-transformer-dir /path/to/FLUX.2-dev/transformer \
+        --output-dir /tmp/modelopt_flux2_fp8/sglang_transformer
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import re
+import shutil
+from collections import defaultdict
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import load_file, save_file
+
+INDEX_FILENAMES = [
+    "model.safetensors.index.json",
+    "diffusion_pytorch_model.safetensors.index.json",
+]
+FP8_E4M3_MAXBOUND = 448.0
+DEFAULT_FLUX2_KEEP_BF16_PATTERNS = [
+    r"^time_guidance_embed\.(timestep_embedder|guidance_embedder)\.linear_[12]$",
+    r"^double_stream_modulation_(img|txt)\.linear$",
+    r"^single_stream_modulation\.linear$",
+    r"^x_embedder$",
+    r"^context_embedder$",
+    r"^norm_out\.linear$",
+]
+
+
+def _resolve_transformer_dir(path: str) -> str:
+    candidate = Path(path).expanduser().resolve()
+    if (candidate / "config.json").is_file():
+        return str(candidate)
+    transformer_dir = candidate / "transformer"
+    if (transformer_dir / "config.json").is_file():
+        return str(transformer_dir)
+    raise FileNotFoundError(f"Could not resolve a transformer directory from: {path}")
+
+
+def _resolve_backbone_ckpt(path: str) -> str:
+    candidate = Path(path).expanduser().resolve()
+    if candidate.is_file():
+        return str(candidate)
+    backbone_path = candidate / "backbone.pt"
+    if backbone_path.is_file():
+        return str(backbone_path)
+    raise FileNotFoundError(f"Could not resolve backbone.pt from: {path}")
+
+
+def _find_index_file(model_dir: str) -> str | None:
+    for filename in INDEX_FILENAMES:
+        candidate = os.path.join(model_dir, filename)
+        if os.path.isfile(candidate):
+            return filename
+
+    matches = sorted(
+        filename
+        for filename in os.listdir(model_dir)
+        if filename.endswith(".safetensors.index.json")
+    )
+    return matches[0] if matches else None
+
+
+def _load_weight_map(model_dir: str) -> tuple[dict[str, str], str | None]:
+    index_filename = _find_index_file(model_dir)
+    if index_filename is not None:
+        with open(os.path.join(model_dir, index_filename), encoding="utf-8") as f:
+            index_data = json.load(f)
+        return dict(index_data["weight_map"]), index_filename
+
+    safetensors_files = sorted(
+        filename
+        for filename in os.listdir(model_dir)
+        if filename.endswith(".safetensors")
+    )
+    if len(safetensors_files) != 1:
+        raise ValueError(
+            f"Expected an index file or a single safetensors shard in {model_dir}, "
+            f"found {len(safetensors_files)} shard(s)."
+        )
+
+    shard_name = safetensors_files[0]
+    with safe_open(
+        os.path.join(model_dir, shard_name), framework="pt", device="cpu"
+    ) as f:
+        weight_map = {key: shard_name for key in f.keys()}
+    index_filename = f"{Path(shard_name).stem}.safetensors.index.json"
+    return weight_map, index_filename
+
+
+def _load_config(model_dir: str) -> dict:
+    config_path = os.path.join(model_dir, "config.json")
+    with open(config_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def get_default_keep_bf16_patterns(
+    *, model_type: str, class_name: str | None
+) -> list[str]:
+    if model_type == "flux2":
+        return list(DEFAULT_FLUX2_KEEP_BF16_PATTERNS)
+    if model_type == "none":
+        return []
+    if class_name == "Flux2Transformer2DModel":
+        return list(DEFAULT_FLUX2_KEEP_BF16_PATTERNS)
+    return []
+
+
+def should_keep_bf16(
+    weight_name: str,
+    keep_bf16_patterns: Sequence[str],
+) -> bool:
+    if not keep_bf16_patterns:
+        return False
+
+    module_name = weight_name[:-7] if weight_name.endswith(".weight") else weight_name
+    return any(re.search(pattern, module_name) for pattern in keep_bf16_patterns)
+
+
+def is_ignored_by_modelopt(
+    weight_name: str,
+    ignore_patterns: Sequence[str],
+) -> bool:
+    if not ignore_patterns:
+        return False
+
+    module_name = weight_name[:-7] if weight_name.endswith(".weight") else weight_name
+    for pattern in ignore_patterns:
+        regex_str = pattern.replace(".", r"\.").replace("*", r".*")
+        if re.fullmatch(regex_str, module_name):
+            return True
+    return False
+
+
+def build_fp8_scale_map(
+    model_state_dict: Mapping[str, torch.Tensor],
+    *,
+    maxbound: float = FP8_E4M3_MAXBOUND,
+) -> dict[str, dict[str, torch.Tensor]]:
+    scale_map: dict[str, dict[str, torch.Tensor]] = {}
+    for key, value in model_state_dict.items():
+        if key.endswith(".weight_quantizer._amax"):
+            layer_name = key[: -len(".weight_quantizer._amax")]
+            scale_map.setdefault(f"{layer_name}.weight", {})["weight_scale"] = (
+                value.detach().to(torch.float32).reshape(1).cpu() / maxbound
+            )
+        elif key.endswith(".input_quantizer._amax"):
+            layer_name = key[: -len(".input_quantizer._amax")]
+            scale_map.setdefault(f"{layer_name}.weight", {})["input_scale"] = (
+                value.detach().to(torch.float32).reshape(1).cpu() / maxbound
+            )
+
+    return {
+        weight_name: scale_tensors
+        for weight_name, scale_tensors in scale_map.items()
+        if {"weight_scale", "input_scale"} <= set(scale_tensors)
+    }
+
+
+def quantize_fp8_weight(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    if weight.dtype == torch.float8_e4m3fn:
+        return weight.contiguous()
+
+    scale = weight_scale.to(weight.device, dtype=torch.float32)
+    if scale.numel() != 1:
+        raise ValueError(
+            f"Only per-tensor FP8 scales are supported for diffusion checkpoints, got shape {tuple(scale.shape)}."
+        )
+
+    quantized = (weight.to(torch.float32) / scale.reshape(1)).to(torch.float8_e4m3fn)
+    return quantized.cpu().contiguous()
+
+
+def _copy_non_shard_files(source_dir: str, output_dir: str) -> None:
+    ignored = set(INDEX_FILENAMES)
+    for entry in os.listdir(source_dir):
+        if entry.endswith(".safetensors") or entry in ignored:
+            continue
+        source_path = os.path.join(source_dir, entry)
+        output_path = os.path.join(output_dir, entry)
+        if os.path.isdir(source_path):
+            shutil.copytree(source_path, output_path, dirs_exist_ok=True)
+        else:
+            shutil.copy2(source_path, output_path)
+
+
+def _load_selected_tensors(
+    model_dir: str,
+    weight_map: Mapping[str, str],
+    tensor_names: Iterable[str],
+) -> dict[str, torch.Tensor]:
+    tensors: dict[str, torch.Tensor] = {}
+    names_by_file: dict[str, list[str]] = defaultdict(list)
+    for name in tensor_names:
+        names_by_file[weight_map[name]].append(name)
+
+    for filename, names in names_by_file.items():
+        shard_path = os.path.join(model_dir, filename)
+        with safe_open(shard_path, framework="pt", device="cpu") as f:
+            for name in names:
+                tensors[name] = f.get_tensor(name).contiguous()
+    return tensors
+
+
+def convert_modelopt_fp8_checkpoint(
+    *,
+    modelopt_hf_dir: str,
+    modelopt_backbone_ckpt: str,
+    output_dir: str,
+    base_transformer_dir: str | None = None,
+    model_type: str = "auto",
+    keep_bf16_patterns: Sequence[str] | None = None,
+    maxbound: float = FP8_E4M3_MAXBOUND,
+    overwrite: bool = False,
+) -> dict[str, int]:
+    source_dir = _resolve_transformer_dir(modelopt_hf_dir)
+    backbone_ckpt_path = _resolve_backbone_ckpt(modelopt_backbone_ckpt)
+    base_dir = (
+        _resolve_transformer_dir(base_transformer_dir) if base_transformer_dir else None
+    )
+
+    config = _load_config(source_dir)
+    quant_config = config.get("quantization_config")
+    if not isinstance(quant_config, dict):
+        raise ValueError(
+            "Expected a flat quantization_config dict in the ModelOpt export."
+        )
+    if (
+        quant_config.get("quant_method") != "modelopt"
+        or "FP8" not in str(quant_config.get("quant_algo", "")).upper()
+    ):
+        raise ValueError(
+            "This tool only supports ModelOpt diffusers FP8 exports "
+            "(quant_method=modelopt, quant_algo=FP8)."
+        )
+
+    class_name = config.get("_class_name")
+    ignore_patterns = list(quant_config.get("ignore", []) or [])
+    patterns = list(
+        get_default_keep_bf16_patterns(model_type=model_type, class_name=class_name)
+    )
+    if keep_bf16_patterns:
+        patterns.extend(keep_bf16_patterns)
+    if patterns and base_dir is None:
+        raise ValueError(
+            "BF16 fallback patterns are enabled, but --base-transformer-dir was not provided."
+        )
+
+    output_path = Path(output_dir).expanduser().resolve()
+    if output_path.exists():
+        if not overwrite:
+            raise FileExistsError(
+                f"Output directory already exists: {output_path}. Use --overwrite to replace it."
+            )
+        shutil.rmtree(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    _copy_non_shard_files(source_dir, str(output_path))
+
+    source_weight_map, index_filename = _load_weight_map(source_dir)
+    base_weight_map: dict[str, str] = {}
+    if base_dir is not None:
+        base_weight_map, _ = _load_weight_map(base_dir)
+
+    backbone_state = torch.load(backbone_ckpt_path, map_location="cpu")[
+        "model_state_dict"
+    ]
+    fp8_scale_map = build_fp8_scale_map(backbone_state, maxbound=maxbound)
+    serialized_quant_config = json.dumps(quant_config, sort_keys=True)
+
+    fallback_weight_names = sorted(
+        weight_name
+        for weight_name in source_weight_map
+        if weight_name.endswith(".weight") and should_keep_bf16(weight_name, patterns)
+    )
+    fallback_tensors = (
+        _load_selected_tensors(base_dir, base_weight_map, fallback_weight_names)
+        if fallback_weight_names
+        else {}
+    )
+
+    weights_by_file: dict[str, list[str]] = defaultdict(list)
+    for weight_name, filename in source_weight_map.items():
+        weights_by_file[filename].append(weight_name)
+
+    updated_weight_map: dict[str, str] = {}
+    total_size = 0
+    added_scale_count = 0
+    preserved_ignored_weight_count = 0
+
+    for filename, names in sorted(weights_by_file.items()):
+        shard_path = os.path.join(source_dir, filename)
+        shard_tensors = load_file(shard_path, device="cpu")
+
+        with safe_open(shard_path, framework="pt", device="cpu") as f:
+            metadata = dict(f.metadata() or {})
+
+        metadata.setdefault("format", "pt")
+        metadata["quantization_config"] = serialized_quant_config
+        metadata["_quantization_metadata"] = serialized_quant_config
+
+        for name in list(shard_tensors.keys()):
+            if name.endswith(".weight") and is_ignored_by_modelopt(
+                name, ignore_patterns
+            ):
+                preserved_ignored_weight_count += 1
+                continue
+            if name in fallback_tensors:
+                shard_tensors[name] = fallback_tensors[name]
+            if (
+                name.endswith(".weight")
+                and name in fp8_scale_map
+                and name not in fallback_tensors
+            ):
+                scale_tensors = fp8_scale_map[name]
+                shard_tensors[name] = quantize_fp8_weight(
+                    shard_tensors[name], scale_tensors["weight_scale"]
+                )
+                shard_tensors[name[:-7] + ".weight_scale"] = scale_tensors[
+                    "weight_scale"
+                ]
+                shard_tensors[name[:-7] + ".input_scale"] = scale_tensors["input_scale"]
+                added_scale_count += 2
+
+        save_file(shard_tensors, os.path.join(output_path, filename), metadata=metadata)
+
+        for name, tensor in shard_tensors.items():
+            updated_weight_map[name] = filename
+            total_size += tensor.element_size() * tensor.numel()
+
+        del shard_tensors
+        gc.collect()
+
+    with open(output_path / index_filename, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "metadata": {"total_size": total_size},
+                "weight_map": updated_weight_map,
+            },
+            f,
+            indent=2,
+            sort_keys=True,
+        )
+
+    return {
+        "quantized_weights": sum(
+            1
+            for name in source_weight_map
+            if name.endswith(".weight")
+            and name in fp8_scale_map
+            and not is_ignored_by_modelopt(name, ignore_patterns)
+        ),
+        "bf16_fallback_weights": len(fallback_weight_names),
+        "preserved_ignored_weights": preserved_ignored_weight_count,
+        "added_scale_tensors": added_scale_count,
+        "output_shards": len(weights_by_file),
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inject FP8 scales from ModelOpt backbone.pt into a diffusers export so "
+            "SGLang diffusion can load it natively."
+        )
+    )
+    parser.add_argument(
+        "--modelopt-hf-dir",
+        required=True,
+        help="ModelOpt --hf-ckpt-dir output, or its transformer subdirectory.",
+    )
+    parser.add_argument(
+        "--modelopt-backbone-ckpt",
+        required=True,
+        help="Path to backbone.pt, or the directory that contains it.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        help="Directory to write the converted SGLang transformer checkpoint.",
+    )
+    parser.add_argument(
+        "--base-transformer-dir",
+        help=(
+            "Original BF16 transformer directory (or parent model dir). Required when "
+            "BF16 fallback layers are enabled."
+        ),
+    )
+    parser.add_argument(
+        "--model-type",
+        choices=["auto", "flux2", "none"],
+        default="auto",
+        help=(
+            "Optional model-family BF16 fallback profile. 'none' uses the generic "
+            "conversion path. 'auto' only enables the validated FLUX.2 fallback "
+            "set when the export config says Flux2Transformer2DModel."
+        ),
+    )
+    parser.add_argument(
+        "--keep-bf16-pattern",
+        action="append",
+        default=[],
+        help=(
+            "Regex matched against module names without the trailing .weight. "
+            "Matching weights are copied from --base-transformer-dir instead of "
+            "staying in FP8."
+        ),
+    )
+    parser.add_argument(
+        "--maxbound",
+        type=float,
+        default=FP8_E4M3_MAXBOUND,
+        help="FP8 maxbound used to turn ModelOpt amax into a scale. E4M3 uses 448.",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace --output-dir if it already exists.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    stats = convert_modelopt_fp8_checkpoint(
+        modelopt_hf_dir=args.modelopt_hf_dir,
+        modelopt_backbone_ckpt=args.modelopt_backbone_ckpt,
+        output_dir=args.output_dir,
+        base_transformer_dir=args.base_transformer_dir,
+        model_type=args.model_type,
+        keep_bf16_patterns=args.keep_bf16_pattern,
+        maxbound=args.maxbound,
+        overwrite=args.overwrite,
+    )
+    print(json.dumps(stats, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a new `sglang-diffusion-modelopt-quant` skill to the skills repo
- document the ModelOpt diffusion FP8/NVFP4 workflow for SGLang Diffusion, including export conversion, BF16-vs-quant validation, benchmark discipline, and FP8 offload constraints
- add `agents/openai.yaml` metadata so the skill is easier to discover and invoke
- update the repository README to list the new skill and show how to install it into `~/.codex/skills`

## Why
This packages the ModelOpt diffusion quantization workflow into a reusable skill so future SGLang diffusion quant bring-up can be done consistently, especially when pairing it with remote GPU skills such as `rtx5090`.

## Validation
- `python3 /Users/bbuf/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/bbuf/工作目录/Common/SGLang-Auto-Driven-SKILLS/skills/sglang-diffusion-modelopt-quant`
