### PR TITLE
[codex] Add model PR optimization history docs

### DIFF
--- a/model-pr-optimization-history/kimi/README.en.md
+++ b/model-pr-optimization-history/kimi/README.en.md
@@ -1,0 +1,231 @@
+# SGLang Kimi K2 / K2 Thinking / K2.5 Support and Optimization Timeline
+
+This document is based on the latest SGLang `origin/main` snapshot `47c4b3825`, plus patch-level reading of the related merged, open, and closed PRs. It covers the main line originally represented by the `sglang-kimi-k2-k25-optimization` skill and adds the newer Kimi K2.5 DeepEP, W4AFP8, AMD MXFP4, and related tracks.
+
+The short conclusion is: as of `47c4b3825`, Kimi K2 and Kimi K2 Thinking have mainline support for regular MoE routing, Marlin W4A16 MoE, EP, and PCG. Kimi K2.5 has a dedicated multimodal wrapper and runtime plumbing for PP, DP ViT, Eagle3, PD disaggregation, and EPLB. The Kimi K2 Thinking `DeepEP + int4/Marlin` PR `#13789` was closed without merging; the active DeepEP direction is Kimi K2.5 W4A16 low-latency DeepEP in `#22496`.
+
+## 1. Chronological Overview
+
+| Created    |     PR | State  | Track            | Code Area                                       | Effect                                                                                  |
+| ---------- | -----: | ------ | ---------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------- |
+| 2025-07-14 |  #8021 | merged | Kimi K2          | `fused_moe_triton/configs`                      | Added H20-3e FP8 MoE tuning config.                                                     |
+| 2025-07-14 |  #8013 | merged | Kimi K2          | `sgl-kernel/csrc/gemm/dsv3_router_gemm_*`       | Made `dsv3_router_gemm` support 384 experts.                                            |
+| 2025-07-15 |  #8047 | merged | Kimi K2          | `fused_moe_triton/configs`                      | Added H20 FP8 MoE tuning config.                                                        |
+| 2025-07-20 |  #8176 | merged | Kimi K2          | `fused_moe_triton/configs`                      | Added H200 TP16 Kimi K2 MoE config.                                                     |
+| 2025-07-20 |  #8178 | merged | Kimi K2          | `fused_moe_triton/configs`                      | Added B200 TP16 Kimi K2 MoE config.                                                     |
+| 2025-07-20 |  #8183 | merged | Kimi K2          | `fused_moe_triton/configs`                      | Corrected the H200 Kimi K2 MoE expert/N shape.                                          |
+| 2025-08-09 |  #9010 | merged | Kimi K2          | `fused_moe_triton/configs/triton_3_4_0`         | Added B200 FP8 MoE config for the newer Triton path.                                    |
+| 2025-11-12 | #13150 | merged | Kimi K2 Thinking | `python/sglang/srt/layers/moe/topk.py`          | Added a torch.compile optimized biased top-k path for 384 experts and one expert group. |
+| 2025-11-14 | #13287 | merged | Kimi K2 Thinking | `sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu` | Added the Kimi K2 dedicated fused gate CUDA op.                                         |
+| 2025-11-15 | #13332 | merged | Kimi K2 Thinking | `topk.py`                                       | Routed Kimi K2 Thinking through the fused gate.                                         |
+| 2025-11-16 | #13374 | merged | Kimi K2 Thinking | `kimi_k2_moe_fused_gate.cu`                     | Optimized fused gate vectorized loads and the small-token path.                         |
+| 2025-11-19 | #13587 | merged | Kimi K2 Thinking | `moe_align_block_size.py`                       | Removed a useless padding kernel from `sgl_moe_align_block_size`.                       |
+| 2025-11-19 | #13596 | merged | Kimi K2 Thinking | `fused_marlin_moe.py`, quant method             | Avoided useless `torch.zeros_` in fake-EP Marlin MoE cases.                             |
+| 2025-11-21 | #13725 | merged | Kimi K2 Thinking | `compressed_tensors_moe.py`                     | Added EP support for Kimi K2 Thinking compressed-tensors MoE.                           |
+| 2025-11-23 | #13789 | closed | Kimi K2 Thinking | DeepEP + Marlin path                            | Tried to support K2 Thinking DeepEP, but closed after illegal memory access.            |
+| 2025-12-14 | #15100 | merged | Kimi K2 Thinking | `fused_marlin_moe.py`, MoE runner               | Made fused Marlin MoE support piecewise CUDA graph.                                     |
+| 2025-12-17 | #15306 | merged | Kimi K2 Thinking | `kimi_k2_moe_fused_gate.cu`                     | Fixed a warp illegal instruction under PCG.                                             |
+| 2025-12-18 | #15347 | merged | Kimi K2 Thinking | `topk.py`                                       | Preferred FlashInfer `fused_topk_deepseek` over the Kimi fused gate where valid.        |
+| 2026-01-19 | #17325 | merged | Kimi K2 Thinking | `topk.py`                                       | Fixed kernel selection conditions in biased grouped top-k.                              |
+| 2026-01-27 | #17789 | merged | Kimi K2.5        | `models/kimi_k25.py`, processor, parser         | Added Kimi K2.5 multimodal model support.                                               |
+| 2026-01-30 | #17991 | merged | Kimi K2.5        | `vision.py`, `kimi_k25.py`                      | Fixed double reduce in VLM DP attention.                                                |
+| 2026-02-01 | #18064 | merged | Kimi K2.5        | `scheduler.py`                                  | Fixed MoE GEMM config initialization under the K2.5 wrapper.                            |
+| 2026-02-06 | #18370 | merged | Kimi K2.5        | `modelopt_quant.py`, `kimi_k25.py`              | Fixed NVFP4 weight mapping and the exclude list.                                        |
+| 2026-02-08 | #18440 | merged | Kimi K2.5        | `kimi_k25.py`                                   | Stored the missing `quant_config`.                                                      |
+| 2026-02-08 | #18434 | merged | Kimi K2.5        | `deepseek_v2.py`, `kimi_k25.py`                 | Added pipeline parallel support.                                                        |
+| 2026-02-12 | #18689 | merged | Kimi K2.5        | `kimi_k25.py`                                   | Added DP ViT encoder support.                                                           |
+| 2026-02-23 | #19181 | merged | Kimi K2/K2.5     | `python/sglang/jit_kernel/moe_wna16_marlin.py`  | Migrated the Marlin MoE kernel from AOT to JIT.                                         |
+| 2026-02-24 | #19228 | merged | Kimi K2.5        | AMD tuning, `fused_moe_triton_config.py`        | Tuned fused MoE config for K2.5 int4 W4A16 on AMD.                                      |
+| 2026-03-02 | #19689 | merged | Kimi K2.5        | `kimi_k25.py`                                   | Added Eagle3 capture and embed/head interfaces.                                         |
+| 2026-03-02 | #19703 | open   | Kimi K2 Thinking | `jit_kernel` fused gate                         | Migrates `kimi_k2_moe_fused_gate` to JIT; not merged yet.                               |
+| 2026-03-05 | #19959 | merged | Kimi K2.5        | `kimi_k25.py`                                   | Exposed PP layer ranges for PD disaggregation.                                          |
+| 2026-03-17 | #20747 | merged | Kimi K2.5        | `kimi_k25.py`                                   | Fixed the K2.5 wrapper surface for piecewise CUDA graph.                                |
+| 2026-03-20 | #21004 | merged | Kimi K2.5        | `kimi_k25.py`                                   | Added the routed expert weight interface needed by EPLB rebalance.                      |
+| 2026-03-25 | #21391 | merged | Kimi K2.5        | `llama_eagle3.py`, test                         | Fixed the DP attention + speculative decoding multimodal launch crash.                  |
+| 2026-03-31 | #21741 | open   | Kimi K2.5        | W4AFP8 MoE                                      | Adds generic compressed-tensors W4AFP8 MoE support.                                     |
+| 2026-04-06 | #22208 | open   | Kimi K2.5        | AMD Triton config                               | Tunes gfx950 small-M decode fused MoE.                                                  |
+| 2026-04-10 | #22488 | open   | Kimi K2 Thinking | JIT fused gate                                  | Generalizes the Kimi2 ungrouped fused gate to GLM-5 256 experts.                        |
+| 2026-04-10 | #22496 | open   | Kimi K2.5        | `deepep_moe_wna16_marlin_direct.py`, etc.       | Adds the K2.5 W4A16 DeepEP low-latency direct Marlin path.                              |
+| 2026-04-14 | #22806 | open   | Kimi K2.5        | `quantization/w4afp8.py`                        | Adds `KimiW4AFp8Config` for loading K2.5 W4AFP8.                                        |
+| 2026-04-16 | #22964 | open   | Kimi K2.5        | `KimiGPUProcessorWrapper`                       | Fixes CPU processor output keys to match the GPU path.                                  |
+| 2026-04-19 | #23186 | open   | Kimi K2.5        | AMD MLA attention                               | Adds fused q/k RMSNorm BF16 for `amd/Kimi-K2.5-MXFP4`.                                  |
+
+## 2. Kimi K2 Stage One: 384 Experts and MoE Tuning
+
+The first Kimi K2 integration problem was not a large model wrapper. The main issue was that the DeepSeek-V3-style MoE infrastructure was more naturally shaped around 256 experts, while Kimi K2 needs 384 experts and device-specific fused MoE tuning configs for H20, H20-3e, H200, and B200.
+
+`#8013` is the central code PR in this stage. It expands `dsv3_router_gemm` from a single 256-expert shape to both 256 and 384:
+
+- Adds constants such as `DEFAULT_NUM_EXPERTS = 256`, `KIMI_K2_NUM_EXPERTS = 384`, and `DEFAULT_HIDDEN_DIM = 7168` in the `sgl-kernel/csrc/gemm/dsv3_router_gemm_entry.cu` family.
+- Dispatches at runtime based on `mat_b.size(0)` and uses `TORCH_CHECK` to only allow 256 or 384 experts, avoiding silent dispatch to the wrong template.
+- Instantiates 384-expert templates for token counts `1..16` and both `float` and `bfloat16` outputs.
+- Extends `bench_dsv3_router_gemm.py` and tests to cover `num_experts in [256, 384]`, so the Kimi K2 path is benchmarked and tested instead of merely compiling.
+
+`#8021`, `#8047`, `#8176`, `#8178`, `#8183`, and `#9010` cover the device-specific tuning config side. They add or correct JSON files under:
+
+- `python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_3_1/`
+- `python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/`
+
+The file names encode the key shape information, such as `E=384` or `E=385`, `N=128/256`, `dtype=fp8_w8a8`, `block_shape=[128, 128]`, and `device_name=NVIDIA_H20/H20-3e/H200/B200`. The `E=385` configs reflect real routed/shared-expert shape variants. Later scheduling logic matches these JSON files using model config, quant config, device name, and Triton version.
+
+## 3. Kimi K2 Thinking: Top-k Routing, Fused Gate, and Marlin MoE
+
+`#13150` first optimized Kimi K2 Thinking biased top-k. The characteristic routing shape is `num_experts == 384`, `num_expert_group == 1`, and small `topk`. The generic grouped top-k path still carried group masking and group score logic. The PR added `kimi_k2_biased_topk_impl` in `topk.py`:
+
+- Computes `scores.sigmoid() + correction_bias` directly.
+- Runs `torch.topk` over all 384 experts to get top-k expert ids.
+- Uses `torch.gather` to recover the original sigmoid weights.
+- Applies optional renormalization and routed scaling.
+- Maps logical expert ids to physical expert ids if a logical-to-physical expert map exists.
+- Filters padding token masks.
+- Uses `@torch.compile` to keep this dedicated path out of Python-level generic branching during decode.
+
+`#13287` lowered that routing path into a CUDA op, `sgl_kernel::kimi_k2_moe_fused_gate`. The kernel is specialized for Kimi K2 Thinking:
+
+- `NUM_EXPERTS = 384`.
+- `topk = 6`.
+- `WARPS_PER_CTA = 6`.
+- Initial `VPT = 12`, fusing sigmoid, bias add, top-k, renormalization, and scaling per token.
+- Separate small-token and large-token launch strategies.
+- Python wrapper, benchmark, and test coverage, with `kimi_k2_biased_topk_impl` as the correctness baseline.
+
+`#13332` wired this kernel into `biased_grouped_topk_gpu`: when the device is CUDA, the expert count is 384, and there is only one expert group, SGLang uses `kimi_k2_moe_fused_gate`; otherwise it falls back to the generic paths.
+
+`#13374` then optimized the fused gate kernel:
+
+- Narrows the score and correction-bias path to `float32`, reducing dtype-generalization overhead.
+- Adds `VEC_SIZE = 4` `float4` vectorized loads.
+- Uses 384 threads per token in the small-token kernel, one thread per expert.
+- Stores intermediate top-k state in shared memory, including `selected_experts[8]`, `warp_experts`, and `warp_maxs`.
+- Reduces `__syncthreads()` and keeps top-k selection, renormalization, and output writes inside a tighter kernel.
+
+`#13587` removes a useless padding kernel from `sgl_moe_align_block_size`. It is small but meaningful in MoE decode, where extra launches and unnecessary padding sit directly on the critical path.
+
+`#13596` added the SGLang-side `fused_marlin_moe` wrapper for Kimi K2 Thinking W4A16 Marlin MoE. The important details are:
+
+- Uses `moe_align_block_size` to align token/expert pairs.
+- Selects `block_size_m` from `[8, 16, 32, 48, 64]`.
+- Calls `moe_wna16_marlin_gemm` for the gate/up projection.
+- Runs `silu_and_mul` for activation fusion.
+- Calls `moe_wna16_marlin_gemm` again for the down projection.
+- Runs `moe_sum_reduce` to merge top-k expert outputs.
+- Previously, the fake-EP path zeroed an intermediate cache unconditionally; the PR narrows `torch.zeros_` to the real `expert_map is not None` case, avoiding zero-fill cost when there is no real EP expert map.
+
+In current main, this Marlin MoE path has been moved by `#19181` to call the JIT kernel from `python/sglang/jit_kernel/moe_wna16_marlin.py` instead of directly depending on an AOT sgl-kernel symbol.
+
+## 4. Kimi K2 Thinking: EP, PCG, and Routing Kernel Selection
+
+`#13725` added Expert Parallelism support to the compressed-tensors MoE path for Kimi K2 Thinking. The key change is that the compressed-tensors quant method no longer treats EP information as fake metadata; it passes the real `expert_map`, top-k ids, weights, and runner metadata into Marlin MoE.
+
+`#15100` made fused Marlin MoE support piecewise CUDA graph. PCG is sensitive to dynamic shapes, temporary tensors, custom ops, and fake ops. This PR adjusted boundaries across `fused_marlin_moe.py`, the MoE runner, and the quant method so the path can be captured by segmented CUDA graphs.
+
+`#15306` is the follow-up PCG fix. It fixed a warp illegal instruction in `kimi_k2_moe_fused_gate.cu`. The issue appeared after the fused gate became captured by PCG and token shapes or expert-selection state became more stable, indicating insufficient protection around invalid expert or warp selection state inside the kernel.
+
+`#15347` changed the routing priority for Kimi K2 Thinking. When FlashInfer `fused_topk_deepseek` is valid, SGLang now prefers it over the Kimi-specific `moe_fused_gate`. Current main roughly orders `biased_grouped_topk_gpu` like this:
+
+1. If `fused_topk_deepseek` is available, the device is CUDA, the expert count is a power of two, and group/top-k constraints are satisfied, use the FlashInfer fused top-k path. For `num_expert_group == 1`, current conditions allow `num_experts <= 384`.
+2. Otherwise try the generic `moe_fused_gate`.
+3. Then try the AITER path.
+4. Then fall back to the Kimi 384-expert `kimi_k2_moe_fused_gate`.
+5. Finally fall back to the torch.compile generic biased top-k.
+
+`#17325` fixed the kernel selection conditions above, avoiding selection of a faster but invalid path when shape or group constraints are not met. After this PR, the Kimi fused gate still exists, but it is a fallback rather than the first-priority route.
+
+`#19703` remains open and aims to migrate `kimi_k2_moe_fused_gate` from AOT `sgl-kernel` into `python/sglang/jit_kernel`. `#22488` goes further by generalizing the Kimi2 ungrouped fused gate to GLM-5's 256-expert shape. Together they suggest this dedicated routing kernel is moving toward a JIT-managed variable-expert implementation rather than a Kimi-only AOT file.
+
+## 5. Kimi K2 Thinking DeepEP Status: Not Mainline-Ready
+
+`#13789` is titled `[DeepEP Support] Support kimi-k2-thinking deepep`, but it is closed and was not merged. The attempted launch command included:
+
+```bash
+SGLANG_DEEPEP_BF16_DISPATCH=1 python3 -m sglang.launch_server \
+  --model-path moonshotai/Kimi-K2-Thinking \
+  --tp 8 --ep 4 \
+  --moe-a2a-backend deepep \
+  --deepep-mode auto \
+  --trust-remote-code \
+  --tool-call-parser kimi_k2 \
+  --reasoning-parser kimi_k2
+```
+
+The patch and discussion exposed an illegal memory access around `DeepEPMoE.forward_marlin_moe -> quant_method.apply_deepep_normal -> fused_marlin_moe`. In other words, Kimi K2 Thinking `DeepEP + int4/Marlin` should not be treated as mainline-ready merely because Marlin MoE was JIT-migrated or regular EP support exists.
+
+`#22496` is different. It is the new open Kimi K2.5 W4A16 DeepEP low-latency route. Instead of reusing the full regular `fused_marlin_moe` layout, it adds:
+
+- `deepep_moe_wna16_marlin_direct.py`
+- `mask_silu_and_mul.py` / `.cuh`
+- `marlin_direct_template.h`
+- `kernel_direct.h`
+- `marlin_tma_utils.h`
+- modifications to `moe_wna16_marlin.cuh`, `ep_moe/layer.py`, `token_dispatcher/deepep.py`, and compressed-tensors quant methods
+
+The core idea is to add `apply_deepep_normal` and `apply_deepep_ll` to the compressed-tensors quant method. `apply_deepep_ll` requires BF16 dispatch and handles DeepEP's three-dimensional `[E, M, K]` hidden states. It builds and caches prefix/layout buffers, compacts active hidden states, runs direct Marlin gate/up and down projections with `mask_silu_and_mul` in between, then expands results back to the DeepEP layout. It also adds `DEEPEP_LL_PROFILE_COMPUTE` profiling logs. This PR targets Kimi K2.5 W4A16 DeepEP low latency, not the closed K2 Thinking DeepEP attempt.
+
+## 6. Kimi K2.5: Multimodal Wrapper and Runtime Interfaces
+
+`#17789` is the starting point for Kimi K2.5 support. It added `python/sglang/srt/models/kimi_k25.py` with the following structure:
+
+- The language model reuses `DeepseekV3ForCausalLM`.
+- The vision tower uses MoonViT3d.
+- A projector maps vision features into the language hidden size.
+- `hf_to_sglang_mapper` maps HF names such as `language_model.layers.` to SGLang internal names such as `language_model.model.layers.`.
+- Processor and parser hooks support Kimi K2.5 multimodal input, reasoning parsing, and tool-call parsing.
+- `pad_input_ids` handles image token padding.
+- `forward` uses `general_mm_embed_routine` to merge image embeddings and text embeddings.
+
+Many later K2.5 PRs make this wrapper transparent to the rest of SGLang. A lot of generic runtime logic expects the model object itself to be a CausalLM, but K2.5 adds a multimodal wrapper, so the wrapper must re-expose the underlying language model's interfaces.
+
+`#18440` stores `self.quant_config`; without it, ModelOpt/NVFP4 logic cannot read quantization config from the wrapper. `#18370` then fixes NVFP4 weight-name mapping and the exclude list so quantization code understands names under the `language_model` wrapper. `#18064` fixes scheduler MoE GEMM config initialization by reading MoE shapes from K2.5 `text_config`.
+
+`#18434` adds PP support. The K2.5 wrapper can pass `pp_proxy_tensors` into the underlying `DeepseekV3ForCausalLM` and handle pipeline-stage forward outputs. `#19959` further exposes `start_layer` and `end_layer`, which are needed by PD disaggregation and other logic that must know the layer range covered by the current PP shard.
+
+`#18689` adds DP ViT. In current main, `KimiK25ForConditionalGeneration` reads `get_global_server_args().mm_enable_dp_encoder` and passes `use_data_parallel` to the vision tower. In `get_image_feature`, if the DP encoder is enabled, it calls `run_dp_sharded_mrope_vision_model`, allowing the multimodal encoder to run sharded across DP.
+
+`#17991` fixes double reduce in VLM DP attention, avoiding a second upper-level reduce after the visual-side DP attention has already reduced. `#21391` fixes a DP attention + speculative decoding launch crash: when Eagle/spec decode extends a multimodal batch, it should reuse `forward_batch.mm_input_embeds` and only append the final token embedding, instead of re-embedding the full multimodal prefix.
+
+`#19689` adds K2.5 Eagle3 interfaces: `set_eagle3_layers_to_capture`, `get_embed_and_head`, and `set_embed_and_head`. `#20747` sets `self.model = self.language_model.model` in the wrapper, fixing piecewise CUDA graph assumptions about the underlying model surface.
+
+`#21004` adds the EPLB rebalance interface. In current main, K2.5's `routed_experts_weights_of_layer` property returns the underlying language model's `_routed_experts_weights_of_layer.value`, allowing EPLB to read per-layer routed expert weights across the wrapper.
+
+## 7. Kimi K2.5 Quantization and Platform Optimization
+
+`#19181` migrates the Marlin MoE kernel to JIT. It adds `python/sglang/jit_kernel/moe_wna16_marlin.py`, compiles through `_jit_moe_wna16_marlin_module`, and exports `moe_wna16_marlin_gemm`. The tests cover:
+
+- `m = 1` and `m = 123`.
+- `n = 128` and `n = 1024`.
+- `fp16` / `bf16`.
+- act-order and non-act-order.
+- `uint4` / `uint4b8` weight layouts.
+- bitwise matching between JIT and the old AOT implementation.
+
+This matters for Kimi because Kimi K2 Thinking and K2.5 W4A16 MoE use Marlin MoE. It is not, however, sufficient to claim DeepEP support: DeepEP still needs token dispatch layout, active-token compaction, expert buffers, and direct Marlin calls to be correct.
+
+`#19228` is the AMD Kimi K2.5 fused MoE tuning PR. It lets config-reading logic pass through K2.5 `text_config`, detect int4 W4A16 group size and block shape from quant config, and generate the correct config filename for `dtype=int4_w4a16`. For int4 packed layout, `N` must be derived from shard intermediate size and then adjusted again for packing.
+
+`#22208` is still open and continues gfx950 small-M decode fused MoE tuning on AMD. `#23186` is another AMD track: in MLA absorb prepare, when AITER is enabled and dtype is BF16, it uses `fused_qk_rmsnorm_bf16` to fuse q_a and kv_a RMSNorm for `amd/Kimi-K2.5-MXFP4`.
+
+`#21741` and `#22806` are the W4AFP8 track. `#21741` adds generic compressed-tensors W4AFP8 MoE support, including FP8 activation scale and CUTLASS W4A8 MoE pieces. `#22806` adds Kimi-specific `KimiW4AFp8Config`:
+
+- Quant method name: `kimi_w4afp8`.
+- Parses all important quant config fields.
+- Distinguishes `ignored_layers` from `unquantized_layers`: ignored layers skip W4 but may still use FP8, while truly unquantized layers such as `lm_head` stay unquantized.
+- Normalizes `model.` prefixes.
+- Returns `Fp8LinearMethod` or `UnquantizedLinearMethod` for ordinary `LinearBase`.
+- Returns `W4AFp8MoEMethod` for `FusedMoE`.
+- Adds expert input scale mapping for HF-standard `gate_proj/down_proj/up_proj`.
+
+`#22964` fixes a processor mismatch. The GPU processor `_call` currently returns `image_grid_thw`, while CPU `_cpu_call` can return `grid_thws` in some paths. The open PR maps the CPU path to `image_grid_thw` as well, avoiding key mismatch during multimodal feature packing.
+
+## 8. Current Main Code Shape
+
+As of `47c4b3825`, the Kimi mainline looks like this:
+
+- In `topk.py`, Kimi K2 Thinking 384-expert routing is a multi-stage selection among FlashInfer `fused_topk_deepseek`, generic `moe_fused_gate`, AITER, Kimi fused gate, and torch.compile generic fallback.
+- `fused_marlin_moe.py` uses JIT `moe_wna16_marlin_gemm` and keeps EP zero-fill only under `expert_map is not None`.
+- `kimi_k25.py` is the central K2.5 wrapper for the language model, vision tower, projector, processor, DP ViT, PP range, Eagle3, PCG, and EPLB interfaces.
+- K2.5 quantization and platform optimization are still moving quickly: NVFP4 has mainline fixes, while W4AFP8, K2.5 W4A16 DeepEP low latency, and AMD MXFP4 fused q/k RMSNorm are still open PR tracks.
+
+So if the Kimi skill is updated again, it should probably split the old “K2/K2.5 optimization” story into two explicit narratives:
+
+1. Kimi K2 Thinking runtime path: 384-expert top-k, fused gate, Marlin MoE, EP, PCG, and the boundary that DeepEP is not mainline-ready yet.
+2. Kimi K2.5 multimodal and quantization path: wrapper transparency, PP/DP/Eagle/EPLB, and the latest NVFP4/W4AFP8/AMD/DeepEP-low-latency state.

--- a/model-pr-optimization-history/kimi/README.en.md
+++ b/model-pr-optimization-history/kimi/README.en.md
@@ -224,8 +224,3 @@ As of `47c4b3825`, the Kimi mainline looks like this:
 - `fused_marlin_moe.py` uses JIT `moe_wna16_marlin_gemm` and keeps EP zero-fill only under `expert_map is not None`.
 - `kimi_k25.py` is the central K2.5 wrapper for the language model, vision tower, projector, processor, DP ViT, PP range, Eagle3, PCG, and EPLB interfaces.
 - K2.5 quantization and platform optimization are still moving quickly: NVFP4 has mainline fixes, while W4AFP8, K2.5 W4A16 DeepEP low latency, and AMD MXFP4 fused q/k RMSNorm are still open PR tracks.
-
-So if the Kimi skill is updated again, it should probably split the old “K2/K2.5 optimization” story into two explicit narratives:
-
-1. Kimi K2 Thinking runtime path: 384-expert top-k, fused gate, Marlin MoE, EP, PCG, and the boundary that DeepEP is not mainline-ready yet.
-2. Kimi K2.5 multimodal and quantization path: wrapper transparency, PP/DP/Eagle/EPLB, and the latest NVFP4/W4AFP8/AMD/DeepEP-low-latency state.

--- a/model-pr-optimization-history/kimi/README.zh.md
+++ b/model-pr-optimization-history/kimi/README.zh.md
@@ -1,0 +1,231 @@
+# SGLang Kimi K2 / K2 Thinking / K2.5 支持与优化时间线
+
+本文基于 SGLang `origin/main` 最新快照 `47c4b3825`，以及相关 merged、open、closed PR 的 patch 阅读结果整理。范围覆盖原有 `sglang-kimi-k2-k25-optimization` skill 涉及的主线，也补充了之后仍在推进的 Kimi K2.5 DeepEP、W4AFP8、AMD MXFP4 等方向。
+
+阅读结论先放前面：截至 `47c4b3825`，Kimi K2 和 Kimi K2 Thinking 的常规 MoE 路由、Marlin W4A16 MoE、EP、PCG 已有主线支持；Kimi K2.5 已有独立多模态 wrapper、PP、DP ViT、Eagle3、PD disaggregation、EPLB 等运行时接口。Kimi K2 Thinking 的 `DeepEP + int4/Marlin` PR `#13789` 已关闭未合入；真正仍在推进的是 Kimi K2.5 W4A16 DeepEP low-latency PR `#22496`。
+
+## 1. 时间线总览
+
+| 创建日期   |     PR | 状态   | 主线             | 代码区域                                        | 作用                                                                        |
+| ---------- | -----: | ------ | ---------------- | ----------------------------------------------- | --------------------------------------------------------------------------- |
+| 2025-07-14 |  #8021 | merged | Kimi K2          | `fused_moe_triton/configs`                      | 增加 H20-3e FP8 MoE tuning config。                                         |
+| 2025-07-14 |  #8013 | merged | Kimi K2          | `sgl-kernel/csrc/gemm/dsv3_router_gemm_*`       | `dsv3_router_gemm` 支持 384 experts。                                       |
+| 2025-07-15 |  #8047 | merged | Kimi K2          | `fused_moe_triton/configs`                      | 增加 H20 FP8 MoE tuning config。                                            |
+| 2025-07-20 |  #8176 | merged | Kimi K2          | `fused_moe_triton/configs`                      | 增加 H200 TP16 Kimi K2 MoE config。                                         |
+| 2025-07-20 |  #8178 | merged | Kimi K2          | `fused_moe_triton/configs`                      | 增加 B200 TP16 Kimi K2 MoE config。                                         |
+| 2025-07-20 |  #8183 | merged | Kimi K2          | `fused_moe_triton/configs`                      | 修正 H200 Kimi K2 MoE config 的 expert/N 组合。                             |
+| 2025-08-09 |  #9010 | merged | Kimi K2          | `fused_moe_triton/configs/triton_3_4_0`         | 增加 B200 新 Triton 版本 FP8 MoE config。                                   |
+| 2025-11-12 | #13150 | merged | Kimi K2 Thinking | `python/sglang/srt/layers/moe/topk.py`          | 给 384 experts、单 expert group 的 biased top-k 加 torch.compile 优化路径。 |
+| 2025-11-14 | #13287 | merged | Kimi K2 Thinking | `sgl-kernel/csrc/moe/kimi_k2_moe_fused_gate.cu` | 新增 Kimi K2 专用 fused gate CUDA op。                                      |
+| 2025-11-15 | #13332 | merged | Kimi K2 Thinking | `topk.py`                                       | 在 Kimi K2 Thinking 路由中接入 fused gate。                                 |
+| 2025-11-16 | #13374 | merged | Kimi K2 Thinking | `kimi_k2_moe_fused_gate.cu`                     | 优化 fused gate kernel 的向量化 load 和 small-token 路径。                  |
+| 2025-11-19 | #13587 | merged | Kimi K2 Thinking | `moe_align_block_size.py`                       | 删除 `sgl_moe_align_block_size` 中无意义的 padding kernel。                 |
+| 2025-11-19 | #13596 | merged | Kimi K2 Thinking | `fused_marlin_moe.py`、quant method             | 避免 fake EP 下 Marlin MoE 的无用 `torch.zeros_`。                          |
+| 2025-11-21 | #13725 | merged | Kimi K2 Thinking | `compressed_tensors_moe.py`                     | 给 Kimi K2 Thinking compressed-tensors MoE 增加 EP 支持。                   |
+| 2025-11-23 | #13789 | closed | Kimi K2 Thinking | DeepEP + Marlin path                            | 尝试支持 K2 Thinking DeepEP，但因 illegal memory access 关闭未合入。        |
+| 2025-12-14 | #15100 | merged | Kimi K2 Thinking | `fused_marlin_moe.py`、MoE runner               | 让 fused Marlin MoE 支持 piecewise CUDA graph。                             |
+| 2025-12-17 | #15306 | merged | Kimi K2 Thinking | `kimi_k2_moe_fused_gate.cu`                     | 修复 PCG 下 warp illegal instruction。                                      |
+| 2025-12-18 | #15347 | merged | Kimi K2 Thinking | `topk.py`                                       | 优先使用 FlashInfer `fused_topk_deepseek` 替代 Kimi fused gate。            |
+| 2026-01-19 | #17325 | merged | Kimi K2 Thinking | `topk.py`                                       | 修复 biased grouped top-k 的 kernel 选择条件。                              |
+| 2026-01-27 | #17789 | merged | Kimi K2.5        | `models/kimi_k25.py`、processor、parser         | 新增 Kimi K2.5 多模态模型支持。                                             |
+| 2026-01-30 | #17991 | merged | Kimi K2.5        | `vision.py`、`kimi_k25.py`                      | 修复 VLM DP attention 的 double reduce。                                    |
+| 2026-02-01 | #18064 | merged | Kimi K2.5        | `scheduler.py`                                  | 修复 K2.5 wrapper 下 MoE GEMM config 初始化。                               |
+| 2026-02-06 | #18370 | merged | Kimi K2.5        | `modelopt_quant.py`、`kimi_k25.py`              | 修复 NVFP4 权重映射和 exclude list。                                        |
+| 2026-02-08 | #18440 | merged | Kimi K2.5        | `kimi_k25.py`                                   | 补齐 `quant_config` 保存。                                                  |
+| 2026-02-08 | #18434 | merged | Kimi K2.5        | `deepseek_v2.py`、`kimi_k25.py`                 | 支持 pipeline parallel。                                                    |
+| 2026-02-12 | #18689 | merged | Kimi K2.5        | `kimi_k25.py`                                   | 增加 DP ViT encoder 支持。                                                  |
+| 2026-02-23 | #19181 | merged | Kimi K2/K2.5     | `python/sglang/jit_kernel/moe_wna16_marlin.py`  | 将 Marlin MoE kernel 从 AOT 迁移到 JIT。                                    |
+| 2026-02-24 | #19228 | merged | Kimi K2.5        | AMD tuning、`fused_moe_triton_config.py`        | 为 K2.5 int4 W4A16 在 AMD 上调 fused MoE config。                           |
+| 2026-03-02 | #19689 | merged | Kimi K2.5        | `kimi_k25.py`                                   | 支持 Eagle3 捕获层和 embed/head 接口。                                      |
+| 2026-03-02 | #19703 | open   | Kimi K2 Thinking | `jit_kernel` fused gate                         | 将 `kimi_k2_moe_fused_gate` 迁移到 JIT，尚未合入。                          |
+| 2026-03-05 | #19959 | merged | Kimi K2.5        | `kimi_k25.py`                                   | 暴露 PP layer range，支持 PD disaggregation。                               |
+| 2026-03-17 | #20747 | merged | Kimi K2.5        | `kimi_k25.py`                                   | 修复 K2.5 piecewise CUDA graph wrapper 暴露面。                             |
+| 2026-03-20 | #21004 | merged | Kimi K2.5        | `kimi_k25.py`                                   | 增加 EPLB rebalance 所需 routed expert weights 接口。                       |
+| 2026-03-25 | #21391 | merged | Kimi K2.5        | `llama_eagle3.py`、test                         | 修复 DP attention + spec decoding 的 multimodal launch crash。              |
+| 2026-03-31 | #21741 | open   | Kimi K2.5        | W4AFP8 MoE                                      | 通用 compressed-tensors W4AFP8 MoE 支持。                                   |
+| 2026-04-06 | #22208 | open   | Kimi K2.5        | AMD Triton config                               | gfx950 small-M decode fused MoE tuning。                                    |
+| 2026-04-10 | #22488 | open   | Kimi K2 Thinking | JIT fused gate                                  | 将 Kimi2 ungrouped fused gate 泛化到 GLM-5 256 experts。                    |
+| 2026-04-10 | #22496 | open   | Kimi K2.5        | `deepep_moe_wna16_marlin_direct.py` 等          | K2.5 W4A16 DeepEP low-latency direct Marlin 路线。                          |
+| 2026-04-14 | #22806 | open   | Kimi K2.5        | `quantization/w4afp8.py`                        | 新增 `KimiW4AFp8Config` 以加载 K2.5 W4AFP8。                                |
+| 2026-04-16 | #22964 | open   | Kimi K2.5        | `KimiGPUProcessorWrapper`                       | 修复 CPU processor 输出 key 与 GPU 路径不一致。                             |
+| 2026-04-19 | #23186 | open   | Kimi K2.5        | AMD MLA attention                               | 为 `amd/Kimi-K2.5-MXFP4` 增加 fused q/k RMSNorm BF16。                      |
+
+## 2. Kimi K2 的第一阶段：384 experts 与 MoE tuning
+
+Kimi K2 早期接入的主要矛盾不是模型 wrapper，而是 DeepSeek-V3 系 MoE 基础设施默认更熟悉 256 experts；Kimi K2 需要 384 experts，并且在 H20、H20-3e、H200、B200 上需要独立 fused MoE tuning config。
+
+`#8013` 是这一阶段的核心代码 PR。它把 `dsv3_router_gemm` 的 expert 数从单一 256 扩展到 256/384 双形态：
+
+- 在 `sgl-kernel/csrc/gemm/dsv3_router_gemm_entry.cu` 等入口中增加 `DEFAULT_NUM_EXPERTS = 256`、`KIMI_K2_NUM_EXPERTS = 384`、`DEFAULT_HIDDEN_DIM = 7168` 等常量。
+- runtime 根据 `mat_b.size(0)` 判断当前 expert 数，并用 `TORCH_CHECK` 明确只允许 256 或 384，避免静默走错模板实例。
+- 为 token 数 `1..16`、输出 `float` / `bfloat16` 两类路径补齐 384 experts 模板实例化。
+- benchmark `bench_dsv3_router_gemm.py` 和测试都扩展到 `num_experts in [256, 384]`，确保 Kimi K2 不只是能编译，而是覆盖 benchmark 和 UT。
+
+`#8021`、`#8047`、`#8176`、`#8178`、`#8183`、`#9010` 则是 tuning config 的设备覆盖。它们新增或修正的 config 文件位于：
+
+- `python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_3_1/`
+- `python/sglang/srt/layers/moe/fused_moe_triton/configs/triton_3_4_0/`
+
+这些文件名编码了关键 shape，例如 `E=384` 或 `E=385`、`N=128/256`、`dtype=fp8_w8a8`、`block_shape=[128, 128]`、`device_name=NVIDIA_H20/H20-3e/H200/B200`。`E=385` 这种 config 反映了实际 MoE 路由或 shared expert 组合下的配置形态；后续调度器会按模型 config、quant config、设备名、Triton 版本去匹配这些 JSON。
+
+## 3. Kimi K2 Thinking：top-k 路由、fused gate 与 Marlin MoE
+
+`#13150` 首先优化了 Kimi K2 Thinking 的 biased top-k。Kimi K2 Thinking 的典型路由形态是 `num_experts == 384`、`num_expert_group == 1`、`topk` 较小。原本通用 grouped top-k 仍会保留 group masking、group score 等泛化逻辑。PR 在 `topk.py` 中新增 `kimi_k2_biased_topk_impl`：
+
+- 直接计算 `scores.sigmoid() + correction_bias`。
+- 对完整 384 experts 做 `torch.topk`，拿到 top-k expert ids。
+- 通过 `torch.gather` 回取原始 sigmoid weights。
+- 按需做 renormalization 和 routed scaling。
+- 如果存在 logical-to-physical expert map，则把逻辑 expert id 映射为物理 expert id。
+- 对 padding token mask 做过滤。
+- 用 `@torch.compile` 固化这个专门路径，避免每次 decode 都走 Python 级泛化分支。
+
+`#13287` 把上述路由进一步下沉为 CUDA op `sgl_kernel::kimi_k2_moe_fused_gate`。kernel 固定服务 Kimi K2 Thinking 的关键形态：
+
+- `NUM_EXPERTS = 384`。
+- `topk = 6`。
+- `WARPS_PER_CTA = 6`。
+- 初版 `VPT = 12`，面向每个 token 的 sigmoid、bias add、top-k、renorm、scaling 一次完成。
+- 同时支持 small-token 和 large-token 的不同 launch 思路。
+- Python wrapper 和 benchmark、test 也一起加入，测试基准是和 `kimi_k2_biased_topk_impl` 对齐。
+
+`#13332` 在 `biased_grouped_topk_gpu` 中接入这个 kernel：当设备是 CUDA、expert 数为 384、只有一个 expert group 时，优先走 `kimi_k2_moe_fused_gate`，否则继续回退到通用路径。
+
+`#13374` 对 fused gate 做第二轮 kernel 级优化：
+
+- 将输入 scores 和 correction bias 明确收窄到 `float32` 路径，减少 dtype 泛化成本。
+- 增加 `VEC_SIZE = 4` 的 `float4` 向量化 load。
+- small-token kernel 中每个 token 用 384 个线程分别处理 384 experts。
+- shared memory 保存 `selected_experts[8]`、`warp_experts`、`warp_maxs` 等中间结果。
+- 减少 `__syncthreads()`，把 top-k 选择、renorm、输出写回放进更紧的 kernel。
+
+`#13587` 删除 `sgl_moe_align_block_size` 的无用 padding kernel。这个修改看起来小，但在 MoE decode 小 batch 场景里，额外 kernel launch 和无意义 padding 会直接进入关键路径。
+
+`#13596` 则针对 Kimi K2 Thinking 的 W4A16 Marlin MoE 做了 SGLang 侧封装 `fused_marlin_moe`。主要细节是：
+
+- 通过 `moe_align_block_size` 整理 token/expert 对齐。
+- 在 block size candidate `[8, 16, 32, 48, 64]` 中选择合适 `block_size_m`。
+- 第一次调用 `moe_wna16_marlin_gemm` 做 gate/up projection。
+- 调用 `silu_and_mul` 做激活融合。
+- 第二次调用 `moe_wna16_marlin_gemm` 做 down projection。
+- 最后 `moe_sum_reduce` 合并 top-k expert 输出。
+- 原本 fake EP 路径会无条件清零中间 cache；PR 把 `torch.zeros_` 收窄到 `expert_map is not None` 才需要的场景，避免非真实 EP 下为不存在的 expert 输出付出清零成本。
+
+当前 main 中这段 Marlin MoE 已经跟随 `#19181` 改为从 `python/sglang/jit_kernel/moe_wna16_marlin.py` 调 JIT kernel，而不是直接依赖 AOT sgl-kernel 符号。
+
+## 4. Kimi K2 Thinking：EP、PCG 与路由 kernel 选择的演进
+
+`#13725` 给 compressed-tensors MoE 路径补上 Kimi K2 Thinking 的 Expert Parallelism 支持。关键点是 compressed-tensors quant method 不再把 EP 信息当作假数据，而是把真实 `expert_map`、top-k ids、weights 和 runner metadata 传入 Marlin MoE。
+
+`#15100` 让 fused Marlin MoE 支持 piecewise CUDA graph。PCG 对动态 shape、临时 tensor、custom op 以及 fake op 都很敏感；这个 PR 调整了 `fused_marlin_moe.py`、MoE runner 和 quant method 的边界，使这条路径可以被分段 CUDA graph 捕获。
+
+`#15306` 是 PCG 后续修复，修掉 `kimi_k2_moe_fused_gate.cu` 中会触发 warp illegal instruction 的问题。这个问题出现在 fused gate 被 PCG 捕获、token shape/专家选择缓存更稳定之后，说明 kernel 内部对无效 expert 或 warp 选择状态的保护不够严。
+
+`#15347` 改变了 Kimi K2 Thinking 的路由优先级：如果满足 FlashInfer `fused_topk_deepseek` 的条件，就优先使用这个 DSV3 优化 kernel，而不是 Kimi 专用 `moe_fused_gate`。当前 main 的 `biased_grouped_topk_gpu` 顺序大致是：
+
+1. 如果 `fused_topk_deepseek` 可用、CUDA、expert 数是 2 的幂，并满足 group/topk 约束，则走 FlashInfer fused top-k。对 `num_expert_group == 1`，当前条件允许 `num_experts <= 384`。
+2. 否则尝试通用 `moe_fused_gate`。
+3. 再尝试 AITER 路径。
+4. 再回退到 Kimi 384 experts 的 `kimi_k2_moe_fused_gate`。
+5. 最后回退到 torch.compile 的 generic biased top-k。
+
+`#17325` 修正了上述 kernel selection 的条件，避免在不满足 shape 或 group 限制时误选更快但不正确的路径。这个 PR 之后，Kimi fused gate 仍然存在，但它已经变成 fallback，而不是第一优先级。
+
+`#19703` 仍 open，目标是把 `kimi_k2_moe_fused_gate` 从 AOT `sgl-kernel` 迁移到 `python/sglang/jit_kernel`。`#22488` 则进一步把 Kimi2 ungrouped fused gate 泛化到 GLM-5 的 256 experts。两者说明这条专用路由 kernel 未来更可能变成 JIT 管理的可变 expert 数 kernel，而不是 Kimi 独占 AOT 文件。
+
+## 5. Kimi K2 Thinking DeepEP 状态：不是已经打通
+
+`#13789` 的标题是 `[DeepEP Support] Support kimi-k2-thinking deepep`，但状态是 closed，未合入。它尝试的启动命令包括：
+
+```bash
+SGLANG_DEEPEP_BF16_DISPATCH=1 python3 -m sglang.launch_server \
+  --model-path moonshotai/Kimi-K2-Thinking \
+  --tp 8 --ep 4 \
+  --moe-a2a-backend deepep \
+  --deepep-mode auto \
+  --trust-remote-code \
+  --tool-call-parser kimi_k2 \
+  --reasoning-parser kimi_k2
+```
+
+patch 和讨论里暴露的问题是在 `DeepEPMoE.forward_marlin_moe -> quant_method.apply_deepep_normal -> fused_marlin_moe` 一侧出现 illegal memory access。也就是说，Kimi K2 Thinking 的 `DeepEP + int4/Marlin` 不能因为 Marlin MoE JIT 化或普通 EP 支持而视为已主线打通。
+
+和它不同，`#22496` 是 Kimi K2.5 W4A16 DeepEP low-latency 的新路线，仍 open。它没有沿用普通 `fused_marlin_moe` 的完整布局，而是新增：
+
+- `deepep_moe_wna16_marlin_direct.py`
+- `mask_silu_and_mul.py` / `.cuh`
+- `marlin_direct_template.h`
+- `kernel_direct.h`
+- `marlin_tma_utils.h`
+- 对 `moe_wna16_marlin.cuh`、`ep_moe/layer.py`、`token_dispatcher/deepep.py`、compressed-tensors quant method 的修改
+
+这个方向的核心是给 compressed-tensors quant method 增加 `apply_deepep_normal` 和 `apply_deepep_ll`。`apply_deepep_ll` 要求 BF16 dispatch，并处理 DeepEP 输出的三维 `[E, M, K]` hidden states；它会构建和缓存 prefix/layout buffer，compact active hidden states，直接跑 Marlin gate/up 和 down 两次，中间用 `mask_silu_and_mul`，最后把结果 expand 回 DeepEP 的布局。它还加入了 `DEEPEP_LL_PROFILE_COMPUTE` profiling 日志。这个 PR 的目标是 Kimi K2.5 W4A16 DeepEP low-latency，不是已经关闭的 K2 Thinking DeepEP。
+
+## 6. Kimi K2.5：多模态 wrapper 与运行时接口
+
+`#17789` 是 Kimi K2.5 支持的起点。它新增 `python/sglang/srt/models/kimi_k25.py`，总体结构是：
+
+- language model 复用 `DeepseekV3ForCausalLM`。
+- vision tower 使用 MoonViT3d。
+- projector 把 vision features 接到 language hidden size。
+- `hf_to_sglang_mapper` 把 HF 权重里的 `language_model.layers.` 映射到 SGLang 内部的 `language_model.model.layers.`。
+- processor 和 parser 接入 Kimi K2.5 的 multimodal 输入、reasoning parser 和 tool-call parser。
+- `pad_input_ids` 处理 image token padding。
+- `forward` 通过 `general_mm_embed_routine` 把 image embeddings 和 text embeddings 合并。
+
+后续 K2.5 的大量 PR 都是在补齐 wrapper 对 SGLang runtime 的“透明性”：很多通用逻辑原本假设模型对象本身就是 CausalLM，而 K2.5 外层多了一层 multimodal wrapper，因此必须把底层 language model 的接口重新暴露出来。
+
+`#18440` 补了 `self.quant_config`，否则 ModelOpt/NVFP4 等量化逻辑拿不到 wrapper 上的 quant config。`#18370` 进一步修正 NVFP4 的权重名映射和 exclude list，使量化模块知道哪些名字要穿过 `language_model` wrapper。`#18064` 则修复 scheduler 初始化 MoE GEMM config 时没有从 K2.5 `text_config` 里取 MoE 形状的问题。
+
+`#18434` 增加 PP 支持。它让 K2.5 wrapper 能向底层 `DeepseekV3ForCausalLM` 传递 `pp_proxy_tensors`，并处理 pipeline stage 的 forward 输出。`#19959` 继续暴露 `start_layer` 和 `end_layer`，用于 PD disaggregation 等需要知道当前 PP shard 覆盖层范围的逻辑。
+
+`#18689` 增加 DP ViT。当前 main 的 `KimiK25ForConditionalGeneration` 会读取 `get_global_server_args().mm_enable_dp_encoder`，把 `use_data_parallel` 传给 vision tower；`get_image_feature` 中如果启用 DP encoder，会走 `run_dp_sharded_mrope_vision_model`，让多模态 encoder 在 DP 维度切分执行。
+
+`#17991` 修复 VLM DP attention double reduce，避免视觉侧 DP attention 已经 reduce 后又在上层重复 reduce。`#21391` 修复 DP attention + speculative decoding 的 launch crash：当 Eagle/spec decode 扩展 multimodal batch 时，不能重新 embed 完整 multimodal prefix，而是要复用 `forward_batch.mm_input_embeds`，只追加最后 token 的 embedding。
+
+`#19689` 为 K2.5 增加 Eagle3 接口：`set_eagle3_layers_to_capture`、`get_embed_and_head`、`set_embed_and_head`。`#20747` 则让 wrapper 设置 `self.model = self.language_model.model`，修复 piecewise CUDA graph 对底层 model surface 的假设。
+
+`#21004` 增加 EPLB rebalance 所需接口：当前 main 中 K2.5 的 `routed_experts_weights_of_layer` property 会返回底层 language model 的 `_routed_experts_weights_of_layer.value`。这样 EPLB 可以跨 wrapper 读取每层 routed expert 权重。
+
+## 7. Kimi K2.5 量化与平台优化
+
+`#19181` 把 Marlin MoE kernel 迁移到 JIT。新增 `python/sglang/jit_kernel/moe_wna16_marlin.py`，通过 `_jit_moe_wna16_marlin_module` 编译并导出 `moe_wna16_marlin_gemm`。测试覆盖：
+
+- `m = 1` 和 `m = 123`。
+- `n = 128` 和 `n = 1024`。
+- `fp16` / `bf16`。
+- act-order 与非 act-order。
+- `uint4` / `uint4b8` 权重布局。
+- JIT 和旧 AOT 结果 bitwise 对齐。
+
+这对 Kimi 很重要，因为 Kimi K2 Thinking / K2.5 的 W4A16 MoE 会走 Marlin MoE。但它不是 DeepEP 打通的充分条件；DeepEP 还要解决 token dispatch layout、active token compact、expert buffer 和 direct Marlin 调用。
+
+`#19228` 是 AMD 方向的 Kimi K2.5 fused MoE tuning。它让 config 读取逻辑能穿过 K2.5 `text_config`，从 quant config 里识别 int4 W4A16 的 group size 和 block shape，并为 `dtype=int4_w4a16` 生成正确 config 文件名。对于 int4 packed layout，`N` 需要按 shard intermediate size 再做 packed 折算。
+
+`#22208` 仍 open，继续针对 AMD `gfx950` 的 small-M decode fused MoE config 做 tuning。`#23186` 也是 AMD 方向：在 MLA absorb prepare 里，如果启用 AITER 且 dtype 是 BF16，就用 `fused_qk_rmsnorm_bf16` 同时融合 q_a 和 kv_a RMSNorm，目标模型是 `amd/Kimi-K2.5-MXFP4`。
+
+`#21741` 和 `#22806` 是 W4AFP8 方向。`#21741` 是通用 compressed-tensors W4AFP8 MoE 支持，引入 FP8 activation scale、CUTLASS W4A8 MoE 等底层能力。`#22806` 则新增 Kimi 专用 `KimiW4AFp8Config`：
+
+- quant method 名称为 `kimi_w4afp8`。
+- 解析 quant config 里的所有关键字段。
+- 区分 `ignored_layers` 和 `unquantized_layers`：前者跳过 W4 但仍可能 FP8，后者如 `lm_head` 完全不量化。
+- 归一化 `model.` 前缀。
+- 对普通 `LinearBase` 返回 `Fp8LinearMethod` 或 `UnquantizedLinearMethod`。
+- 对 `FusedMoE` 返回 `W4AFp8MoEMethod`。
+- 补齐 HF 标准 `gate_proj/down_proj/up_proj` 的 expert input scale 映射。
+
+`#22964` 修复 processor 的小坑：GPU processor `_call` 当前会输出 `image_grid_thw`，而 CPU `_cpu_call` 在某些路径输出 `grid_thws`。open PR 会把 CPU 路径也映射成 `image_grid_thw`，避免后续 multimodal feature packing 出现 key mismatch。
+
+## 8. 当前 main 的代码形态
+
+截至 `47c4b3825`，Kimi 相关主线可以概括为以下形态：
+
+- `topk.py` 中 Kimi K2 Thinking 的 384 experts 路由已经不是单一路线，而是 FlashInfer `fused_topk_deepseek`、通用 `moe_fused_gate`、AITER、Kimi fused gate、torch.compile generic 的多级选择。
+- `fused_marlin_moe.py` 使用 JIT `moe_wna16_marlin_gemm`，并保留 `expert_map is not None` 下的 EP 清零逻辑。
+- `kimi_k25.py` 是 K2.5 的核心 wrapper，负责 language model、vision tower、projector、processor、DP ViT、PP range、Eagle3、PCG、EPLB 等运行时接口。
+- K2.5 的量化和平台优化还在快速推进：NVFP4 已有主线修复，W4AFP8、K2.5 W4A16 DeepEP low-latency、AMD MXFP4 fused q/k RMSNorm 仍是 open PR 方向。
+
+因此，Kimi skill 如果继续更新，建议把旧的“K2/K2.5 optimization”拆成两条明确叙事：
+
+1. Kimi K2 Thinking runtime path：384 experts top-k、fused gate、Marlin MoE、EP、PCG，以及 DeepEP 尚未主线打通的边界。
+2. Kimi K2.5 multimodal and quantization path：wrapper 透明性、PP/DP/Eagle/EPLB、NVFP4/W4AFP8/AMD/DeepEP low-latency 的最新状态。

--- a/model-pr-optimization-history/kimi/README.zh.md
+++ b/model-pr-optimization-history/kimi/README.zh.md
@@ -224,8 +224,3 @@ patch 和讨论里暴露的问题是在 `DeepEPMoE.forward_marlin_moe -> quant_m
 - `fused_marlin_moe.py` 使用 JIT `moe_wna16_marlin_gemm`，并保留 `expert_map is not None` 下的 EP 清零逻辑。
 - `kimi_k25.py` 是 K2.5 的核心 wrapper，负责 language model、vision tower、projector、processor、DP ViT、PP range、Eagle3、PCG、EPLB 等运行时接口。
 - K2.5 的量化和平台优化还在快速推进：NVFP4 已有主线修复，W4AFP8、K2.5 W4A16 DeepEP low-latency、AMD MXFP4 fused q/k RMSNorm 仍是 open PR 方向。
-
-因此，Kimi skill 如果继续更新，建议把旧的“K2/K2.5 optimization”拆成两条明确叙事：
-
-1. Kimi K2 Thinking runtime path：384 experts top-k、fused gate、Marlin MoE、EP、PCG，以及 DeepEP 尚未主线打通的边界。
-2. Kimi K2.5 multimodal and quantization path：wrapper 透明性、PP/DP/Eagle/EPLB、NVFP4/W4AFP8/AMD/DeepEP low-latency 的最新状态。

--- a/model-pr-optimization-history/minimax/README.en.md
+++ b/model-pr-optimization-history/minimax/README.en.md
@@ -1,0 +1,241 @@
+# SGLang MiniMax M2 / M2.5 / M2.7 Support and Optimization Timeline
+
+This document is based on the latest SGLang `origin/main` snapshot `47c4b3825`, plus patch-level reading of MiniMax-related merged and open PRs. It covers the main line originally represented by the `sglang-minimax-m2-m25-optimization` skill and adds the latest MiniMax M2.7, TP QK RMSNorm allreduce fusion, DP attention, FP4/NVFP4, NPU, DeepEP, EPLB, and tool-call streaming state.
+
+The short conclusion is: as of `47c4b3825`, the mainline MiniMax M2-series model file is `python/sglang/srt/models/minimax_m2.py`. It already supports base loading for M2/M2.1/M2.5, tool calling, reasoning parsing, Eagle3 aux hidden states, PP, DP-attention-related attention-TP grouping, M2.5 reduce-scatter/FP4 all-gather/AR fusion, and the TP QK RMSNorm allreduce fusion you mentioned. M2.7 currently appears mostly as documentation and reuse of the same model class, so the skill should be renamed from `sglang-minimax-m2-m25-optimization` to something more accurate, such as `sglang-minimax-m2-series-optimization` or `sglang-minimax-m2-m27-optimization`.
+
+## 1. Chronological Overview
+
+| Created    |     PR | State  | Track            | Code Area                                                     | Effect                                                                                                       |
+| ---------- | -----: | ------ | ---------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| 2025-10-25 | #12129 | merged | M2 bring-up      | `models/minimax_m2.py`, `function_call/minimax_m2.py`, parser | Added the MiniMax M2 model, tool-call parser, reasoning parser, and docs.                                    |
+| 2025-10-27 | #12186 | merged | Precision        | `MiniMaxM2RMSNormTP`                                          | Multiplied RMSNorm weight before casting back to the original dtype for better precision.                    |
+| 2025-11-07 | #12798 | merged | Eagle3           | `minimax_m2.py`, memory cache                                 | Added `aux_hidden_states` capture.                                                                           |
+| 2025-11-14 | #13297 | merged | Eagle3           | `minimax_m2.py`                                               | Added the missing `get_embed_and_head`.                                                                      |
+| 2025-11-25 | #13892 | merged | DeepEP call      | `MiniMaxM2MoE.forward_deepep`                                 | Fixed DeepEP MoE forward arguments by passing `TopKOutput` instead of split top-k tensors.                   |
+| 2025-11-27 | #14047 | merged | Router           | `layers/moe/topk.py`, `minimax_m2.py`                         | Added `topk_sigmoid` and the `scoring_func="sigmoid"` path.                                                  |
+| 2025-12-04 | #14416 | merged | QK RMSNorm       | `minimax_m2.py`                                               | Fused q/k RMSNormTP sumsq, allreduce organization, and apply.                                                |
+| 2026-01-05 | #16483 | merged | QK RMSNorm       | `rms_sumsq_serial`                                            | Added 512-aligned padding for the RMSNormTP allreduce buffer.                                                |
+| 2026-01-27 | #17826 | open   | PP + DP          | `minimax_m2.py`                                               | Open PR for Pipeline + Data Parallelism; some ideas were absorbed by later mainline PRs.                     |
+| 2026-02-04 | #18217 | merged | PCG              | `fp8_kernel.py`, `minimax_m2.py`                              | Added MiniMax-M2 piecewise CUDA graph support.                                                               |
+| 2026-02-27 | #19468 | open   | DeepEP           | server args, CI, MiniMax config                               | Open PR to support DeepEP with MiniMax models.                                                               |
+| 2026-02-28 | #19577 | merged | PP               | `minimax_m2.py`                                               | Added official PP support for the MiniMax M2 series.                                                         |
+| 2026-03-02 | #19652 | merged | NVFP4            | quantization, Marlin fallback                                 | Runs NVFP4 on non-Blackwell GPUs through Marlin fallback.                                                    |
+| 2026-03-06 | #19995 | merged | Loader           | `minimax_m2.py`                                               | Added `packed_modules_mapping`.                                                                              |
+| 2026-03-06 | #20031 | open   | Loader           | `minimax_m2.py`, weight test                                  | Supports AWQ merged expert `w13` weight loading.                                                             |
+| 2026-03-07 | #20067 | merged | M2.5 distributed | `layernorm.py`, `minimax_m2.py`, test                         | Added DP attention, DP reduce-scatter, FP4 all-gather, and prepare_attn AR fusion for M2.5.                  |
+| 2026-03-13 | #20489 | open   | DP attention     | `minimax_m2.py`, runner, memory pool, rotary                  | Fixes MiniMax M2 DP-attn attention-TP, empty batch, and related issues.                                      |
+| 2026-03-16 | #20673 | merged | TP QKNorm        | `jit_kernel/all_reduce.py`, `tp_qknorm.cuh`, `minimax_m2.py`  | Added JIT fused TP QK RMSNorm + custom allreduce.                                                            |
+| 2026-03-18 | #20870 | merged | Loader           | `minimax_m2.py`                                               | Fixed KV cache scale loading being swallowed by qkv renaming.                                                |
+| 2026-03-18 | #20873 | open   | M2.7 docs        | docs                                                          | Adds MiniMax-M2.7 and M2.7-highspeed to the old docs.                                                        |
+| 2026-03-19 | #20905 | merged | NPU/ModelSlim    | `modelslim.py`, `minimax_m2.py`                               | Adapts the w2 quant layer suffix for Minimax2.5.                                                             |
+| 2026-03-20 | #20967 | merged | TP16 bugfix      | `MiniMaxM2RMSNormTP`                                          | Fixed repeated output under TP16 caused by KV-head replication.                                              |
+| 2026-03-20 | #20975 | open   | DP attention     | DP attention follow-up fixes                                  | Successor to `#20489`, continuing DP-attn, rotary empty batch, and rank-buffer fixes.                        |
+| 2026-04-08 | #22300 | open   | FP8 GEMM         | `fp8.py`, `fp8_utils.py`, loader utils                        | Fixes FP8 GEMM performance/correctness issues from incorrect DeepGEMM UE8M0 scale conversion on fp16 models. |
+| 2026-04-09 | #22432 | open   | NPU              | `split_qkv_tp_rmsnorm_rope`                                   | Fuses split qkv, TP RMSNorm, and RoPE on NPU.                                                                |
+| 2026-04-14 | #22744 | open   | NVIDIA TF32      | server args, model runner                                     | Adds `--enable-tf32-matmul` to improve MiniMax gate GEMM performance.                                        |
+| 2026-04-16 | #22934 | open   | EPLB             | `minimax_m2.py`                                               | Adds the EPLB routed expert weight interface for MiniMax.                                                    |
+| 2026-04-20 | #23190 | open   | NPU + Eagle3     | `split_qkv_tp_rmsnorm_rope`, hidden states capture            | Successor to `#22432`, adding NPU empty-batch and DP-attn Eagle3 hidden-state capture fixes.                 |
+| 2026-04-21 | #23301 | open   | Tool calling     | `function_call/minimax_m2.py`                                 | Streams string parameters token by token to reduce tool-call argument latency.                               |
+
+## 2. MiniMax M2 Bring-up: Model Structure, Parser, and Weight Loading
+
+`#12129` is the starting point for MiniMax M2 support. It added `python/sglang/srt/models/minimax_m2.py`, matching the MiniMax checkpoint structure:
+
+- `MiniMaxM2RMSNormTP`: TP-aware RMSNorm for Q/K normalization.
+- `MiniMaxM2MLP` and `MiniMaxM2MoE`: MiniMax layers are MoE layers and do not have DeepSeek-style shared experts.
+- `MiniMaxM2Attention`: QK normalization, partial RoPE, `QKVParallelLinear`, and `RadixAttention`.
+- `MiniMaxM2DecoderLayer`: attention followed by MoE, with TBO operations for gate, expert selection, and expert compute.
+- `MiniMaxM2Model` and `MiniMaxM2ForCausalLM`: embedding, layers, norm, lm head, logits processor, and weight loading.
+
+The same PR also added `python/sglang/srt/function_call/minimax_m2.py`. MiniMax M2 tool calls are not OpenAI-style JSON; they use an XML-like block:
+
+```xml
+<minimax:tool_call>
+<invoke name="func1">
+<parameter name="param1">value1</parameter>
+</invoke>
+</minimax:tool_call>
+```
+
+`MinimaxM2Detector` therefore has to recognize `<minimax:tool_call>`, `<invoke name="...">`, and `<parameter name="...">`. The initial streaming parser tracks state such as `_in_tool_call`, `_current_parameters`, and `_streamed_parameters`, gradually emitting the tool name and argument JSON fragments. The reasoning parser also initially registered `minimax-m2`, although the actual behavior later became closer to Qwen3-style thinking.
+
+The initial weight loader handled several name mappings:
+
+- `q_proj/k_proj/v_proj` are stacked into `qkv_proj`.
+- `gate_proj/up_proj` are stacked into `gate_up_proj`.
+- MoE expert `w1/w2/w3` map to gate/down/up.
+- `rotary_emb.inv_freq` is skipped.
+- Extra GPTQ bias tensors are skipped tolerantly.
+
+`#19995` later exposed these stacking relationships explicitly:
+
+```python
+packed_modules_mapping = {
+    "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+    "gate_up_proj": ["gate_proj", "up_proj"],
+}
+```
+
+This allows quantization, loaders, and external tools to know directly from the model class which checkpoint modules are packed.
+
+`#20870` fixed KV cache scale loading. KV scales in checkpoints are named like `self_attn.k_proj.k_scale` / `self_attn.v_proj.v_scale`, but the stacked mapping loop used to rename `k_proj` to `qkv_proj` first, causing `maybe_remap_kv_scale_name` to miss the original pattern. The PR adds `_is_kv_scale = name.endswith(".k_scale") or name.endswith(".v_scale")`; for KV scales it skips qkv renaming and lets the original names reach `maybe_remap_kv_scale_name`, which then maps them to `self_attn.attn.k_scale/v_scale`.
+
+`#20031` is still open and targets AWQ merged expert weights. Some checkpoints merge gate/up into `w13` instead of storing separate `w1/w3`. The PR uses `FusedMoE.make_expert_params_mapping_fused(ckpt_gate_up_proj_name="w13", ckpt_down_proj_name="w2", ...)` and tries the fused mapping before the old `w1/w2/w3` mapping.
+
+## 3. Router and DeepEP Calls: Sigmoid Top-k and Unified TopKOutput
+
+MiniMax M2 routing uses sigmoid scoring rather than the default softmax. `#14047` adds a `scoring_func` field to `TopKConfig` and supports `scoring_func="sigmoid"` across `topk.py`:
+
+- CUDA/HIP imports `topk_sigmoid`.
+- `fused_topk_torch_native` abstracts `scoring_func_impl`, supporting softmax and sigmoid.
+- `fused_topk` calls `topk_sigmoid(topk_weights, topk_ids, gating_output, renormalize, correction_bias)` when `scoring_func == "sigmoid"`.
+- `select_experts` threads `topk_config.scoring_func` down to the fused top-k implementation.
+- `MiniMaxM2MoE` removes the early workaround of setting `use_grouped_topk=True, num_expert_group=1, topk_group=1` and directly relies on sigmoid scoring.
+
+`#13892` fixes the DeepEP MoE forward protocol. Earlier code unpacked `self.topk(...)` into `topk_weights, topk_idx, _` and passed them separately into `self.experts(topk_idx=..., topk_weights=...)`. The mainline MoE runner later standardized on `TopKOutput`, so the PR changed it to:
+
+- `topk_output = self.topk(...)` for non-empty token batches.
+- `topk_output = self.topk.empty_topk_output(device=hidden_states.device)` for empty token batches.
+- experts call unified as `self.experts(hidden_states=hidden_states, topk_output=topk_output)`.
+
+This lets normal MoE, DeepEP MoE, empty batches, and later EP/DP extensions share the same top-k data structure.
+
+`#19468` remains open and aims to officially support DeepEP with MiniMax models. The patch touches server args, CI DeepEP installation, and MiniMax hidden-size / BF16 requirements. Current main already routes `MiniMaxM2MoE.forward` to `forward_deepep` when `get_moe_a2a_backend().is_deepep()` or Ascend FuseEP is enabled, but complete DeepEP readiness still depends on this track being merged and tested.
+
+## 4. QK RMSNorm: From Precision Fix to TP Allreduce Fusion
+
+`#12186` is a one-line precision fix, but an important one. The old logic was:
+
+```python
+x = x.to(orig_dtype) * self.weight
+```
+
+The PR changes it to:
+
+```python
+x = (x * self.weight).to(orig_dtype)
+```
+
+Now the weight multiplication happens on the fp32 normalized tensor, and only the final result is cast back to the original dtype.
+
+`#14416` is the first Q/K RMSNormTP fusion. MiniMax attention applies RMSNorm to q and k, and under TP the variance must be aggregated across ranks. The PR adds Triton kernels:
+
+- `rmsnorm_sumsq_kernel_serial`: computes q and k sum of squares together and writes fp32 `[B, 2]`.
+- `rmsnorm_apply_kernel_serial`: reads the allreduced sumsq, applies `rsqrt(sum_sq / full_dim + eps)`, and multiplies q/k by their weights.
+- `rms_sumsq_serial` and `rms_apply_serial` Python wrappers.
+- `MiniMaxM2RMSNormTP.forward_qk`, which normalizes q/k together and reduces launch/allreduce organization overhead.
+- `MiniMaxM2Attention.forward_prepare` calls `forward_qk` when `use_qk_norm` is enabled instead of calling q_norm and k_norm separately.
+
+`#16483` optimizes this allreduce buffer. SGLang custom allreduce `sglang::cross_device_reduce_1stage` needs alignment, and MiniMax RMSNormTP reduces a `[B, 2]` fp32 tensor. The PR pads the element count to 512 alignment, avoiding performance and boundary issues for unaligned custom allreduce sizes. The PR description reports roughly 6% throughput improvement on M2.1.
+
+`#20967` fixes repeated output under TP16. The root cause is that when attention TP size is larger than the number of KV heads, KV heads are replicated across ranks, but the old RMSNormTP weight loader still sharded directly by rank. The PR aligns `MiniMaxM2RMSNormTP` with `QKVParallelLinear`:
+
+- If `attn_tp_size >= num_heads`, require `attn_tp_size % num_heads == 0`, keep one logical head per rank, and set `num_head_replicas = attn_tp_size // num_heads`.
+- Otherwise require `num_heads % attn_tp_size == 0`, assign `num_heads // attn_tp_size` heads per rank, and set `num_head_replicas = 1`.
+- The weight loader uses `shard_id = attn_tp_rank // num_head_replicas`, so replicated ranks load the same shard.
+- Forward allreduce uses the attention TP group rather than blindly using global TP.
+
+`#20673` is the “allreduce TP norm” optimization you mentioned, and it has been merged. It adds the JIT kernel `python/sglang/jit_kernel/csrc/distributed/tp_qknorm.cuh` and exposes the following in `python/sglang/jit_kernel/all_reduce.py`:
+
+- `fused_parallel_qknorm`
+- `get_fused_parallel_qknorm_max_occupancy`
+
+MiniMax adds `MiniMaxM2QKRMSNorm`:
+
+- The default `_forward_naive` still runs `rms_sumsq_serial(q, k)`, `attn_tp_all_reduce(sum_sq)`, and `rms_apply_serial(...)`.
+- When `world_size > 1`, the device is CUDA, and `SGLANG_USE_FUSED_PARALLEL_QKNORM` is true, it uses the JIT fused path.
+- The fused path first queries max occupancy from dtype, world size, and full q/k dimensions.
+- It creates `CustomAllReduceV2` with the attention TP group.
+- Max push size is derived from `chunked_prefill_size`, `context_len`, and `max_prefill_tokens`, then aligned to 512.
+- At runtime, the registered custom op `fused_tp_qknorm` calls `fused_parallel_qknorm(COMM_MAP[counter].obj, q, k, q_weight, k_weight, eps)`, combining q/k norm and cross-TP reduction in one JIT kernel/communication path.
+
+This PR also adds `test_tp_qknorm.py` and `bench_tp_qknorm.py`. The PR description reports decode throughput improving from 150 tps to 157 tps, making it one of the most important MiniMax QKNorm optimizations.
+
+## 5. PP, DP Attention, M2.5 Distributed Path, and PCG
+
+`#19577` is the official MiniMax PP merge. It does several things:
+
+- `MiniMaxM2Model` uses `make_layers`, producing `self.layers, self.start_layer, self.end_layer`.
+- Non-last PP ranks use `PPMissingLayer` for `norm` and `lm_head`.
+- Forward accepts `pp_proxy_tensors`; the first rank starts from embeddings, while non-first ranks read `hidden_states/residual` from the proxy.
+- Non-last ranks return `PPProxyTensors({"hidden_states": hidden_states, "residual": residual})`.
+- `load_weights` uses `get_layer_id(name)` to skip layer weights outside the current PP shard.
+
+`#17826` is an open PP + DP PR. It was not merged, but ideas such as attention-TP rank/size, `is_dp_attention_enabled()`, and whether embedding/lm head should use the attention TP group were gradually absorbed into later mainline PRs.
+
+`#20067` is the main MiniMax-M2.5 distributed optimization PR. Its title is direct: DP attention, DP reduce-scatter, FP4 all-gather, and AR fusion in prepare_attn. Current main shows these results:
+
+- `MiniMaxM2Attention` initializes QKV and O projection with `get_attention_tp_rank()` / `get_attention_tp_size()` instead of default global TP.
+- `VocabParallelEmbedding(..., use_attn_tp_group=is_dp_attention_enabled())` makes embedding operate on the attention TP group in DP attention mode.
+- `MiniMaxM2DecoderLayer` creates `LayerCommunicator(..., allow_reduce_scatter=True)`.
+- MoE forward receives `should_allreduce_fusion` and `use_reduce_scatter`; when the next layer can fuse allreduce or the current layer can use reduce-scatter, it does not immediately run `tensor_model_parallel_all_reduce` inside MoE.
+- When `should_use_flashinfer_cutlass_moe_fp4_allgather()` is true, MoE also skips its internal allreduce so the FP4 all-gather path can own communication.
+- Registered tests cover M2.5 shapes such as TP8+EP8 and TP8+DP8+EP8+DP-attention.
+
+`#18217` adds piecewise CUDA graph support for MiniMax-M2. It handles config lookup in `fp8_kernel.py` under Dynamo compiling and replaces expert distribution recorder contexts with `nullcontext()` in MoE expert selection, TBO ops, and the model forward loop where PCG capture would otherwise see incompatible dynamic context.
+
+`#20489` and `#20975` are still-open DP attention fix lines. Their patches include:
+
+- MiniMax attention uses attention TP size/group for head partitioning and communication instead of global TP.
+- `model_runner` initializes `global_num_tokens_gpu` with `dp_size` when `require_attn_tp_gather` is true, avoiding invalid device ordinal/access on higher ranks.
+- memory pool and rotary embedding handle empty batches to avoid 0-sized tensor view errors.
+- follow-up patches fix function names from `get_attention_tp_world_size` to the actually available `get_attn_tensor_model_parallel_world_size` / `get_attn_tp_group`.
+
+Current main already has many attention-TP and empty-hidden-state protections, but these PRs show that DP-attn boundaries are still being refined.
+
+## 6. Eagle3, M2.7, and Tool-call Streaming
+
+`#12798` adds Eagle3 aux hidden state capture for MiniMax M2:
+
+- `MiniMaxM2Model` adds `layers_to_capture`.
+- In the forward loop, if the current layer id is in the capture list, `hidden_states + residual` is appended to `aux_hidden_states`.
+- `MiniMaxM2ForCausalLM.set_eagle3_layers_to_capture` sets default capture layers `[2, num_layers // 2, num_layers - 3]`, or uses caller-provided layer ids.
+- The logits processor receives `aux_hidden_states` for Eagle3.
+
+`#13297` adds `get_embed_and_head`, returning `self.model.embed_tokens.weight, self.lm_head.weight`, so Eagle3 can access the main model embedding and lm head.
+
+`#20873` is an open old-docs PR that adds MiniMax-M2.7 and M2.7-highspeed. Although this PR is not merged, latest main already contains `docs_new/cookbook/autoregressive/MiniMax/MiniMax-M2.7.mdx`, and the cookbook navigation includes MiniMax-M2.7. At the code level, M2.7 still reuses the `MiniMaxM2ForCausalLM` model family, so the skill name should no longer be locked to M2.5.
+
+`#23301` is the new open tool-call streaming PR. It rewrites `MinimaxM2Detector.parse_streaming_increment` so string parameters can stream token by token:
+
+- Adds `_STREAM_HOLD_BACK = len("</parameter>") - 1` to avoid emitting a partial end tag as parameter content.
+- Adds fine-grained state such as `_in_parameter`, `_current_param_name`, `_param_raw_sent_len`, `_current_param_is_string`, and `_first_param_started`.
+- For string parameters, once `<parameter name="...">` is seen, it emits the JSON key prefix and then incrementally JSON-escapes and appends value content.
+- Non-string parameters such as int, bool, object, and array are still buffered until `</parameter>` and converted once.
+- At `</invoke>`, it closes the JSON object with `}` when needed.
+
+The value of this PR is not model throughput; it improves agent/tool-use experience because long string arguments no longer have to wait for the full `</parameter>` before any argument text is returned.
+
+## 7. Quantization, NPU, TF32, EPLB, and Other Open Optimization Tracks
+
+`#19652` is generic but important for MiniMax M2.5: NVFP4 Marlin fallback. It adds `marlin_utils_fp4.py`, allowing non-Blackwell GPUs starting at SM75 to run NVFP4 through Marlin FP4 fallback:
+
+- Detects Blackwell; if the GPU is not Blackwell but supports Marlin FP4, fallback is enabled.
+- Processes NVFP4 scales by converting FP8-S1E4M3 scales into the FP8-S0E5M3 format better suited for Marlin dequantization.
+- Repacks linear and MoE weights into Marlin tile layout.
+- The MoE fallback builds `MarlinMoeQuantInfo` so fused Marlin MoE can use FP4 scalar type and global scales.
+- Adds `test_nvfp4_marlin_fallback.py` for linear and MoE coverage.
+
+`#22300` is an open FP8 GEMM scale fix. The issue is that if weight scales are converted at load time into the UE8M0/R128c4 packed format required by DeepGEMM, but runtime falls back to Triton because fp16 output dtype, K shape, or backend constraints are not satisfied, Triton still expects ordinary fp32 scales. That can cause wrong results or performance issues. The PR makes `should_deepgemm_weight_requant_ue8m0` check output dtype and weight shape, and makes FlashInfer/TRTLLM fallback detect `weight_scale.format_ue8m0`.
+
+`#20905` is the NPU ModelSlim track. MiniMax2.5 checkpoint MoE quant descriptions may use suffixes like `.0.w2.weight` instead of ordinary `.0.gate_proj.weight`. The PR updates ModelSlim MoE scheme detection so `W4A4_DYNAMIC`, `W4A8_DYNAMIC`, and `W8A8_DYNAMIC` can be recognized from MiniMax's w2 suffix.
+
+`#22432` and `#23190` are the NPU fused attention-prepare track. They introduce `sgl_kernel_npu.norm.split_qkv_tp_rmsnorm_rope.split_qkv_tp_rmsnorm_rope`, which fuses qkv split, TP RMSNorm, and RoPE after qkv projection inside `forward_prepare_npu`. `#23190` also adds empty-hidden-state short-circuiting and fixes Eagle3 hidden state capture under DP-attn.
+
+`#22744` is the NVIDIA TF32 gate GEMM optimization. It adds `--enable-tf32-matmul`, and model runner calls `torch.set_float32_matmul_precision("high")`. The PR description reports MiniMax gate GEMM FP32 overhead dropping from 9.1% to 3.3%, and batch64 throughput rising from 3076.99 to 3302.03 tok/s.
+
+`#22934` is the open MiniMax EPLB bugfix. It adds `get_moe_weights` to `MiniMaxM2MoE`, using `filter_moe_weight_param_global_expert` to filter local/redundant expert weights. `MiniMaxM2ForCausalLM` gains `_routed_experts_weights_of_layer = LazyValue(...)` and a `routed_experts_weights_of_layer` property. Current main already has a similar wrapper interface for Kimi K2.5, but the MiniMax version has not landed yet.
+
+## 8. Current Main Code Shape and Skill Naming
+
+As of `47c4b3825`, the MiniMax mainline looks like this:
+
+- `MiniMaxM2ForCausalLM` is the shared model class for M2/M2.1/M2.5/M2.7.
+- `MiniMaxM2MoE` uses sigmoid top-k, `TopKOutput`, normal/DeepEP branches, and communication control for reduce-scatter and FP4 all-gather.
+- `MiniMaxM2Attention` uses attention TP rank/size and supports DP-attention head partitioning; Q/K RMSNorm goes through `MiniMaxM2QKRMSNorm`, with JIT fused TP QKNorm allreduce enabled by `SGLANG_USE_FUSED_PARALLEL_QKNORM`.
+- `MiniMaxM2DecoderLayer` uses `LayerCommunicator` for prepare_attn AR fusion, prepare_mlp, reduce-scatter, and postprocess.
+- The loader supports packed mapping, KV scale remapping, and PP shard skipping; AWQ `w13` merged expert loading is still open.
+- M2.7 appears in docs while the code still reuses the same M2-series implementation.
+
+Therefore, the skill should be renamed from `sglang-minimax-m2-m25-optimization` to `sglang-minimax-m2-series-optimization`. If the latest model name must be explicit, `sglang-minimax-m2-m27-optimization` is also reasonable, but “series” is more durable because M2.7, M2.7-highspeed, and future platform optimizations continue to reuse the same model-family implementation.

--- a/model-pr-optimization-history/minimax/README.en.md
+++ b/model-pr-optimization-history/minimax/README.en.md
@@ -2,7 +2,7 @@
 
 This document is based on the latest SGLang `origin/main` snapshot `47c4b3825`, plus patch-level reading of MiniMax-related merged and open PRs. It covers the main line originally represented by the `sglang-minimax-m2-m25-optimization` skill and adds the latest MiniMax M2.7, TP QK RMSNorm allreduce fusion, DP attention, FP4/NVFP4, NPU, DeepEP, EPLB, and tool-call streaming state.
 
-The short conclusion is: as of `47c4b3825`, the mainline MiniMax M2-series model file is `python/sglang/srt/models/minimax_m2.py`. It already supports base loading for M2/M2.1/M2.5, tool calling, reasoning parsing, Eagle3 aux hidden states, PP, DP-attention-related attention-TP grouping, M2.5 reduce-scatter/FP4 all-gather/AR fusion, and the TP QK RMSNorm allreduce fusion you mentioned. M2.7 currently appears mostly as documentation and reuse of the same model class, so the skill should be renamed from `sglang-minimax-m2-m25-optimization` to something more accurate, such as `sglang-minimax-m2-series-optimization` or `sglang-minimax-m2-m27-optimization`.
+The short conclusion is: as of `47c4b3825`, the mainline MiniMax M2-series model file is `python/sglang/srt/models/minimax_m2.py`. It already supports base loading for M2/M2.1/M2.5, tool calling, reasoning parsing, Eagle3 aux hidden states, PP, DP-attention-related attention-TP grouping, M2.5 reduce-scatter/FP4 all-gather/AR fusion, and the TP QK RMSNorm allreduce fusion you mentioned. M2.7 currently appears mostly as documentation and reuse of the same model class.
 
 ## 1. Chronological Overview
 
@@ -195,7 +195,7 @@ Current main already has many attention-TP and empty-hidden-state protections, b
 
 `#13297` adds `get_embed_and_head`, returning `self.model.embed_tokens.weight, self.lm_head.weight`, so Eagle3 can access the main model embedding and lm head.
 
-`#20873` is an open old-docs PR that adds MiniMax-M2.7 and M2.7-highspeed. Although this PR is not merged, latest main already contains `docs_new/cookbook/autoregressive/MiniMax/MiniMax-M2.7.mdx`, and the cookbook navigation includes MiniMax-M2.7. At the code level, M2.7 still reuses the `MiniMaxM2ForCausalLM` model family, so the skill name should no longer be locked to M2.5.
+`#20873` is an open old-docs PR that adds MiniMax-M2.7 and M2.7-highspeed. Although this PR is not merged, latest main already contains `docs_new/cookbook/autoregressive/MiniMax/MiniMax-M2.7.mdx`, and the cookbook navigation includes MiniMax-M2.7. At the code level, M2.7 still reuses the `MiniMaxM2ForCausalLM` model family.
 
 `#23301` is the new open tool-call streaming PR. It rewrites `MinimaxM2Detector.parse_streaming_increment` so string parameters can stream token by token:
 
@@ -227,7 +227,7 @@ The value of this PR is not model throughput; it improves agent/tool-use experie
 
 `#22934` is the open MiniMax EPLB bugfix. It adds `get_moe_weights` to `MiniMaxM2MoE`, using `filter_moe_weight_param_global_expert` to filter local/redundant expert weights. `MiniMaxM2ForCausalLM` gains `_routed_experts_weights_of_layer = LazyValue(...)` and a `routed_experts_weights_of_layer` property. Current main already has a similar wrapper interface for Kimi K2.5, but the MiniMax version has not landed yet.
 
-## 8. Current Main Code Shape and Skill Naming
+## 8. Current Main Code Shape
 
 As of `47c4b3825`, the MiniMax mainline looks like this:
 
@@ -237,5 +237,3 @@ As of `47c4b3825`, the MiniMax mainline looks like this:
 - `MiniMaxM2DecoderLayer` uses `LayerCommunicator` for prepare_attn AR fusion, prepare_mlp, reduce-scatter, and postprocess.
 - The loader supports packed mapping, KV scale remapping, and PP shard skipping; AWQ `w13` merged expert loading is still open.
 - M2.7 appears in docs while the code still reuses the same M2-series implementation.
-
-Therefore, the skill should be renamed from `sglang-minimax-m2-m25-optimization` to `sglang-minimax-m2-series-optimization`. If the latest model name must be explicit, `sglang-minimax-m2-m27-optimization` is also reasonable, but “series” is more durable because M2.7, M2.7-highspeed, and future platform optimizations continue to reuse the same model-family implementation.

--- a/model-pr-optimization-history/minimax/README.zh.md
+++ b/model-pr-optimization-history/minimax/README.zh.md
@@ -1,0 +1,241 @@
+# SGLang MiniMax M2 / M2.5 / M2.7 支持与优化时间线
+
+本文基于 SGLang `origin/main` 最新快照 `47c4b3825`，以及 MiniMax 相关 merged、open PR patch 阅读结果整理。范围覆盖原有 `sglang-minimax-m2-m25-optimization` skill 涉及的主线，并补充 MiniMax M2.7、TP QK RMSNorm allreduce fusion、DP attention、FP4/NVFP4、NPU、DeepEP、EPLB 和 tool-call streaming 的最新状态。
+
+阅读结论先放前面：截至 `47c4b3825`，MiniMax M2 系列主线模型文件是 `python/sglang/srt/models/minimax_m2.py`，它已经支持 M2/M2.1/M2.5 的基础加载、tool calling、reasoning parser、Eagle3 aux hidden states、PP、DP attention 相关 attention-TP 分组、M2.5 reduce-scatter/FP4 all-gather/AR fusion，以及你提到的 TP QK RMSNorm allreduce fusion。M2.7 当前主要体现为文档和同一模型类复用，建议 skill 名称从 `sglang-minimax-m2-m25-optimization` 改成更准确的 `sglang-minimax-m2-series-optimization` 或 `sglang-minimax-m2-m27-optimization`。
+
+## 1. 时间线总览
+
+| 创建日期   |     PR | 状态   | 主线          | 代码区域                                                      | 作用                                                                                |
+| ---------- | -----: | ------ | ------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| 2025-10-25 | #12129 | merged | M2 bring-up   | `models/minimax_m2.py`、`function_call/minimax_m2.py`、parser | 新增 MiniMax M2 模型、tool-call parser、reasoning parser 和文档。                   |
+| 2025-10-27 | #12186 | merged | 精度          | `MiniMaxM2RMSNormTP`                                          | RMSNorm 中先乘 weight 再转回原 dtype，提高精度。                                    |
+| 2025-11-07 | #12798 | merged | Eagle3        | `minimax_m2.py`、memory cache                                 | 支持捕获 `aux_hidden_states`。                                                      |
+| 2025-11-14 | #13297 | merged | Eagle3        | `minimax_m2.py`                                               | 补齐 `get_embed_and_head`。                                                         |
+| 2025-11-25 | #13892 | merged | DeepEP 调用   | `MiniMaxM2MoE.forward_deepep`                                 | 修正 DeepEP MoE forward 参数，从拆散 top-k 改为传 `TopKOutput`。                    |
+| 2025-11-27 | #14047 | merged | Router        | `layers/moe/topk.py`、`minimax_m2.py`                         | 增加 `topk_sigmoid` 和 `scoring_func="sigmoid"` 路径。                              |
+| 2025-12-04 | #14416 | merged | QK RMSNorm    | `minimax_m2.py`                                               | 融合 q/k RMSNormTP 的 sumsq、allreduce 和 apply。                                   |
+| 2026-01-05 | #16483 | merged | QK RMSNorm    | `rms_sumsq_serial`                                            | 给 RMSNormTP allreduce buffer 做 512 对齐 padding。                                 |
+| 2026-01-27 | #17826 | open   | PP + DP       | `minimax_m2.py`                                               | 支持 Pipeline + Data Parallelism 的开放 PR，部分思想已被后续主线吸收。              |
+| 2026-02-04 | #18217 | merged | PCG           | `fp8_kernel.py`、`minimax_m2.py`                              | 支持 MiniMax-M2 piecewise CUDA graph。                                              |
+| 2026-02-27 | #19468 | open   | DeepEP        | server args、CI、MiniMax config                               | 让 MiniMax 模型支持 DeepEP 的开放 PR。                                              |
+| 2026-02-28 | #19577 | merged | PP            | `minimax_m2.py`                                               | 正式增加 MiniMax M2 系列 PP 支持。                                                  |
+| 2026-03-02 | #19652 | merged | NVFP4         | quantization、Marlin fallback                                 | 非 Blackwell GPU 上用 Marlin fallback 跑 NVFP4。                                    |
+| 2026-03-06 | #19995 | merged | Loader        | `minimax_m2.py`                                               | 增加 `packed_modules_mapping`。                                                     |
+| 2026-03-06 | #20031 | open   | Loader        | `minimax_m2.py`、weight test                                  | 支持 AWQ merged expert `w13` 权重加载。                                             |
+| 2026-03-07 | #20067 | merged | M2.5 分布式   | `layernorm.py`、`minimax_m2.py`、test                         | M2.5 支持 DP attention、DP reduce-scatter、FP4 all-gather、prepare_attn AR fusion。 |
+| 2026-03-13 | #20489 | open   | DP attention  | `minimax_m2.py`、runner、memory pool、rotary                  | 修复 MiniMax M2 DP-attn 的 attention-TP、empty batch 等问题。                       |
+| 2026-03-16 | #20673 | merged | TP QKNorm     | `jit_kernel/all_reduce.py`、`tp_qknorm.cuh`、`minimax_m2.py`  | 新增 JIT fused TP QK RMSNorm + custom allreduce。                                   |
+| 2026-03-18 | #20870 | merged | Loader        | `minimax_m2.py`                                               | 修复 KV cache scale 加载时被 qkv rename 吞掉的问题。                                |
+| 2026-03-18 | #20873 | open   | M2.7 docs     | docs                                                          | 旧 docs 中增加 MiniMax-M2.7 和 M2.7-highspeed。                                     |
+| 2026-03-19 | #20905 | merged | NPU/ModelSlim | `modelslim.py`、`minimax_m2.py`                               | 适配 Minimax2.5 的 w2 quant layer suffix。                                          |
+| 2026-03-20 | #20967 | merged | TP16 bugfix   | `MiniMaxM2RMSNormTP`                                          | 修复 TP16 下 KV head replica 造成的重复输出。                                       |
+| 2026-03-20 | #20975 | open   | DP attention  | DP attention 后续修复                                         | `#20489` 的后续版，继续修 DP-attn、rotary empty batch、rank buffer。                |
+| 2026-04-08 | #22300 | open   | FP8 GEMM      | `fp8.py`、`fp8_utils.py`、loader utils                        | 修复 fp16 模型上 DeepGEMM UE8M0 scale 误转换导致的 FP8 GEMM 性能/正确性问题。       |
+| 2026-04-09 | #22432 | open   | NPU           | `split_qkv_tp_rmsnorm_rope`                                   | NPU 上融合 split qkv、TP RMSNorm、RoPE。                                            |
+| 2026-04-14 | #22744 | open   | NVIDIA TF32   | server args、model runner                                     | 增加 `--enable-tf32-matmul` 提升 MiniMax gate GEMM 性能。                           |
+| 2026-04-16 | #22934 | open   | EPLB          | `minimax_m2.py`                                               | 给 MiniMax 增加 EPLB routed expert weights 接口。                                   |
+| 2026-04-20 | #23190 | open   | NPU + Eagle3  | `split_qkv_tp_rmsnorm_rope`、hidden states capture            | `#22432` 后续，补 NPU empty batch 和 DP-attn 下 Eagle3 hidden states capture。      |
+| 2026-04-21 | #23301 | open   | Tool calling  | `function_call/minimax_m2.py`                                 | string 参数 token-by-token streaming，降低 tool-call 参数延迟。                     |
+
+## 2. MiniMax M2 bring-up：模型结构、parser 与权重加载
+
+`#12129` 是 MiniMax M2 接入的起点。它新增 `python/sglang/srt/models/minimax_m2.py`，模型结构和 MiniMax checkpoint 对齐：
+
+- `MiniMaxM2RMSNormTP`：为 Q/K normalization 设计的 TP-aware RMSNorm。
+- `MiniMaxM2MLP` 与 `MiniMaxM2MoE`：MiniMax 的每层是 MoE，不像 DeepSeek 那样带 shared experts。
+- `MiniMaxM2Attention`：使用 QK normalization、partial RoPE、`QKVParallelLinear` 和 `RadixAttention`。
+- `MiniMaxM2DecoderLayer`：attention 后接 MoE，支持 TBO 所需的 gate、select experts、expert compute 等 operation 拆分。
+- `MiniMaxM2Model` 与 `MiniMaxM2ForCausalLM`：负责 embedding、layers、norm、lm head、logits processor 和权重加载。
+
+同一个 PR 还新增 `python/sglang/srt/function_call/minimax_m2.py`。MiniMax M2 的 tool call 格式不是 OpenAI JSON，而是 XML-like block：
+
+```xml
+<minimax:tool_call>
+<invoke name="func1">
+<parameter name="param1">value1</parameter>
+</invoke>
+</minimax:tool_call>
+```
+
+`MinimaxM2Detector` 因此要识别 `<minimax:tool_call>`、`<invoke name="...">` 和 `<parameter name="...">`。streaming 初版会维护 `_in_tool_call`、`_current_parameters`、`_streamed_parameters` 等状态，逐步发出 tool name 和参数 JSON fragment。reasoning parser 初期也接入了 `minimax-m2`，后来实际行为与 Qwen3-style thinking 更接近。
+
+权重加载初版处理几类名字映射：
+
+- `q_proj/k_proj/v_proj` 堆叠进 `qkv_proj`。
+- `gate_proj/up_proj` 堆叠进 `gate_up_proj`。
+- MoE experts 的 `w1/w2/w3` 分别映射 gate/down/up。
+- 跳过 `rotary_emb.inv_freq`。
+- 对 GPTQ extra bias 做容错跳过。
+
+`#19995` 后来把这些堆叠关系显式暴露为：
+
+```python
+packed_modules_mapping = {
+    "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+    "gate_up_proj": ["gate_proj", "up_proj"],
+}
+```
+
+这让量化、加载器和外部工具能从模型类上直接知道哪些 checkpoint module 是 packed module。
+
+`#20870` 修了 KV cache scale 加载。问题是 checkpoint 里 KV scale 名字类似 `self_attn.k_proj.k_scale` / `self_attn.v_proj.v_scale`，但 stacked mapping loop 会先把 `k_proj` 改成 `qkv_proj`，导致 `maybe_remap_kv_scale_name` 无法识别原始模式。PR 增加 `_is_kv_scale = name.endswith(".k_scale") or name.endswith(".v_scale")`，遇到 KV scale 时跳过 qkv rename，让原始名字直接进入 `maybe_remap_kv_scale_name`，最终映射到 `self_attn.attn.k_scale/v_scale`。
+
+`#20031` 仍 open，目标是支持 AWQ merged expert weights。某些 checkpoint 把 gate/up 合并为 `w13`，而不是 `w1/w3` 分开。PR 使用 `FusedMoE.make_expert_params_mapping_fused(ckpt_gate_up_proj_name="w13", ckpt_down_proj_name="w2", ...)`，并在旧 `w1/w2/w3` mapping 前先尝试 fused mapping。
+
+## 3. Router 与 DeepEP 调用：sigmoid top-k 和 TopKOutput 统一
+
+MiniMax M2 的 router 使用 sigmoid scoring，而不是默认 softmax。`#14047` 把 `TopKConfig` 增加 `scoring_func` 字段，并在 `topk.py` 的多条路径中支持 `scoring_func="sigmoid"`：
+
+- CUDA/HIP 导入 `topk_sigmoid`。
+- `fused_topk_torch_native` 中抽象 `scoring_func_impl`，支持 softmax/sigmoid。
+- `fused_topk` 在 `scoring_func == "sigmoid"` 时调用 `topk_sigmoid(topk_weights, topk_ids, gating_output, renormalize, correction_bias)`。
+- `select_experts` 把 `topk_config.scoring_func` 一路传到底层 fused top-k。
+- `MiniMaxM2MoE` 删除早期为了复用 grouped top-k 而设置的 `use_grouped_topk=True, num_expert_group=1, topk_group=1`，直接依赖 sigmoid scoring。
+
+`#13892` 修复 DeepEP MoE forward 的参数协议。早期代码把 `self.topk(...)` 返回拆成 `topk_weights, topk_idx, _`，然后分别传给 `self.experts(topk_idx=..., topk_weights=...)`。主线 MoE runner 后续统一为 `TopKOutput`，所以 PR 改成：
+
+- 正常 token 时 `topk_output = self.topk(...)`。
+- 空 token 时 `topk_output = self.topk.empty_topk_output(device=hidden_states.device)`。
+- experts 调用统一为 `self.experts(hidden_states=hidden_states, topk_output=topk_output)`。
+
+这使 MiniMax 的 normal MoE、DeepEP MoE、空 batch 场景和后续 EP/DP 扩展都能共享同一 top-k 数据结构。
+
+`#19468` 仍 open，目标是让 MiniMax 模型正式支持 DeepEP。patch 涉及 server args、CI DeepEP 安装和 MiniMax hidden size / BF16 要求。当前 main 中 `MiniMaxM2MoE.forward` 已经会在 `get_moe_a2a_backend().is_deepep()` 或 Ascend FuseEP 时走 `forward_deepep`，但完整 DeepEP 可用性仍要看这个方向后续合入和测试。
+
+## 4. QK RMSNorm：从精度修复到 TP allreduce fusion
+
+`#12186` 是一个只有一行的精度修复，但非常关键。原逻辑是：
+
+```python
+x = x.to(orig_dtype) * self.weight
+```
+
+PR 改成：
+
+```python
+x = (x * self.weight).to(orig_dtype)
+```
+
+这样 weight 乘法发生在 fp32 normalized tensor 上，最后才 cast 回原 dtype，避免提前降精度。
+
+`#14416` 是第一版 Q/K RMSNormTP fusion。MiniMax 的 attention 会对 q 和 k 分别做 RMSNorm，而且 TP 下 variance 需要跨 rank 汇总。PR 新增 Triton kernel：
+
+- `rmsnorm_sumsq_kernel_serial`：同时计算 q 和 k 的 sum of squares，输出 fp32 `[B, 2]`。
+- `rmsnorm_apply_kernel_serial`：读取 allreduce 后的 sumsq，对 q/k 应用 `rsqrt(sum_sq / full_dim + eps)` 和各自 weight。
+- `rms_sumsq_serial` 和 `rms_apply_serial` 作为 Python wrapper。
+- `MiniMaxM2RMSNormTP.forward_qk` 把 q/k 的 norm 合在一起，减少 kernel launch 和 allreduce 组织成本。
+- `MiniMaxM2Attention.forward_prepare` 在 `use_qk_norm` 时调用 `forward_qk`，而不是分别调用 q_norm 和 k_norm。
+
+`#16483` 优化了这个 allreduce buffer。SGLang 的 custom allreduce `sglang::cross_device_reduce_1stage` 需要对齐，MiniMax RMSNormTP reduce 的是 `[B, 2]` fp32 tensor。PR 把 buffer 元素数 pad 到 512 对齐，避免 custom allreduce 处理非对齐大小时的性能/边界问题。PR 描述中提到 M2.1 上吞吐约有 6% 提升。
+
+`#20967` 修复 TP16 重复输出。根因是当 attention TP size 大于 KV head 数时，KV heads 会在多个 rank 上 replica，而旧 RMSNormTP weight sharding 仍按 rank 直接切 shard。PR 让 `MiniMaxM2RMSNormTP` 对齐 `QKVParallelLinear` 的逻辑：
+
+- 如果 `attn_tp_size >= num_heads`，要求 `attn_tp_size % num_heads == 0`，本 rank 只有 1 个 logical head，并设置 `num_head_replicas = attn_tp_size // num_heads`。
+- 否则要求 `num_heads % attn_tp_size == 0`，每 rank 负责 `num_heads // attn_tp_size` 个 head，`num_head_replicas = 1`。
+- weight loader 使用 `shard_id = attn_tp_rank // num_head_replicas`，使 replicated ranks 读取同一个 shard。
+- forward 中 allreduce 使用 attention TP group，而不是盲目使用全局 TP。
+
+`#20673` 是你提到的 “allreduce TP norm” 优化，目前已经 merged。它新增 JIT kernel `python/sglang/jit_kernel/csrc/distributed/tp_qknorm.cuh`，并在 `python/sglang/jit_kernel/all_reduce.py` 暴露：
+
+- `fused_parallel_qknorm`
+- `get_fused_parallel_qknorm_max_occupancy`
+
+MiniMax 侧新增 `MiniMaxM2QKRMSNorm`：
+
+- 默认 `_forward_naive` 仍然是 `rms_sumsq_serial(q, k)`、`attn_tp_all_reduce(sum_sq)`、`rms_apply_serial(...)`。
+- 当 `world_size > 1`、设备是 CUDA，并且环境变量 `SGLANG_USE_FUSED_PARALLEL_QKNORM` 为 true 时，使用 JIT fused path。
+- fused path 先根据 dtype、world size、q/k full dim 查询 max occupancy。
+- 创建 `CustomAllReduceV2`，group 是 attention TP group。
+- max push size 根据 `chunked_prefill_size`、`context_len`、`max_prefill_tokens` 推导并做 512 对齐。
+- runtime 调用 registered custom op `fused_tp_qknorm`，最终执行 `fused_parallel_qknorm(COMM_MAP[counter].obj, q, k, q_weight, k_weight, eps)`，在一个 JIT kernel/通信路径中完成 q/k norm 和跨 TP reduce。
+
+这个 PR 还加入 `test_tp_qknorm.py` 和 `bench_tp_qknorm.py`。PR 描述中的 decode benchmark 从 150 tps 提升到 157 tps，是当前 MiniMax QKNorm 路径最重要的亮点之一。
+
+## 5. PP、DP attention、M2.5 分布式路径和 PCG
+
+`#19577` 是 MiniMax PP 的正式合入。它做了几件事：
+
+- `MiniMaxM2Model` 使用 `make_layers`，得到 `self.layers, self.start_layer, self.end_layer`。
+- 非最后 PP rank 的 `norm` 和 `lm_head` 用 `PPMissingLayer`。
+- forward 接受 `pp_proxy_tensors`，首 rank 从 embedding 开始，非首 rank 从 proxy 读取 `hidden_states/residual`。
+- 非最后 rank 返回 `PPProxyTensors({"hidden_states": hidden_states, "residual": residual})`。
+- `load_weights` 用 `get_layer_id(name)` 跳过不属于当前 PP shard 的 layer 权重。
+
+`#17826` 是 open 的 PP + DP PR，虽然未合入，但其中 attention-TP rank/size、`is_dp_attention_enabled()`、embedding/lm head 是否使用 attention TP group 等思路，已经在后续 merged PR 中逐步进入主线。
+
+`#20067` 是 MiniMax-M2.5 分布式优化的主 PR。它的标题已经很直接：DP attention、DP reduce-scatter、FP4 all-gather、prepare_attn 中 AR fusion。当前 main 中能看到这些结果：
+
+- `MiniMaxM2Attention` 使用 `get_attention_tp_rank()` / `get_attention_tp_size()` 初始化 QKV 和 O projection，而不是默认全局 TP。
+- `VocabParallelEmbedding(..., use_attn_tp_group=is_dp_attention_enabled())` 让 DP attention 模式下 embedding 按 attention TP group 工作。
+- `MiniMaxM2DecoderLayer` 创建 `LayerCommunicator(..., allow_reduce_scatter=True)`。
+- MoE forward 接收 `should_allreduce_fusion` 和 `use_reduce_scatter`，如果下一层可以融合 allreduce 或当前可 reduce-scatter，就不在 MoE 内部立即做 `tensor_model_parallel_all_reduce`。
+- 当 `should_use_flashinfer_cutlass_moe_fp4_allgather()` 为 true 时，也跳过 MoE 内部 allreduce，让 FP4 all-gather 路径接管通信。
+- registered test 覆盖 TP8+EP8、TP8+DP8+EP8+DP-attention 等 M2.5 形态。
+
+`#18217` 让 MiniMax-M2 支持 piecewise CUDA graph。它在 `fp8_kernel.py` 中处理 Dynamo compiling 时的 config 获取，并在 MoE select experts、TBO op 和 model forward loop 里用 `nullcontext()` 替代 expert distribution recorder context，以免 PCG 捕获时引入不兼容的动态上下文。
+
+`#20489` 和 `#20975` 是仍 open 的 DP attention 修复线。patch 内容包括：
+
+- MiniMax attention 使用 attention TP size/group 做 head partition 和通信，而不是全局 TP。
+- `model_runner` 在 `require_attn_tp_gather` 时按 `dp_size` 初始化 `global_num_tokens_gpu`，避免高 rank invalid device ordinal/access。
+- memory pool 和 rotary embedding 处理空 batch，避免 0-sized tensor view 错误。
+- 后续 patch 还补了函数名从 `get_attention_tp_world_size` 到实际可用的 `get_attn_tensor_model_parallel_world_size` / `get_attn_tp_group`。
+
+当前 main 已经有不少 attention-TP 和空 hidden state 保护，但这两个 PR 说明 DP-attn 的边界仍在继续被打磨。
+
+## 6. Eagle3、M2.7 与 tool-call streaming
+
+`#12798` 给 MiniMax M2 增加 Eagle3 所需的 aux hidden states 捕获：
+
+- `MiniMaxM2Model` 增加 `layers_to_capture`。
+- forward loop 中如果当前 layer id 在 capture 列表里，就把 `hidden_states + residual` 放进 `aux_hidden_states`。
+- `MiniMaxM2ForCausalLM.set_eagle3_layers_to_capture` 设置默认捕获层 `[2, num_layers // 2, num_layers - 3]`，或使用调用方传入的 layer ids。
+- logits processor 收到 `aux_hidden_states`，供 Eagle3 使用。
+
+`#13297` 补齐 `get_embed_and_head`，返回 `self.model.embed_tokens.weight, self.lm_head.weight`，让 Eagle3 能拿到主模型 embedding 和 lm head。
+
+`#20873` 是 open 的旧文档 PR，增加 MiniMax-M2.7 和 M2.7-highspeed。虽然这个 PR 还没合入，但最新 main 的 `docs_new` 里已经有 `docs_new/cookbook/autoregressive/MiniMax/MiniMax-M2.7.mdx`，并且 cookbook 导航里也有 MiniMax-M2.7。代码层面 M2.7 仍复用 `MiniMaxM2ForCausalLM` 系列模型类，因此 skill 名称最好不要再锁死到 M2.5。
+
+`#23301` 是 tool-call streaming 的新 open PR。它重写 `MinimaxM2Detector.parse_streaming_increment`，使 string 类型参数可以 token-by-token streaming：
+
+- 增加 `_STREAM_HOLD_BACK = len("</parameter>") - 1`，避免把 end tag 的半截误当作参数内容发出去。
+- 增加 `_in_parameter`、`_current_param_name`、`_param_raw_sent_len`、`_current_param_is_string`、`_first_param_started` 等 fine-grained 状态。
+- string 参数在看到 `<parameter name="...">` 后先发 JSON key prefix，再逐步 JSON escape 并追加 value content。
+- int/bool/object/array 等非 string 参数仍然 buffer 到 `</parameter>` 后一次性转换。
+- 结束 `</invoke>` 时补齐 JSON object 的 `}`。
+
+这个 PR 的价值不是模型吞吐，而是 agent/tool-use 体验：长 string 参数不必等完整 `</parameter>` 出现才开始返回。
+
+## 7. 量化、NPU、TF32、EPLB 等开放优化方向
+
+`#19652` 是通用但对 MiniMax M2.5 很重要的 NVFP4 Marlin fallback。它新增 `marlin_utils_fp4.py`，允许非 Blackwell GPU 从 SM75 起使用 Marlin FP4 fallback：
+
+- 检测是否 Blackwell；非 Blackwell 但支持 Marlin FP4 时启用 fallback。
+- 处理 NVFP4 scale：把 FP8-S1E4M3 scale 转成 Marlin dequant 更合适的 FP8-S0E5M3 格式。
+- 对 linear 和 MoE 权重做 Marlin tile layout repack。
+- MoE fallback 会构造 `MarlinMoeQuantInfo`，让 fused Marlin MoE 用 FP4 scalar type 和 global scale。
+- 新增 `test_nvfp4_marlin_fallback.py` 覆盖 linear 和 MoE。
+
+`#22300` 是 FP8 GEMM scale 的开放修复。问题是加载时如果把 weight scale 转成 DeepGEMM 所需的 UE8M0/R128c4 packed format，但 runtime 因 fp16 output dtype、K shape 或 backend 条件不满足而 fallback 到 Triton，Triton 仍期待普通 fp32 scale，会导致错误结果或性能问题。PR 让 `should_deepgemm_weight_requant_ue8m0` 同时检查 output dtype 和 weight shape，并在 FlashInfer/TRTLLM fallback 中检测 `weight_scale.format_ue8m0`。
+
+`#20905` 是 NPU ModelSlim 方向。MiniMax2.5 checkpoint 的 MoE quant 描述可能使用 `.0.w2.weight` 这样的 suffix，而不是普通 `.0.gate_proj.weight`。PR 调整 ModelSlim MoE scheme 探测，让 `W4A4_DYNAMIC`、`W4A8_DYNAMIC`、`W8A8_DYNAMIC` 能从 MiniMax 的 w2 suffix 识别出来。
+
+`#22432` 和 `#23190` 是 NPU fused attention prepare 方向。它们引入 `sgl_kernel_npu.norm.split_qkv_tp_rmsnorm_rope.split_qkv_tp_rmsnorm_rope`，在 NPU 上把 qkv projection 之后的 split、TP RMSNorm 和 RoPE 合并到 `forward_prepare_npu`。`#23190` 还补了 empty hidden states 短路，以及 DP-attn 下 Eagle3 hidden states capture 的修复。
+
+`#22744` 是 NVIDIA TF32 gate GEMM 优化。它增加 `--enable-tf32-matmul`，model runner 里调用 `torch.set_float32_matmul_precision("high")`。PR 描述显示 MiniMax gate GEMM 的 FP32 开销占比可从 9.1% 降到 3.3%，batch64 吞吐从 3076.99 提到 3302.03 tok/s。
+
+`#22934` 是 MiniMax EPLB bugfix，仍 open。它给 `MiniMaxM2MoE` 增加 `get_moe_weights`，用 `filter_moe_weight_param_global_expert` 过滤本地/冗余 expert 权重；`MiniMaxM2ForCausalLM` 增加 `_routed_experts_weights_of_layer = LazyValue(...)` 和 `routed_experts_weights_of_layer` property。当前 main 的 Kimi K2.5 已有类似 EPLB wrapper 接口，而 MiniMax 这条还没进主线。
+
+## 8. 当前 main 的代码形态与 skill 命名建议
+
+截至 `47c4b3825`，MiniMax 主线形态可以概括为：
+
+- `MiniMaxM2ForCausalLM` 是 M2/M2.1/M2.5/M2.7 系列共用的模型类。
+- `MiniMaxM2MoE` 使用 sigmoid top-k、`TopKOutput`、normal/DeepEP 分支、reduce-scatter 和 FP4 all-gather 相关通信控制。
+- `MiniMaxM2Attention` 使用 attention TP rank/size，支持 DP attention 的 head partition；Q/K RMSNorm 走 `MiniMaxM2QKRMSNorm`，可通过 `SGLANG_USE_FUSED_PARALLEL_QKNORM` 启用 JIT fused TP QKNorm allreduce。
+- `MiniMaxM2DecoderLayer` 通过 `LayerCommunicator` 支持 prepare_attn AR fusion、prepare_mlp、reduce-scatter 和 postprocess。
+- loader 已支持 packed mapping、KV scale remap、PP shard skip；AWQ `w13` merged expert loader 仍 open。
+- 文档层已经出现 M2.7；代码层仍复用同一个 M2 系列实现。
+
+因此建议把 skill 从 `sglang-minimax-m2-m25-optimization` 改成 `sglang-minimax-m2-series-optimization`。如果希望名字里显式表达最新模型，也可以叫 `sglang-minimax-m2-m27-optimization`，但 “series” 更稳，因为 M2.7、M2.7-highspeed 和后续高性能/平台优化都会继续复用同一模型族实现。

--- a/model-pr-optimization-history/minimax/README.zh.md
+++ b/model-pr-optimization-history/minimax/README.zh.md
@@ -2,7 +2,7 @@
 
 本文基于 SGLang `origin/main` 最新快照 `47c4b3825`，以及 MiniMax 相关 merged、open PR patch 阅读结果整理。范围覆盖原有 `sglang-minimax-m2-m25-optimization` skill 涉及的主线，并补充 MiniMax M2.7、TP QK RMSNorm allreduce fusion、DP attention、FP4/NVFP4、NPU、DeepEP、EPLB 和 tool-call streaming 的最新状态。
 
-阅读结论先放前面：截至 `47c4b3825`，MiniMax M2 系列主线模型文件是 `python/sglang/srt/models/minimax_m2.py`，它已经支持 M2/M2.1/M2.5 的基础加载、tool calling、reasoning parser、Eagle3 aux hidden states、PP、DP attention 相关 attention-TP 分组、M2.5 reduce-scatter/FP4 all-gather/AR fusion，以及你提到的 TP QK RMSNorm allreduce fusion。M2.7 当前主要体现为文档和同一模型类复用，建议 skill 名称从 `sglang-minimax-m2-m25-optimization` 改成更准确的 `sglang-minimax-m2-series-optimization` 或 `sglang-minimax-m2-m27-optimization`。
+阅读结论先放前面：截至 `47c4b3825`，MiniMax M2 系列主线模型文件是 `python/sglang/srt/models/minimax_m2.py`，它已经支持 M2/M2.1/M2.5 的基础加载、tool calling、reasoning parser、Eagle3 aux hidden states、PP、DP attention 相关 attention-TP 分组、M2.5 reduce-scatter/FP4 all-gather/AR fusion，以及你提到的 TP QK RMSNorm allreduce fusion。M2.7 当前主要体现为文档和同一模型类复用。
 
 ## 1. 时间线总览
 
@@ -195,7 +195,7 @@ MiniMax 侧新增 `MiniMaxM2QKRMSNorm`：
 
 `#13297` 补齐 `get_embed_and_head`，返回 `self.model.embed_tokens.weight, self.lm_head.weight`，让 Eagle3 能拿到主模型 embedding 和 lm head。
 
-`#20873` 是 open 的旧文档 PR，增加 MiniMax-M2.7 和 M2.7-highspeed。虽然这个 PR 还没合入，但最新 main 的 `docs_new` 里已经有 `docs_new/cookbook/autoregressive/MiniMax/MiniMax-M2.7.mdx`，并且 cookbook 导航里也有 MiniMax-M2.7。代码层面 M2.7 仍复用 `MiniMaxM2ForCausalLM` 系列模型类，因此 skill 名称最好不要再锁死到 M2.5。
+`#20873` 是 open 的旧文档 PR，增加 MiniMax-M2.7 和 M2.7-highspeed。虽然这个 PR 还没合入，但最新 main 的 `docs_new` 里已经有 `docs_new/cookbook/autoregressive/MiniMax/MiniMax-M2.7.mdx`，并且 cookbook 导航里也有 MiniMax-M2.7。代码层面 M2.7 仍复用 `MiniMaxM2ForCausalLM` 系列模型类。
 
 `#23301` 是 tool-call streaming 的新 open PR。它重写 `MinimaxM2Detector.parse_streaming_increment`，使 string 类型参数可以 token-by-token streaming：
 
@@ -227,7 +227,7 @@ MiniMax 侧新增 `MiniMaxM2QKRMSNorm`：
 
 `#22934` 是 MiniMax EPLB bugfix，仍 open。它给 `MiniMaxM2MoE` 增加 `get_moe_weights`，用 `filter_moe_weight_param_global_expert` 过滤本地/冗余 expert 权重；`MiniMaxM2ForCausalLM` 增加 `_routed_experts_weights_of_layer = LazyValue(...)` 和 `routed_experts_weights_of_layer` property。当前 main 的 Kimi K2.5 已有类似 EPLB wrapper 接口，而 MiniMax 这条还没进主线。
 
-## 8. 当前 main 的代码形态与 skill 命名建议
+## 8. 当前 main 的代码形态
 
 截至 `47c4b3825`，MiniMax 主线形态可以概括为：
 
@@ -237,5 +237,3 @@ MiniMax 侧新增 `MiniMaxM2QKRMSNorm`：
 - `MiniMaxM2DecoderLayer` 通过 `LayerCommunicator` 支持 prepare_attn AR fusion、prepare_mlp、reduce-scatter 和 postprocess。
 - loader 已支持 packed mapping、KV scale remap、PP shard skip；AWQ `w13` merged expert loader 仍 open。
 - 文档层已经出现 M2.7；代码层仍复用同一个 M2 系列实现。
-
-因此建议把 skill 从 `sglang-minimax-m2-m25-optimization` 改成 `sglang-minimax-m2-series-optimization`。如果希望名字里显式表达最新模型，也可以叫 `sglang-minimax-m2-m27-optimization`，但 “series” 更稳，因为 M2.7、M2.7-highspeed 和后续高性能/平台优化都会继续复用同一模型族实现。


### PR DESCRIPTION
## Summary

- Add a new `model-pr-optimization-history/` directory next to `skills/`.
- Document the Kimi K2 / K2 Thinking / K2.5 support and optimization timeline in matching Chinese and English Markdown files.
- Document the MiniMax M2 / M2.5 / M2.7 support and optimization timeline in matching Chinese and English Markdown files.

## Details

The documents summarize the relevant SGLang PRs in chronological order, including merged, open, and closed work where it affects the current model-support story. They cover code-level changes across routing, MoE kernels, Marlin/JIT paths, PP/DP/PCG/Eagle/EPLB support, quantization, platform-specific optimizations, and current open tracks.

## Validation

- Ran `npx --yes prettier@3.6.2 --write "model-pr-optimization-history/**/*.md"`.
- Ran `npx --yes prettier@3.6.2 --check "model-pr-optimization-history/**/*.md"`.
- Ran `git diff --check -- model-pr-optimization-history`.
- Verified Kimi zh/en each reference 41 PRs and MiniMax zh/en each reference 29 PRs.
