### PR TITLE
[codex] add DeepSeek optimization skills

### DIFF
--- a/model-pr-optimization-history/deepseek-v3-r1/README.en.md
+++ b/model-pr-optimization-history/deepseek-v3-r1/README.en.md
@@ -1,0 +1,249 @@
+# SGLang DeepSeek V3 / R1 Support and Optimization Timeline
+
+This document is based on SGLang `origin/main` snapshot `929e00eea`, sgl-cookbook `origin/main` snapshot `8ec4d03`, and patch-level reading of DeepSeek V3/R1 merged, open, and reverted PRs. The scope only covers DeepSeek V3, V3-0324, R1, R1-0528, and their quantization, MTP, DeepEP, LoRA, and backend optimization tracks. DeepSeek V3.1 parser/template differences and DeepSeek V3.2 DSA/NSA sparse attention are documented separately.
+
+Conclusion: as of `929e00eea`, the main DeepSeek V3/R1 runtime entry is still `DeepseekV3ForCausalLM` in `python/sglang/srt/models/deepseek_v2.py`, and the MTP draft-model entry is `DeepseekV3ForCausalLMNextN` in `python/sglang/srt/models/deepseek_nextn.py`. Main now has a full surface for MLA backend selection, FP8/FP4/W4AFP8/MXFP4/MXFP8/NVFP4 loading, shared-expert fusion, MTP, R1 W4A8 DeepEP, DP attention, LoRA, and multi-hardware validation. Additional runtime items include adaptive EAGLE, PCG plus speculative decoding, thinking-token radix-cache stripping, and spec-v2 adaptive speculative decoding. The main open items are JIT router GEMM, quantized DeepSeek MLA `.weight` access, ROCm MLA restoration, LoRA adapter bypass, CuteDSL EP plus DP-attention double reduce, MUSA, DCP, and spec-v2 adaptive speculative decoding.
+
+## 1. Timeline Overview
+
+| Created | PR | State | Track | Code Area | Effect |
+| --- | ---: | --- | --- | --- | --- |
+| 2024-12-26 | [#2601](https://github.com/sgl-project/sglang/pull/2601) | merged | AMD bring-up | Triton decode attention, fused MoE, `deepseek_v2.py` | Made DeepSeek V3 runnable on AMD paths. |
+| 2024-12-30 | [#2667](https://github.com/sgl-project/sglang/pull/2667) | merged | AMD FP8 | `deepseek_v2.py` | Fixed DeepSeek V3 FP8 accuracy on AMD. |
+| 2025-02-05 | [#3314](https://github.com/sgl-project/sglang/pull/3314) | merged | docs | DeepSeek docs | Added DeepSeek usage and multi-node launch docs. |
+| 2025-02-12 | [#3522](https://github.com/sgl-project/sglang/pull/3522) | merged | docs | DeepSeek V3 launch docs | Refined DeepSeek V3 launch parameters in docs. |
+| 2025-02-14 | [#3582](https://github.com/sgl-project/sglang/pull/3582) | merged | MTP | `deepseek_nextn.py`, speculative decoding | Added NextN/EAGLE speculative decoding for DeepSeek V3/R1. |
+| 2025-02-26 | [#3893](https://github.com/sgl-project/sglang/pull/3893) | merged | FP8 GEMM | benchmarks, DeepGEMM | Added DeepGEMM and SGLang FP8 block-wise GEMM benchmarks. |
+| 2025-03-05 | [#4079](https://github.com/sgl-project/sglang/pull/4079) | merged | INT8 docs | DeepSeek docs | Added an INT8 launch example. |
+| 2025-03-07 | [#4165](https://github.com/sgl-project/sglang/pull/4165) | merged | DeepGEMM | `sgl-kernel` | Integrated DeepGEMM into `sgl-kernel`. |
+| 2025-03-08 | [#4199](https://github.com/sgl-project/sglang/pull/4199) | merged | DeepGEMM | Linear layers | Made Linear layers support DeepGEMM. |
+| 2025-03-09 | [#4218](https://github.com/sgl-project/sglang/pull/4218) | merged | MTP/MLA | FlashInfer MLA | Added NextN support for the FlashInfer MLA backend. |
+| 2025-03-16 | [#4472](https://github.com/sgl-project/sglang/pull/4472) | merged | FlashMLA | attention backend | Added the initial FlashMLA backend. |
+| 2025-03-17 | [#4514](https://github.com/sgl-project/sglang/pull/4514) | merged | FlashMLA graph | `flashmla_backend.py`, server args | Added CUDA graph support for the FlashMLA backend. |
+| 2025-03-18 | [#4530](https://github.com/sgl-project/sglang/pull/4530) | merged | fused MoE | `moe_fused_gate.cu`, tests, benchmarks | Added the DeepSeek-style fused group gate selection kernel. |
+| 2025-03-20 | [#4613](https://github.com/sgl-project/sglang/pull/4613) | merged | DeepGEMM default | server defaults | Enabled DeepGEMM by default on Hopper. |
+| 2025-03-20 | [#4631](https://github.com/sgl-project/sglang/pull/4631) | merged | ROCm MTP | NextN | Enabled MTP/NextN on AMD GPUs. |
+| 2025-03-27 | [#4831](https://github.com/sgl-project/sglang/pull/4831) | merged | FA3 MLA | attention backend | Added FA3 backend support for MLA. |
+| 2025-04-05 | [#5086](https://github.com/sgl-project/sglang/pull/5086) | merged | MoE align | `moe_align_kernel.cu`, fused MoE | Reduced `moe_align_block_size_kernel` small-batch overhead. |
+| 2025-04-07 | [#5113](https://github.com/sgl-project/sglang/pull/5113) | merged | MHA chunked prefill | `flashattention_backend.py`, scheduler, `deepseek_v2.py` | Added `MHA_CHUNKED_KV` for DeepSeek chunked prefill. |
+| 2025-04-09 | [#5210](https://github.com/sgl-project/sglang/pull/5210) | merged | FA3 default | server defaults | Used FA3 MLA by default on Hopper. |
+| 2025-04-11 | [#5263](https://github.com/sgl-project/sglang/pull/5263) | merged | DeepGEMM guard | defaults | Temporarily turned off DeepGEMM by default. |
+| 2025-04-12 | [#5310](https://github.com/sgl-project/sglang/pull/5310) | merged | DeepGEMM guard | defaults | Limited DeepGEMM usage to Hopper. |
+| 2025-04-14 | [#5371](https://github.com/sgl-project/sglang/pull/5371) | merged | fused MoE | `deepseek_v2.py`, MoE gate | Applied the fused MoE gate in DeepSeek V3/R1. |
+| 2025-04-14 | [#5381](https://github.com/sgl-project/sglang/pull/5381) | merged | MLA kernel | `merge_attn_states.cu` | Added the faster `merge_state_v2` CUDA merge-attention-state kernel. |
+| 2025-04-14 | [#5385](https://github.com/sgl-project/sglang/pull/5385) | merged | RoPE | `rotary_embedding.py` | Applied DeepSeek CUDA RoPE. |
+| 2025-04-14 | [#5390](https://github.com/sgl-project/sglang/pull/5390) | merged | Cutlass MLA | `cutlass_mla_backend.py`, sgl-kernel attention | Added the Cutlass MLA attention backend. |
+| 2025-04-15 | [#5432](https://github.com/sgl-project/sglang/pull/5432) | merged | DeepGEMM BMM | `fp8_kernel.py`, `deepseek_v2.py` | Introduced DeepGEMM `group_gemm_masked` as an MLA BMM exploration path. |
+| 2025-04-16 | [#5473](https://github.com/sgl-project/sglang/pull/5473) | merged | FP8 quant | `fp8_kernel.py`, `fp8_utils.py` | Replaced the Triton kernel with `sglang_per_token_group_quant_fp8` from `sgl-kernel`. |
+| 2025-04-19 | [#5549](https://github.com/sgl-project/sglang/pull/5549) | merged | MLA FP8 quant | `fp8_kernel.py`, `deepseek_v2.py` | Reused a zero-scalar allocator and removed one `per_tensor_quant_mla_fp8` kernel. |
+| 2025-04-20 | [#5571](https://github.com/sgl-project/sglang/pull/5571) | merged | shared experts | SM90 shared experts | Enabled DeepSeek V3 shared-expert fusion on SM90. |
+| 2025-04-20 | [#5578](https://github.com/sgl-project/sglang/pull/5578) | merged | MLA copy | `deepseek_v2.py`, RoPE | Removed an extra copy in DeepSeek `forward_absorb`. |
+| 2025-04-22 | [#5619](https://github.com/sgl-project/sglang/pull/5619) | merged | MLA projection | `deepseek_v2.py`, loader | Fused `q_a_proj` and `kv_a_proj_with_mqa`. |
+| 2025-04-22 | [#5628](https://github.com/sgl-project/sglang/pull/5628) | merged | DeepGEMM default | defaults, docs | Turned DeepGEMM back on by default and updated docs. |
+| 2025-04-24 | [#5707](https://github.com/sgl-project/sglang/pull/5707) | merged | MTP/fusion | R1 MTP, shared experts | Fixed the R1 combination of MTP and shared-expert fusion. |
+| 2025-04-24 | [#5716](https://github.com/sgl-project/sglang/pull/5716) | merged | MoE tuning | Triton fused-MoE config | Updated H20 DeepSeek/R1 FP8 W8A8 fused-MoE Triton configs. |
+| 2025-04-25 | [#5740](https://github.com/sgl-project/sglang/pull/5740) | merged | MoE tuning | H200 Triton fused-MoE config | Updated H200 Triton 3.2 fused-MoE configs and warning behavior. |
+| 2025-04-25 | [#5748](https://github.com/sgl-project/sglang/pull/5748) | merged | MLA KV cache | `flashattention_backend.py`, `memory_pool.py`, `deepseek_v2.py` | Fused MLA set-KV-cache and removed K concat overhead. |
+| 2025-04-27 | [#5793](https://github.com/sgl-project/sglang/pull/5793) | merged | MTP ergonomics | server/spec args | Auto-set the MTP draft model path. |
+| 2025-05-01 | [#5952](https://github.com/sgl-project/sglang/pull/5952) | merged | MTP API | CI, docs | Updated tests and docs for the MTP API change. |
+| 2025-05-02 | [#5977](https://github.com/sgl-project/sglang/pull/5977) | merged | MLA streams | `deepseek_v2.py` | Overlapped q/k norm with two streams. |
+| 2025-05-05 | [#6034](https://github.com/sgl-project/sglang/pull/6034) | merged | docs | MLA backend docs | Updated MLA attention backend documentation. |
+| 2025-05-07 | [#6081](https://github.com/sgl-project/sglang/pull/6081) | merged | MTP/DP attention | MTP, DP attention | Added MTP support with DP attention. |
+| 2025-05-08 | [#6109](https://github.com/sgl-project/sglang/pull/6109) | merged | FlashMLA/MTP | FlashMLA, FP8 KV | Added FlashMLA backend support with MTP and FP8 KV cache. |
+| 2025-05-09 | [#6151](https://github.com/sgl-project/sglang/pull/6151) | closed | hybrid attention | model_runner, cuda graph, server args | Explored a hybrid attention backend; it did not become the V3/R1 main path. |
+| 2025-05-12 | [#6220](https://github.com/sgl-project/sglang/pull/6220) | merged | fused MoE | top-k reduce, quant methods | Fused routed scaling factor into the top-k reduce kernel. |
+| 2025-06-05 | [#6890](https://github.com/sgl-project/sglang/pull/6890) | merged | DeepGEMM/MLA | `fused_qkv_a_proj_with_mqa` | Replaced the Triton path with DeepGEMM for this fused projection. |
+| 2025-06-08 | [#6970](https://github.com/sgl-project/sglang/pull/6970) | merged | routed scaling | DeepSeek MoE | Fused the routed scaling factor in DeepSeek. |
+| 2025-06-13 | [#7146](https://github.com/sgl-project/sglang/pull/7146) | merged | DeepGEMM format | per-token-group quant | Supported the new DeepGEMM format in per-token-group quantization. |
+| 2025-06-13 | [#7150](https://github.com/sgl-project/sglang/pull/7150) | merged | DeepGEMM refactor | DeepGEMM integration | Refactored DeepGEMM integration. |
+| 2025-06-13 | [#7155](https://github.com/sgl-project/sglang/pull/7155) | merged | DeepGEMM format | SRT quant | Added SRT-side support for the new DeepGEMM quant format. |
+| 2025-06-13 | [#7156](https://github.com/sgl-project/sglang/pull/7156) | merged | DeepGEMM format | DeepSeek weights | Re-quantized DeepSeek weights for the new DeepGEMM input format. |
+| 2025-06-14 | [#7172](https://github.com/sgl-project/sglang/pull/7172) | merged | DeepGEMM | new DeepGEMM path | Completed support for the new DeepGEMM path. |
+| 2025-06-20 | [#7376](https://github.com/sgl-project/sglang/pull/7376) | merged | MTP/FP4 | `deepseek_nextn.py`, speculative decoding | Fixed MTP with DeepSeek R1 FP4. |
+| 2025-07-04 | [#7762](https://github.com/sgl-project/sglang/pull/7762) | merged | R1 W4AFP8 | `w4afp8.py`, `cutlass_w4a8_moe.py`, EP MoE | Added R1 W4AFP8 config, Cutlass W4A8 MoE, and EP-MoE paths. |
+| 2025-07-17 | [#8118](https://github.com/sgl-project/sglang/pull/8118) | merged | R1 W4AFP8 TP | Cutlass grouped W4A8 MoE | Added TP mode for R1-W4AFP8. |
+| 2025-07-22 | [#8247](https://github.com/sgl-project/sglang/pull/8247) | merged | R1 W4A8 DeepEP | `token_dispatcher/deepep.py`, W4A8 MoE | Added normal DeepEP for R1 W4A8/W4AFP8. |
+| 2025-07-28 | [#8464](https://github.com/sgl-project/sglang/pull/8464) | merged | R1 W4A8 DeepEP LL | DeepEP low latency | Added low-latency DeepEP for R1 W4A8. |
+| 2025-09-04 | [#10027](https://github.com/sgl-project/sglang/pull/10027) | merged | W4AFP8 perf | glue kernels | Optimized R1 W4AFP8 glue kernels. |
+| 2025-09-12 | [#10361](https://github.com/sgl-project/sglang/pull/10361) | merged | DP/compile | DP plus torch compile | Fixed GPU fault with DeepSeek V3 DP plus torch-compile. |
+| 2025-10-12 | [#11512](https://github.com/sgl-project/sglang/pull/11512) | merged | FP4 default | server defaults | Updated R1-FP4 default config on Blackwell. |
+| 2025-10-16 | [#11708](https://github.com/sgl-project/sglang/pull/11708) | merged | FP4/SM120 | backend defaults | Enabled FP4 DeepSeek on SM120. |
+| 2025-10-23 | [#12000](https://github.com/sgl-project/sglang/pull/12000) | merged | deterministic | DeepSeek attention | Added deterministic inference for single-GPU DeepSeek-architecture models. |
+| 2025-10-24 | [#12057](https://github.com/sgl-project/sglang/pull/12057) | merged | docs | W4FP8 docs | Added a W4FP8 usage example. |
+| 2025-11-06 | [#12778](https://github.com/sgl-project/sglang/pull/12778) | merged | Blackwell default | `server_args.py` | Updated DeepSeek V3 auto quantization on SM100. |
+| 2025-11-09 | [#12921](https://github.com/sgl-project/sglang/pull/12921) | merged | W4AFP8 perf | W4A8 kernels | Optimized W4AFP8 kernels for DeepSeek-V3-0324. |
+| 2025-11-19 | [#13548](https://github.com/sgl-project/sglang/pull/13548) | merged | MTP/B200 | NextN, speculative decoding | Fixed DeepSeek V3 MTP on B200. |
+| 2025-11-30 | [#14162](https://github.com/sgl-project/sglang/pull/14162) | merged | DeepEP LL | R1 W4A8 DeepEP | Made R1 W4A8 DeepEP low-latency dispatch use FP8 communication. |
+| 2025-12-11 | [#14897](https://github.com/sgl-project/sglang/pull/14897) | merged | DP accuracy | BF16 KV | Fixed DeepSeek V3 DP accuracy with BF16 KV. |
+| 2025-12-17 | [#15304](https://github.com/sgl-project/sglang/pull/15304) | merged | MXFP4 | AMD EP | Fixed MXFP4 DeepSeek V3 with EP accuracy. |
+| 2025-12-18 | [#15347](https://github.com/sgl-project/sglang/pull/15347) | merged | router/top-k | `topk.py` | Replaced the generic `moe_fused_gate` hot path with `fused_topk_deepseek`. |
+| 2025-12-20 | [#15531](https://github.com/sgl-project/sglang/pull/15531) | merged | PCG/FP4 | CUDA graph | Added piecewise CUDA graph support for DeepSeek V3 FP4. |
+| 2026-01-07 | [#16649](https://github.com/sgl-project/sglang/pull/16649) | merged | loader refactor | `deepseek_common/deepseek_weight_loader.py` | Split DeepSeek V2/V3 weight loading into a mixin. |
+| 2026-01-15 | [#17133](https://github.com/sgl-project/sglang/pull/17133) | merged | MoE tuning | fused MoE configs | Added H20/H20-3E MoE configs for DeepSeek-family shapes. |
+| 2026-01-16 | [#17178](https://github.com/sgl-project/sglang/pull/17178) | merged | eval/parser | eval choices | Removed `deepseek-r1` from thinking-mode choices because R1 parser behavior differs from V3-style thinking. |
+| 2026-01-25 | [#17707](https://github.com/sgl-project/sglang/pull/17707) | merged | router bench | `dsv3_router_gemm` | Added a Blackwell router GEMM benchmark. |
+| 2026-01-26 | [#17744](https://github.com/sgl-project/sglang/pull/17744) | merged | loader memory | weight loader | Deferred `dict(weights)` materialization to avoid large-checkpoint OOM. |
+| 2026-02-03 | [#18242](https://github.com/sgl-project/sglang/pull/18242) | merged | ROCm perf | MI300X | Optimized DeepSeek R1 on MI300X. |
+| 2026-02-08 | [#18451](https://github.com/sgl-project/sglang/pull/18451) | merged | AMD router | AITER router GEMM | Uses `aiter_dsv3_router_gemm` when the expert count is at most 256. |
+| 2026-02-09 | [#18461](https://github.com/sgl-project/sglang/pull/18461) | merged | XPU | Intel GPU | Enabled R1 inference on Intel GPU. |
+| 2026-02-11 | [#18607](https://github.com/sgl-project/sglang/pull/18607) | merged | AMD MTP | TP4 MTP | Fixed DeepSeek V3 MTP accuracy on AMD TP4. |
+| 2026-02-22 | [#19122](https://github.com/sgl-project/sglang/pull/19122) | merged | MLA refactor | `deepseek_common/attention_forward_methods/` | Moved DeepSeek MLA forward code into shared forward-method modules. |
+| 2026-02-26 | [#19425](https://github.com/sgl-project/sglang/pull/19425) | merged | R1 MXFP4 | NextN loading | Fixed R1-0528-MXFP4 weight-loading shape mismatch. |
+| 2026-03-04 | [#19834](https://github.com/sgl-project/sglang/pull/19834) | merged | AMD CI | MI35x lanes | Added DeepSeek KV FP8 and all-reduce fusion tests on MI35x. |
+| 2026-03-04 | [#19843](https://github.com/sgl-project/sglang/pull/19843) | merged | AMD perf | AITER FP8 top-k | Kept correction bias in BF16 for AITER FP8 routing to avoid runtime dtype conversion. |
+| 2026-03-18 | [#20841](https://github.com/sgl-project/sglang/pull/20841) | merged | DP bugfix | DeepSeek R1 DP | Fixed a GPU fault when DeepSeek R1 runs with DP. |
+| 2026-03-24 | [#21280](https://github.com/sgl-project/sglang/pull/21280) | merged | MXFP8 | routed MoE | Added MXFP8 DeepSeek V3 routed-MoE support. |
+| 2026-03-28 | [#21599](https://github.com/sgl-project/sglang/pull/21599) | merged | MTP/spec | server args, EAGLE runtime, spec workers | Added adaptive `speculative_num_steps` for EAGLE top-k=1. |
+| 2026-03-31 | [#21719](https://github.com/sgl-project/sglang/pull/21719) | merged | revert | DeepEP LL | Reverted `#14162`. |
+| 2026-04-05 | [#22128](https://github.com/sgl-project/sglang/pull/22128) | merged | PCG/spec | `model_runner.py`, PCG runner, server args | Allowed piecewise CUDA graph to run with speculative decoding. |
+| 2026-04-08 | [#22316](https://github.com/sgl-project/sglang/pull/22316) | merged | reland | DeepEP LL | Relanded R1 W4A8 DeepEP low-latency FP8 communication. |
+| 2026-04-08 | [#22323](https://github.com/sgl-project/sglang/pull/22323) | merged | LoRA | quant info, MLA LoRA | Refactored LoRA quant info and added DeepSeek V3 MLA LoRA support. |
+| 2026-04-16 | [#22933](https://github.com/sgl-project/sglang/pull/22933) | merged | CPU shared expert | CPU MoE | Expanded the CPU shared-expert interface without scaling factor; this is CPU parity, not H200 throughput. |
+| 2026-04-16 | [#22950](https://github.com/sgl-project/sglang/pull/22950) | closed | reasoning cache | model config, scheduler, radix cache, reasoning parser | Explored parser-gated two-phase reasoning radix-cache stripping; it did not become current main. |
+| 2026-04-20 | [#23195](https://github.com/sgl-project/sglang/pull/23195) | open | quant bugfix | `DeepseekV2AttentionMLA` | Guards `.weight` access for AWQ/compressed-tensors layers. |
+| 2026-04-20 | [#23257](https://github.com/sgl-project/sglang/pull/23257) | open | MoE/DP | CuteDSL EP plus DP attention | Fixes double reduce in `DeepseekV2MoE` with CuteDSL EP plus DP attention. |
+| 2026-04-21 | [#23315](https://github.com/sgl-project/sglang/pull/23315) | merged | reasoning cache | `schedule_batch.py`, `mem_cache/common.py`, `server_args.py` | Added opt-in thinking-token stripping from radix cache. |
+| 2026-04-21 | [#23336](https://github.com/sgl-project/sglang/pull/23336) | open | spec v2 | scheduler output processor, EAGLE v2 workers | Extends adaptive speculative decoding to spec v2. |
+
+## 2. Single-Node H200 Optimization Coverage
+
+The single-node H200 optimization notes explicitly name `#4514`, `#4530`, `#5086`, `#5113`, `#5381`, `#5385`, `#5390`, `#5432`, `#5473`, `#5549`, `#5578`, `#5619`, `#5716`, `#5740`, `#5748`, `#5977`, `#6034`, `#6151`, and `#6220`. These PRs are included in the timeline and are marked according to their current-main status: default path, optional backend, exploratory path, or closed direction.
+
+These PRs fall into four main tracks.
+
+The first track is FP8 Block GEMM / DeepGEMM. `#3893` put DeepGEMM and SGLang FP8 block-wise GEMM on the same benchmark surface; `#4165` integrated DeepGEMM into `sgl-kernel`; and `#4199` made Linear layers support DeepGEMM. The sequence `#4613`, `#5263`, `#5310`, and `#5628` shows that the default was iterated carefully: enable on Hopper, temporarily disable when needed, restrict to the safe architecture set, then re-enable with documentation. `#5432`'s DeepGEMM `group_gemm_masked` BMM and MLA FP8 quant kernel is an exploratory path and should not be described as the current H200 default. `#5473` moved per-token-group FP8 quantization from Triton to `sgl-kernel`, while `#5549` reused a zero-scalar allocator and removed one kernel from `per_tensor_quant_mla_fp8`. Later, `#6890` and `#7146`, `#7150`, `#7155`, `#7156`, `#7172` moved the fused projection and DeepSeek weight quantization to the new DeepGEMM input format.
+
+The second track is Fused MoE. `#4530` added `moe_fused_gate.cu`, bindings, benchmarks, and tests for DeepSeek biased grouped top-k / group gate selection; `#5086` reduced `moe_align_block_size_kernel` small-batch overhead; `#5371` connected the fused MoE gate to DeepSeek V3/R1; `#5571` enabled shared-expert fusion on SM90; `#5716` and `#5740` added H20/H200 fused-MoE Triton configs; `#6220` fused routed scaling factor into the top-k reduce kernel, and `#6970` later fused the same scaling directly in the DeepSeek path. When reading current main, check `topk.py`, `fused_moe_triton/fused_moe.py`, `sgl-kernel/csrc/moe/moe_fused_gate.cu`, `moe_align_kernel.cu`, and `sgl_kernel_ops.h` together.
+
+The third track is MLA / attention backend work. FlashMLA starts with `#4472`, gains CUDA graph support in `#4514`, and later gets MTP plus FP8 KV cache support in `#6109`. FA3 MLA starts with `#4831`, and `#5210` makes FA3 MLA the Hopper default. Cutlass MLA is `#5390`, while `#6034` documents the boundaries between FA3, FlashMLA, Cutlass MLA, and other backends. On the model-file hot path, `#5113` adds `MHA_CHUNKED_KV`, `#5381` adds the `merge_state_v2` CUDA kernel, `#5385` applies DeepSeek CUDA RoPE, `#5578` removes a `forward_absorb` copy, `#5619` fuses `q_a_proj` and `kv_a_proj_with_mqa`, `#5748` fuses MLA set-KV-cache, and `#5977` overlaps q/k norm with two streams.
+
+The fourth track is MTP and backend interaction. `#3582` is the V3/R1 NextN/EAGLE starting point, `#4218` supports FlashInfer MLA plus NextN, `#5707` fixes R1 MTP plus shared-expert fusion, `#5793` auto-sets the draft model path, `#5952` updates tests and docs for the MTP API, `#6081` supports MTP plus DP attention, and `#6109` connects FlashMLA, MTP, and FP8 KV cache. `#6151` is a closed hybrid-attention backend exploration, so it should be recorded as history but not counted as current mainline support.
+
+## 2.1 Update: MTP/PCG and Thinking Radix Cache
+
+After refreshing SGLang and sgl-cookbook, SGLang main is still `929e00eea`, but sgl-cookbook moved to `8ec4d03`; there are no DeepSeek cookbook doc or model-entry changes from the previous cookbook snapshot to `8ec4d03`. The real additions in this pass are therefore SGLang runtime PRs.
+
+`#21599` makes EAGLE top-k=1 `speculative_num_steps` adaptive, touching `server_args.py`, speculative runtime state/params, EAGLE workers, and runner code. It affects V3/R1 MTP performance tuning because the draft-step count should no longer be assumed static. `#22128` allows piecewise CUDA graph to coexist with speculative decoding through `model_runner.py`, `piecewise_cuda_graph_runner.py`, and the server-flag gate; PCG plus MTP should no longer be written off as categorically unsupported.
+
+`#22950` is the closed early design for reasoning radix-cache stripping, spanning model config, scheduler, radix cache, and `reasoning_parser.py`; current main should be read from merged `#23315`. `#23315` adds an opt-in server argument and changes `schedule_batch.py` / `mem_cache/common.py` so thinking tokens can be stripped from radix-cache entries, preventing `<think>` / `</think>`-style reasoning tokens from becoming reusable prefix material. Open `#23336` carries adaptive spec into spec v2 via `scheduler_output_processor_mixin.py`, `managers/utils.py`, `eagle_worker_v2.py`, and `multi_layer_eagle_worker_v2.py`.
+
+## 3. Current Main Code Shape
+
+DeepSeek V3/R1 mainline support is not a brand-new model file. It reuses `deepseek_v2.py`, which evolved from the DeepSeek V2 implementation. `DeepseekV3ForCausalLM` inherits from `DeepseekV2ForCausalLM`, and the core layers include `DeepseekV2AttentionMLA`, `DeepseekV2MoE`, `DeepseekV2DecoderLayer`, and `DeepseekV2Model`. This is why many fixes named `deepseek_v2` also affect V3, R1, V3.1, and even V3.2.
+
+The most important shared modules in current main are:
+
+- `python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py`: stacked qkv/gate_up loading, expert parameter mapping, `kv_b_proj` post-processing, W4AFP8 scale mapping, and DeepGEMM BMM weight transforms.
+- `python/sglang/srt/models/deepseek_common/attention_backend_handler.py`: forward-method selection by backend, deterministic mode, PCG, and MHA/MLA subtype.
+- `python/sglang/srt/models/deepseek_common/attention_forward_methods/`: MLA/MHA forward logic after `#19122`.
+- `python/sglang/srt/models/deepseek_nextn.py`: MTP/NextN draft layer.
+- `python/sglang/srt/parser/reasoning_parser.py`: separation between `deepseek-r1` and `deepseek-v3` reasoning parsers.
+- `python/sglang/srt/function_call/deepseekv3_detector.py`: V3/R1 tool-call parser.
+- `python/sglang/srt/managers/schedule_batch.py` and `python/sglang/srt/mem_cache/common.py`: current-main path for thinking-token radix-cache stripping.
+- `python/sglang/srt/server_args.py`: the main entry point for DeepSeek-family default attention backend, KV-cache dtype, quantized backend, and DeepEP/DP-attention guards.
+
+`server_args.py` now applies several DeepSeek V3/R1 automatic choices. On Blackwell SM100, if no MLA backend is specified, it defaults to `trtllm_mla`. Official FP8 and ModelOpt FP8/FP4 quantized checkpoints tend to select `flashinfer_trtllm` MoE runner when conditions allow. With piecewise CUDA graph enabled, V3/R1 records the “use MLA for prefill” path. ROCm has separate AITER all-reduce fusion and FP4/EAGLE backend defaults. Performance debugging must therefore include launch args, server-side automatic rewrites, and the model file.
+
+## 4. MLA and Weight Loading: From Runnable to Backend-Aware
+
+DeepSeek V3/R1 attention is primarily MLA. `DeepseekV2AttentionMLA` builds q/k/v latent projections from `q_lora_rank`, `kv_lora_rank`, `qk_nope_head_dim`, `qk_rope_head_dim`, and `v_head_dim`. In current main, `q_a_proj` and `kv_a_proj_with_mqa` can be fused into `fused_qkv_a_proj_with_mqa`, while `kv_b_proj` is post-processed after loading to expose components such as `w_kc` and `w_vc` that backends need.
+
+After `#16649`, weight loading lives in `DeepseekV2WeightLoaderMixin`, which all later DeepSeek-family models reuse. Key details include:
+
+- `gate_proj/up_proj` stack into `gate_up_proj`, while q/k/v names follow MLA-specific mapping.
+- Expert parameters go through `make_expert_params_mapping` and W4AFP8 input-scale mapping.
+- When shared-expert fusion is enabled, `mlp.shared_experts` can map to `mlp.experts.256`.
+- `kv_b_proj` has post-load handling for AWQ, FP8 block scale, and DeepGEMM BMM.
+- R1 MXFP4 / NextN checkpoints can use `model.layers.61*` naming and require special handling in `deepseek_nextn.py`.
+
+`#17744` is a practical memory fix: it avoids eagerly materializing `dict(weights)` while loading large checkpoints. `#23195` remains open and warns that quantized layers may not expose `.weight`; if MLA initialization fails on AWQ or compressed-tensors checkpoints, inspect that direction before assuming missing weights.
+
+After `#19122`, MLA forward code moved into `attention_forward_methods`. That makes backend switching cleaner, but it also creates compatibility-regression risk. Open `#22938` is still restoring MI300X DeepSeek MLA paths, and open `#21530` is still fixing ROCm fused MLA decode RoPE.
+
+## 5. MoE Routing, Shared Experts, and Communication Boundaries
+
+DeepSeek V3/R1 MoE has 256 routed experts plus shared experts. Current main's `DeepseekV2MoE` computes `num_fused_shared_experts` from config and server args. When fusion is enabled, the loader remaps `mlp.shared_experts` to `mlp.experts.256`, placing routed and shared experts on one fused-MoE compute surface.
+
+Fusion is deliberately conservative:
+
+- TBO/SBO disables fusion.
+- DeepEP disables fusion by default unless `--enforce-shared-experts-fusion` is set.
+- W4AFP8 disables fusion because routed and shared experts may use different quantization methods.
+- Architecture, expert-count, or backend-capability mismatches also disable it.
+
+Shared-expert fusion under DeepEP is more complex. Ordinary fusion is `256 + 1`; DeepEP fusion expands the local expert layout to `256 + EP_size`, and TopK must handle shared expert interleaving and mapping across EP ranks. Bugs here often show up as output correctness or double reduction, not as a slow single kernel. `#23257` is still open and targets exactly the overlap between MoE internal all-reduce and outer DP-attention reduce for CuteDSL EP plus DP attention.
+
+The main routing change is `#15347`. DeepSeek biased grouped top-k no longer prefers the generic `moe_fused_gate`; when constraints match, it uses `fused_topk_deepseek`. `#17707` added a Blackwell router benchmark, and `#22933` expanded the CPU shared-expert interface when scaling factor is absent, which is CPU parity cleanup rather than H200 GPU throughput. Open `#21531` migrates `dsv3_router_gemm` from AOT sgl-kernel to JIT, which is important for future router maintainability and deployment.
+
+## 6. MTP / NextN: The Draft Layer Is Its Own Runtime Surface
+
+DeepSeek V3/R1 MTP uses EAGLE and `DeepseekV3ForCausalLMNextN`. It has a separate NextN layer, shared embed/head reuse, its own loading logic, and sometimes different quantization.
+
+Current `deepseek_nextn.py` has these important constraints:
+
+- Only one NextN layer is supported.
+- The target model is `DeepseekV3ForCausalLM`, and the draft model is `DeepseekV3ForCausalLMNextN`.
+- The draft layer may be BF16 or may use quantization handling that differs from the target.
+- AMD R1 MXFP4 needs special naming and shape fixes.
+- Some DeepEP BF16 dispatch environment variables may need to be toggled around NextN execution.
+
+`#7376` fixed R1 FP4 MTP, `#13548` fixed V3 MTP on B200, `#18607` fixed V3 MTP accuracy on AMD TP4, and `#19425` fixed R1-0528-MXFP4 draft loading shape. In current validation, the H200 V3 MTP registered test expects GSM8K above `0.935`, average spec accept length above `2.8`, and batch-size-1 throughput above the non-MTP lane.
+
+The newer spec line adds two constraints that should be recorded explicitly: `#21599` makes EAGLE top-k=1 draft steps adaptive, and `#22128` lets PCG coexist with speculative decoding. Open `#23336` continues this into the spec-v2 worker path. When writing a skill or debugging performance, record the target model, draft model, spec v1/v2, PCG, and DP attention together.
+
+## 7. R1 W4AFP8 / W4A8 DeepEP: A Separate Quantized Optimization Ladder
+
+R1 W4AFP8 should not be treated as ordinary FP8. `W4AFp8Config` from `#7762` detects mixed precision from the quant config, maps ordinary Linear layers to FP8 or unquantized methods, and maps MoE experts to W4A8. `cutlass_w4a8_moe.py` handles packed int4 expert weights, FP8 activations, input scales, and grouped MoE runners.
+
+Several later PRs make the path complete:
+
+- `#8118` adds TP mode for R1-W4AFP8.
+- `#8247` adds normal DeepEP by letting DeepEP dispatch metadata enter W4A8 MoE `apply_deepep_normal`.
+- `#8464` adds low-latency DeepEP.
+- `#10027` and `#12921` optimize W4AFP8 glue kernels and DeepSeek-V3-0324 W4AFP8 performance.
+
+The low-latency DeepEP FP8 communication track must be read with its revert history: `#14162` landed R1 W4A8 DeepEP LL FP8 communication, `#21719` reverted it, and `#22316` relanded it. Reading only `#14162` gives the wrong conclusion; the real current-main state is the post-`#22316` code.
+
+## 8. Quantization, Platforms, and Parser Support
+
+The current DeepSeek V3/R1 quantization surface is broad:
+
+- Official V3 FP8: no need to manually pass `--quantization fp8`; the server can recognize the quantization config.
+- FP4/NVFP4: `#11512`, `#11708`, and `#12778` make Blackwell/SM120 defaults and backend selection safer.
+- W4AFP8/W4A8: centered on `w4afp8.py`, `cutlass_w4a8_moe.py`, and DeepEP normal/LL paths.
+- MXFP4: `#15304` fixes AMD EP accuracy, `#19425` fixes R1-0528-MXFP4 draft loading, and open `#21529` continues ROCm Quark W4A4 work.
+- MXFP8: `#21280` adds MXFP8 support for routed MoE.
+- LoRA: `#22323` refactors LoRA quant info and supports DeepSeek V3 MLA LoRA; open `#22268` points to adapter bypass in `prepare_qkv_latent`.
+
+Parser choices must also be separated. V3/R1 tool calling uses `--tool-call-parser deepseekv3`, V3-style thinking uses `--reasoning-parser deepseek-v3`, and R1 uses `--reasoning-parser deepseek-r1`. The R1 parser handles output without an opening `<think>` tag by forcing content into reasoning until `</think>`; this differs from the Qwen3-style parser used by V3/V3.1.
+
+Radix cache should be checked separately from the thinking parser. `#23315`'s opt-in strip is cache-layer behavior: it decides whether thinking tokens can be reused as prefix-cache content; it is not a parser-format change in `deepseekv3_detector.py` or `reasoning_parser.py`. For multi-turn reasoning anomalies, record the parser, strip flag, and cache-hit state together.
+
+## 9. Current Validation Surface and Open PRs
+
+Current main has validation lanes for:
+
+- `test/registered/8-gpu-models/test_deepseek_v3_basic.py`: H200 V3 base accuracy and performance, with GSM8K above `0.935`.
+- `test/registered/8-gpu-models/test_deepseek_v3_mtp.py`: H200 V3 MTP, average spec accept length, and throughput.
+- `test/registered/amd/test_deepseek_v3_basic.py`, `test/registered/amd/test_deepseek_v3_mtp.py`, `test/registered/amd/test_deepseek_r1_mxfp4_8gpu.py`: AMD base, MTP, and R1 MXFP4.
+- `test/registered/backends/test_deepseek_r1_fp8_trtllm_backend.py`: R1 FP8 TRTLLM backend.
+- `test/registered/quant/test_deepseek_v3_fp4_4gpu.py`, `test/registered/quant/test_w4a8_deepseek_v3.py`: FP4 and W4A8.
+- `test/registered/mla/test_mla_deepseek_v3.py`, `test/registered/mla/test_mla_int8_deepseek_v3.py`: MLA and INT8 MLA.
+- `test/registered/lora/test_lora_deepseek_v3_base_logprob_diff.py`: LoRA logprob regression.
+- `test/registered/kernels/test_fused_topk_deepseek.py`: DeepSeek fused top-k.
+
+Open PRs to track:
+
+- `#14194`: DCP for DeepSeek V2/V3.
+- `#15315`, `#15380`: group GEMM for DeepSeek-R1-W4AFP8.
+- `#18892`: DeepSeek V3 GEMM JIT.
+- `#21526`: ROCm AITER router GEMM regression.
+- `#21529`: ROCm DeepSeek-architecture MXFP4/Quark W4A4.
+- `#21530`: ROCm fused MLA decode RoPE.
+- `#21531`: `dsv3_router_gemm` JIT migration.
+- `#22268`: DeepSeek MLA LoRA adapter bypass.
+- `#22774`: MUSA backend.
+- `#22938`: MI300X DeepSeek path restoration after the MLA refactor.
+- `#23195`: quantized-layer `.weight` access guard.
+- `#23257`: CuteDSL EP plus DP-attention double reduce.
+- `#23336`: spec-v2 adaptive speculative decoding.

--- a/model-pr-optimization-history/deepseek-v3-r1/README.zh.md
+++ b/model-pr-optimization-history/deepseek-v3-r1/README.zh.md
@@ -1,0 +1,249 @@
+# SGLang DeepSeek V3 / R1 支持与优化时间线
+
+本文基于 SGLang `origin/main` 最新快照 `929e00eea`、sgl-cookbook `origin/main` 快照 `8ec4d03`，以及 DeepSeek V3/R1 相关 merged、open、reverted PR 的 patch 阅读结果整理。范围只覆盖 DeepSeek V3、V3-0324、R1、R1-0528 以及这些模型的量化、MTP、DeepEP、LoRA 和后端优化；DeepSeek V3.1 的 parser/template 差异和 DeepSeek V3.2 的 DSA/NSA 稀疏注意力单独成文。
+
+结论：截至 `929e00eea`，DeepSeek V3/R1 的主线入口仍是 `python/sglang/srt/models/deepseek_v2.py` 里的 `DeepseekV3ForCausalLM`，MTP 草稿模型入口是 `python/sglang/srt/models/deepseek_nextn.py` 里的 `DeepseekV3ForCausalLMNextN`。当前主线已经形成了完整的 MLA 后端选择、FP8/FP4/W4AFP8/MXFP4/MXFP8/NVFP4 加载、共享专家融合、MTP、R1 W4A8 DeepEP、DP attention、LoRA 和多硬件验证面；新增运行时内容包括 adaptive EAGLE、PCG + speculative decoding、thinking token radix-cache strip 以及 spec v2 adaptive spec。后续需要跟进的方向主要是 open PR 中的 JIT router GEMM、DeepSeek MLA 量化层 `.weight` 访问、ROCm MLA 恢复、LoRA adapter 旁路、CuteDSL EP + DP attention 双重 reduce、MUSA、DCP 和 spec v2 自适应 speculative decoding。
+
+## 1. 时间线总览
+
+| 创建日期 | PR | 状态 | 主线 | 代码区域 | 作用 |
+| --- | ---: | --- | --- | --- | --- |
+| 2024-12-26 | [#2601](https://github.com/sgl-project/sglang/pull/2601) | merged | AMD bring-up | Triton decode attention、fused MoE、`deepseek_v2.py` | 支持 DeepSeek V3 在 AMD 路径运行。 |
+| 2024-12-30 | [#2667](https://github.com/sgl-project/sglang/pull/2667) | merged | AMD FP8 | `deepseek_v2.py` | 修正 AMD 上 DeepSeek V3 FP8 精度。 |
+| 2025-02-05 | [#3314](https://github.com/sgl-project/sglang/pull/3314) | merged | docs | DeepSeek 文档 | 增加 DeepSeek 使用和多机启动文档。 |
+| 2025-02-12 | [#3522](https://github.com/sgl-project/sglang/pull/3522) | merged | docs | DeepSeek V3 launch docs | 修正文档里的 DeepSeek V3 启动参数。 |
+| 2025-02-14 | [#3582](https://github.com/sgl-project/sglang/pull/3582) | merged | MTP | `deepseek_nextn.py`、spec decode | 给 DeepSeek V3/R1 增加 NextN/EAGLE speculative decoding。 |
+| 2025-02-26 | [#3893](https://github.com/sgl-project/sglang/pull/3893) | merged | FP8 GEMM | benchmark、DeepGEMM | 增加 DeepGEMM 和 SGLang FP8 block-wise GEMM benchmark。 |
+| 2025-03-05 | [#4079](https://github.com/sgl-project/sglang/pull/4079) | merged | INT8 docs | DeepSeek docs | 增加 INT8 启动示例。 |
+| 2025-03-07 | [#4165](https://github.com/sgl-project/sglang/pull/4165) | merged | DeepGEMM | `sgl-kernel` | 把 DeepGEMM 集成进 `sgl-kernel`。 |
+| 2025-03-08 | [#4199](https://github.com/sgl-project/sglang/pull/4199) | merged | DeepGEMM | Linear layers | 让 Linear 支持 DeepGEMM。 |
+| 2025-03-09 | [#4218](https://github.com/sgl-project/sglang/pull/4218) | merged | MTP/MLA | FlashInfer MLA | 给 FlashInfer MLA backend 增加 NextN 支持。 |
+| 2025-03-16 | [#4472](https://github.com/sgl-project/sglang/pull/4472) | merged | FlashMLA | attention backend | 增加初始 FlashMLA backend。 |
+| 2025-03-17 | [#4514](https://github.com/sgl-project/sglang/pull/4514) | merged | FlashMLA graph | `flashmla_backend.py`、server args | 给 FlashMLA backend 增加 CUDA graph 支持。 |
+| 2025-03-18 | [#4530](https://github.com/sgl-project/sglang/pull/4530) | merged | fused MoE | `moe_fused_gate.cu`、test、benchmark | 增加 DeepSeek 风格 fused group gate selection kernel。 |
+| 2025-03-20 | [#4613](https://github.com/sgl-project/sglang/pull/4613) | merged | DeepGEMM default | server defaults | 在 Hopper 架构上默认启用 DeepGEMM。 |
+| 2025-03-20 | [#4631](https://github.com/sgl-project/sglang/pull/4631) | merged | ROCm MTP | NextN | 在 AMD GPU 上启用 MTP/NextN。 |
+| 2025-03-27 | [#4831](https://github.com/sgl-project/sglang/pull/4831) | merged | FA3 MLA | attention backend | 给 MLA 增加 FA3 backend。 |
+| 2025-04-05 | [#5086](https://github.com/sgl-project/sglang/pull/5086) | merged | MoE align | `moe_align_kernel.cu`、fused MoE | 降低 `moe_align_block_size_kernel` 小 batch 开销。 |
+| 2025-04-07 | [#5113](https://github.com/sgl-project/sglang/pull/5113) | merged | MHA chunked prefill | `flashattention_backend.py`、scheduler、`deepseek_v2.py` | 增加 `MHA_CHUNKED_KV`，支持 DeepSeek chunked prefill。 |
+| 2025-04-09 | [#5210](https://github.com/sgl-project/sglang/pull/5210) | merged | FA3 default | server defaults | Hopper 上默认使用 FA3 MLA。 |
+| 2025-04-11 | [#5263](https://github.com/sgl-project/sglang/pull/5263) | merged | DeepGEMM guard | defaults | 临时关闭 DeepGEMM 默认启用。 |
+| 2025-04-12 | [#5310](https://github.com/sgl-project/sglang/pull/5310) | merged | DeepGEMM guard | defaults | 限制 DeepGEMM 只在 Hopper 使用。 |
+| 2025-04-14 | [#5371](https://github.com/sgl-project/sglang/pull/5371) | merged | fused MoE | `deepseek_v2.py`、MoE gate | 在 DeepSeek V3/R1 应用 fused MoE gate。 |
+| 2025-04-14 | [#5381](https://github.com/sgl-project/sglang/pull/5381) | merged | MLA kernel | `merge_attn_states.cu` | 增加更快的 `merge_state_v2` CUDA merge-attention-state kernel。 |
+| 2025-04-14 | [#5385](https://github.com/sgl-project/sglang/pull/5385) | merged | RoPE | `rotary_embedding.py` | 应用 DeepSeek CUDA RoPE。 |
+| 2025-04-14 | [#5390](https://github.com/sgl-project/sglang/pull/5390) | merged | Cutlass MLA | `cutlass_mla_backend.py`、sgl-kernel attention | 增加 Cutlass MLA attention backend。 |
+| 2025-04-15 | [#5432](https://github.com/sgl-project/sglang/pull/5432) | merged | DeepGEMM BMM | `fp8_kernel.py`、`deepseek_v2.py` | 引入 DeepGEMM `group_gemm_masked` 作为 MLA BMM 探索路径。 |
+| 2025-04-16 | [#5473](https://github.com/sgl-project/sglang/pull/5473) | merged | FP8 quant | `fp8_kernel.py`、`fp8_utils.py` | 用 `sgl-kernel` 的 `sglang_per_token_group_quant_fp8` 替换 Triton kernel。 |
+| 2025-04-19 | [#5549](https://github.com/sgl-project/sglang/pull/5549) | merged | MLA FP8 quant | `fp8_kernel.py`、`deepseek_v2.py` | 复用 zero scalar allocator，并去掉 `per_tensor_quant_mla_fp8` 中一个 kernel。 |
+| 2025-04-20 | [#5571](https://github.com/sgl-project/sglang/pull/5571) | merged | shared experts | SM90 shared experts | 在 SM90 上启用 DeepSeek V3 shared-experts fusion。 |
+| 2025-04-20 | [#5578](https://github.com/sgl-project/sglang/pull/5578) | merged | MLA copy | `deepseek_v2.py`、RoPE | 移除 DeepSeek `forward_absorb` 中一次额外 copy。 |
+| 2025-04-22 | [#5619](https://github.com/sgl-project/sglang/pull/5619) | merged | MLA projection | `deepseek_v2.py`、loader | 融合 `q_a_proj` 和 `kv_a_proj_with_mqa`。 |
+| 2025-04-22 | [#5628](https://github.com/sgl-project/sglang/pull/5628) | merged | DeepGEMM default | defaults、docs | 重新默认开启 DeepGEMM 并更新文档。 |
+| 2025-04-24 | [#5707](https://github.com/sgl-project/sglang/pull/5707) | merged | MTP/fusion | R1 MTP、shared experts | 修复 R1 同时启用 MTP 和 shared-expert fusion 的组合。 |
+| 2025-04-24 | [#5716](https://github.com/sgl-project/sglang/pull/5716) | merged | MoE tuning | Triton fused MoE config | 更新 H20 DeepSeek/R1 FP8 W8A8 fused-MoE Triton config。 |
+| 2025-04-25 | [#5740](https://github.com/sgl-project/sglang/pull/5740) | merged | MoE tuning | H200 Triton fused MoE config | 更新 H200 Triton 3.2 fused-MoE config 和 warning。 |
+| 2025-04-25 | [#5748](https://github.com/sgl-project/sglang/pull/5748) | merged | MLA KV cache | `flashattention_backend.py`、`memory_pool.py`、`deepseek_v2.py` | 融合 MLA set-KV-cache kernel，并去掉 K concat 开销。 |
+| 2025-04-27 | [#5793](https://github.com/sgl-project/sglang/pull/5793) | merged | MTP ergonomics | server/spec args | 自动设置 MTP draft model path。 |
+| 2025-05-01 | [#5952](https://github.com/sgl-project/sglang/pull/5952) | merged | MTP API | CI、docs | 更新 MTP API 变化后的测试和文档。 |
+| 2025-05-02 | [#5977](https://github.com/sgl-project/sglang/pull/5977) | merged | MLA streams | `deepseek_v2.py` | 用双 stream overlap q/k norm。 |
+| 2025-05-05 | [#6034](https://github.com/sgl-project/sglang/pull/6034) | merged | docs | MLA backend docs | 更新 MLA attention backend 文档。 |
+| 2025-05-07 | [#6081](https://github.com/sgl-project/sglang/pull/6081) | merged | MTP/DP attention | MTP、DP attention | 支持 MTP 和 DP attention 组合。 |
+| 2025-05-08 | [#6109](https://github.com/sgl-project/sglang/pull/6109) | merged | FlashMLA/MTP | FlashMLA、FP8 KV | 支持 FlashMLA backend + MTP + FP8 KV cache。 |
+| 2025-05-09 | [#6151](https://github.com/sgl-project/sglang/pull/6151) | closed | hybrid attention | model_runner、cuda graph、server args | 探索 hybrid attention backend；未成为 V3/R1 主线。 |
+| 2025-05-12 | [#6220](https://github.com/sgl-project/sglang/pull/6220) | merged | fused MoE | top-k reduce、quant methods | 把 routed scaling factor 融进 top-k reduce kernel。 |
+| 2025-06-05 | [#6890](https://github.com/sgl-project/sglang/pull/6890) | merged | DeepGEMM/MLA | `fused_qkv_a_proj_with_mqa` | 用 DeepGEMM 替换该 fused projection 上的 Triton 路径。 |
+| 2025-06-08 | [#6970](https://github.com/sgl-project/sglang/pull/6970) | merged | routed scaling | DeepSeek MoE | 在 DeepSeek 内融合 routed scaling factor。 |
+| 2025-06-13 | [#7146](https://github.com/sgl-project/sglang/pull/7146) | merged | DeepGEMM format | per-token-group quant | 支持新 DeepGEMM 格式的 per-token-group quant。 |
+| 2025-06-13 | [#7150](https://github.com/sgl-project/sglang/pull/7150) | merged | DeepGEMM refactor | DeepGEMM integration | 重构 DeepGEMM 集成。 |
+| 2025-06-13 | [#7155](https://github.com/sgl-project/sglang/pull/7155) | merged | DeepGEMM format | SRT quant | 在 SRT 侧支持新 DeepGEMM quant 格式。 |
+| 2025-06-13 | [#7156](https://github.com/sgl-project/sglang/pull/7156) | merged | DeepGEMM format | DeepSeek weights | 重新量化 DeepSeek 权重以适配新 DeepGEMM input format。 |
+| 2025-06-14 | [#7172](https://github.com/sgl-project/sglang/pull/7172) | merged | DeepGEMM | new DeepGEMM path | 完成新 DeepGEMM 路径支持。 |
+| 2025-06-20 | [#7376](https://github.com/sgl-project/sglang/pull/7376) | merged | MTP/FP4 | `deepseek_nextn.py`、spec decode | 修复 DeepSeek R1 FP4 的 MTP。 |
+| 2025-07-04 | [#7762](https://github.com/sgl-project/sglang/pull/7762) | merged | R1 W4AFP8 | `w4afp8.py`、`cutlass_w4a8_moe.py`、EP MoE | 新增 R1 W4AFP8 配置、Cutlass W4A8 MoE 和 EP-MoE 路径。 |
+| 2025-07-17 | [#8118](https://github.com/sgl-project/sglang/pull/8118) | merged | R1 W4AFP8 TP | Cutlass grouped W4A8 MoE | 给 R1-W4AFP8 增加 TP 模式。 |
+| 2025-07-22 | [#8247](https://github.com/sgl-project/sglang/pull/8247) | merged | R1 W4A8 DeepEP | `token_dispatcher/deepep.py`、W4A8 MoE | 给 R1 W4A8/W4AFP8 增加 normal DeepEP。 |
+| 2025-07-28 | [#8464](https://github.com/sgl-project/sglang/pull/8464) | merged | R1 W4A8 DeepEP LL | DeepEP low-latency | 给 R1 W4A8 增加 low-latency DeepEP。 |
+| 2025-09-04 | [#10027](https://github.com/sgl-project/sglang/pull/10027) | merged | W4AFP8 perf | glue kernels | 优化 R1 W4AFP8 胶水 kernel。 |
+| 2025-09-12 | [#10361](https://github.com/sgl-project/sglang/pull/10361) | merged | DP/compile | DP + torch compile | 修复 DeepSeek V3 DP + torch-compile GPU fault。 |
+| 2025-10-12 | [#11512](https://github.com/sgl-project/sglang/pull/11512) | merged | FP4 default | server defaults | 更新 R1-FP4 在 Blackwell 上的默认配置。 |
+| 2025-10-16 | [#11708](https://github.com/sgl-project/sglang/pull/11708) | merged | FP4/SM120 | backend defaults | 支持 SM120 上的 FP4 DeepSeek。 |
+| 2025-10-23 | [#12000](https://github.com/sgl-project/sglang/pull/12000) | merged | deterministic | DeepSeek attention | 支持 DeepSeek 架构单卡 deterministic inference。 |
+| 2025-10-24 | [#12057](https://github.com/sgl-project/sglang/pull/12057) | merged | docs | W4FP8 docs | 增加 W4FP8 用法示例。 |
+| 2025-11-06 | [#12778](https://github.com/sgl-project/sglang/pull/12778) | merged | Blackwell default | `server_args.py` | 更新 DeepSeek V3 在 SM100 上的自动量化设置。 |
+| 2025-11-09 | [#12921](https://github.com/sgl-project/sglang/pull/12921) | merged | W4AFP8 perf | W4A8 kernels | 优化 DeepSeek-V3-0324 W4AFP8 kernel。 |
+| 2025-11-19 | [#13548](https://github.com/sgl-project/sglang/pull/13548) | merged | MTP/B200 | NextN、spec decode | 修复 B200 上 DeepSeek V3 MTP。 |
+| 2025-11-30 | [#14162](https://github.com/sgl-project/sglang/pull/14162) | merged | DeepEP LL | R1 W4A8 DeepEP | 让 R1 W4A8 DeepEP low-latency dispatch 使用 FP8 通信。 |
+| 2025-12-11 | [#14897](https://github.com/sgl-project/sglang/pull/14897) | merged | DP accuracy | BF16 KV | 修复 DeepSeek V3 DP + BF16 KV 精度。 |
+| 2025-12-17 | [#15304](https://github.com/sgl-project/sglang/pull/15304) | merged | MXFP4 | AMD EP | 修复 MXFP4 DeepSeek V3 + EP 精度。 |
+| 2025-12-18 | [#15347](https://github.com/sgl-project/sglang/pull/15347) | merged | router/top-k | `topk.py` | 用 `fused_topk_deepseek` 替换通用 `moe_fused_gate` 热路径。 |
+| 2025-12-20 | [#15531](https://github.com/sgl-project/sglang/pull/15531) | merged | PCG/FP4 | CUDA graph | 给 DeepSeek V3 FP4 增加 piecewise CUDA graph。 |
+| 2026-01-07 | [#16649](https://github.com/sgl-project/sglang/pull/16649) | merged | loader refactor | `deepseek_common/deepseek_weight_loader.py` | 把 DeepSeek V2/V3 权重加载拆成 mixin。 |
+| 2026-01-15 | [#17133](https://github.com/sgl-project/sglang/pull/17133) | merged | MoE tuning | fused MoE configs | 增加 H20/H20-3E 的 DeepSeek 系 MoE config。 |
+| 2026-01-16 | [#17178](https://github.com/sgl-project/sglang/pull/17178) | merged | eval/parser | eval choices | 从 thinking-mode choices 移除 `deepseek-r1`，因为 R1 parser 和 V3 thinking parser 不同。 |
+| 2026-01-25 | [#17707](https://github.com/sgl-project/sglang/pull/17707) | merged | router bench | `dsv3_router_gemm` | 增加 Blackwell router GEMM benchmark。 |
+| 2026-01-26 | [#17744](https://github.com/sgl-project/sglang/pull/17744) | merged | loader memory | weight loader | 延迟 `dict(weights)` 物化，避免大 checkpoint OOM。 |
+| 2026-02-03 | [#18242](https://github.com/sgl-project/sglang/pull/18242) | merged | ROCm perf | MI300X | 优化 DeepSeek R1 在 MI300X 上的运行。 |
+| 2026-02-08 | [#18451](https://github.com/sgl-project/sglang/pull/18451) | merged | AMD router | AITER router GEMM | expert 数不超过 256 时使用 `aiter_dsv3_router_gemm`。 |
+| 2026-02-09 | [#18461](https://github.com/sgl-project/sglang/pull/18461) | merged | XPU | Intel GPU | 支持 R1 在 Intel GPU 上推理。 |
+| 2026-02-11 | [#18607](https://github.com/sgl-project/sglang/pull/18607) | merged | AMD MTP | TP4 MTP | 修复 AMD TP4 DeepSeek V3 MTP 精度。 |
+| 2026-02-22 | [#19122](https://github.com/sgl-project/sglang/pull/19122) | merged | MLA refactor | `deepseek_common/attention_forward_methods/` | 把 DeepSeek MLA forward 拆到共享 forward-method 模块。 |
+| 2026-02-26 | [#19425](https://github.com/sgl-project/sglang/pull/19425) | merged | R1 MXFP4 | NextN loading | 修复 R1-0528-MXFP4 权重加载 shape mismatch。 |
+| 2026-03-04 | [#19834](https://github.com/sgl-project/sglang/pull/19834) | merged | AMD CI | MI35x lanes | 增加 DeepSeek KV FP8 和 all-reduce fusion 的 MI35x 测试。 |
+| 2026-03-04 | [#19843](https://github.com/sgl-project/sglang/pull/19843) | merged | AMD perf | AITER FP8 top-k | AITER FP8 路由中保留 BF16 correction bias，避免 runtime dtype conversion。 |
+| 2026-03-18 | [#20841](https://github.com/sgl-project/sglang/pull/20841) | merged | DP bugfix | DeepSeek R1 DP | 修复 DeepSeek R1 DP GPU fault。 |
+| 2026-03-24 | [#21280](https://github.com/sgl-project/sglang/pull/21280) | merged | MXFP8 | routed MoE | 增加 MXFP8 DeepSeek V3 routed MoE 支持。 |
+| 2026-03-28 | [#21599](https://github.com/sgl-project/sglang/pull/21599) | merged | MTP/spec | server args、EAGLE runtime、spec workers | 给 EAGLE top-k=1 增加自适应 `speculative_num_steps`。 |
+| 2026-03-31 | [#21719](https://github.com/sgl-project/sglang/pull/21719) | merged | revert | DeepEP LL | 回滚 `#14162`。 |
+| 2026-04-05 | [#22128](https://github.com/sgl-project/sglang/pull/22128) | merged | PCG/spec | `model_runner.py`、PCG runner、server args | 允许 piecewise CUDA graph 和 speculative decoding 同时使用。 |
+| 2026-04-08 | [#22316](https://github.com/sgl-project/sglang/pull/22316) | merged | reland | DeepEP LL | 重新合入 R1 W4A8 DeepEP low-latency FP8 通信。 |
+| 2026-04-08 | [#22323](https://github.com/sgl-project/sglang/pull/22323) | merged | LoRA | quant info、MLA LoRA | 重构 LoRA quant info，并增加 DeepSeek V3 MLA LoRA 支持。 |
+| 2026-04-16 | [#22933](https://github.com/sgl-project/sglang/pull/22933) | merged | CPU shared expert | CPU MoE | 扩展无 scaling factor 时的 CPU shared-expert 接口，偏 CPU parity 而非 H200 吞吐。 |
+| 2026-04-16 | [#22950](https://github.com/sgl-project/sglang/pull/22950) | closed | reasoning cache | model config、scheduler、radix cache、reasoning parser | 探索 parser-gated 两阶段 reasoning radix-cache stripping，未成为当前主线。 |
+| 2026-04-20 | [#23195](https://github.com/sgl-project/sglang/pull/23195) | open | quant bugfix | `DeepseekV2AttentionMLA` | 给 AWQ/compressed-tensors 层的 `.weight` 访问加保护。 |
+| 2026-04-20 | [#23257](https://github.com/sgl-project/sglang/pull/23257) | open | MoE/DP | CuteDSL EP + DP attention | 修复 `DeepseekV2MoE` 在 CuteDSL EP + DP attention 下的 double-reduce。 |
+| 2026-04-21 | [#23315](https://github.com/sgl-project/sglang/pull/23315) | merged | reasoning cache | `schedule_batch.py`、`mem_cache/common.py`、`server_args.py` | 增加可选的 thinking token radix-cache strip。 |
+| 2026-04-21 | [#23336](https://github.com/sgl-project/sglang/pull/23336) | open | spec v2 | scheduler output processor、EAGLE v2 workers | 把 adaptive speculative decoding 扩展到 spec v2。 |
+
+## 2. 单机 H200 优化资料覆盖
+
+单机 H200 优化资料列出了 `#4514`、`#4530`、`#5086`、`#5113`、`#5381`、`#5385`、`#5390`、`#5432`、`#5473`、`#5549`、`#5578`、`#5619`、`#5716`、`#5740`、`#5748`、`#5977`、`#6034`、`#6151`、`#6220`。这些 PR 已进入时间线，并按当前 main 状态标注为默认路径、可选 backend、探索路径或 closed 方向。
+
+这批 PR 的主线可以拆成四条。
+
+第一条是 FP8 Block GEMM / DeepGEMM。`#3893` 先用 benchmark 把 DeepGEMM 和 SGLang FP8 block-wise GEMM 放到同一比较面；`#4165` 把 DeepGEMM 接进 `sgl-kernel`；`#4199` 让 Linear 支持 DeepGEMM。之后 `#4613`、`#5263`、`#5310`、`#5628` 说明默认策略不是一次性固定的，而是在 Hopper 默认、临时关闭、限制架构、重新开启之间迭代。`#5432` 的 DeepGEMM `group_gemm_masked` BMM 和 MLA FP8 quant kernel 属于探索路径，不能直接写成当前 H200 默认；`#5473` 把 per-token-group FP8 quantization 从 Triton 换成 `sgl-kernel`，`#5549` 通过 zero scalar allocator 复用去掉 `per_tensor_quant_mla_fp8` 里一个 kernel。后续 `#6890` 和 `#7146`、`#7150`、`#7155`、`#7156`、`#7172` 又把 fused projection 和 DeepSeek 权重量化迁到新的 DeepGEMM input format。
+
+第二条是 Fused MoE。`#4530` 增加 `moe_fused_gate.cu`、绑定、benchmark 和测试，专门处理 DeepSeek biased grouped top-k / group gate selection；`#5086` 降低 `moe_align_block_size_kernel` 小 batch 开销；`#5371` 把 fused MoE gate 接进 DeepSeek V3/R1；`#5571` 在 SM90 上打开 shared-experts fusion；`#5716` 和 `#5740` 分别补 H20/H200 fused-MoE Triton config；`#6220` 把 routed scaling factor 融进 top-k reduce kernel，`#6970` 又把同类 scaling 直接融进 DeepSeek 路径。读当前 main 时，要同时看 `topk.py`、`fused_moe_triton/fused_moe.py`、`sgl-kernel/csrc/moe/moe_fused_gate.cu`、`moe_align_kernel.cu` 和 `sgl_kernel_ops.h`。
+
+第三条是 MLA/attention backend。FlashMLA 先由 `#4472` 接入，`#4514` 加 CUDA graph，`#6109` 再补 MTP 和 FP8 KV cache；FA3 MLA 由 `#4831` 接入，`#5210` 让 Hopper 默认走 FA3 MLA；Cutlass MLA 是 `#5390`，后续 `#6034` 用文档把 FA3、FlashMLA、Cutlass MLA 等 backend 的选择边界写清楚。模型文件热路径方面，`#5113` 增加 `MHA_CHUNKED_KV`，`#5381` 增加 `merge_state_v2` CUDA kernel，`#5385` 接 DeepSeek CUDA RoPE，`#5578` 移除 `forward_absorb` copy，`#5619` 融合 `q_a_proj` / `kv_a_proj_with_mqa`，`#5748` 融合 MLA set-KV-cache kernel，`#5977` 用双 stream overlap q/k norm。
+
+第四条是 MTP 和 backend 组合。`#3582` 是 V3/R1 NextN/EAGLE 起点，`#4218` 支持 FlashInfer MLA + NextN，`#5707` 修 R1 的 MTP + shared-expert fusion 组合，`#5793` 自动设置 draft model path，`#5952` 更新 MTP API 的测试和文档，`#6081` 支持 MTP + DP attention，`#6109` 又把 FlashMLA、MTP、FP8 KV cache 连接起来。`#6151` 是 closed 的 hybrid attention backend 探索，应作为历史背景记录，但不能算当前主线支持。
+
+## 2.1 MTP/PCG 与 Thinking Radix Cache
+
+SGLang main 快照为 `929e00eea`，sgl-cookbook 快照为 `8ec4d03`。cookbook 更新未改变 DeepSeek 文档或模型条目；相关增量集中在 SGLang 运行时 PR。
+
+`#21599` 把 EAGLE top-k=1 的 `speculative_num_steps` 做成自适应路径，改动覆盖 `server_args.py`、spec runtime state/params、EAGLE workers 和 runner。它会影响 V3/R1 MTP 性能调参：不应再假设 draft step 数是静态常量。`#22128` 允许 piecewise CUDA graph 与 speculative decoding 共存，相关逻辑在 `model_runner.py`、`piecewise_cuda_graph_runner.py` 和 server flag gate；因此排查 PCG + MTP 时不应再归类为“不支持组合”。
+
+`#22950` 是 closed 的 reasoning radix-cache strip 早期方案，涉及 model config、scheduler、radix cache 和 `reasoning_parser.py`；当前主线应以 merged `#23315` 为准。`#23315` 在 `server_args.py` 增加 opt-in 参数，并在 `schedule_batch.py` / `mem_cache/common.py` 里支持把 thinking tokens 从 radix-cache entry 中剥离，避免 `<think>` / `</think>` 这类 reasoning token 变成后续请求可复用 prefix。open `#23336` 则把 adaptive spec 推到 spec v2 的 `scheduler_output_processor_mixin.py`、`managers/utils.py`、`eagle_worker_v2.py` 和 `multi_layer_eagle_worker_v2.py`。
+
+## 3. 当前主线代码形态
+
+DeepSeek V3/R1 的当前主线不是一个新文件，而是复用 DeepSeek V2 时代演进出来的 `deepseek_v2.py`。`DeepseekV3ForCausalLM` 继承 `DeepseekV2ForCausalLM`，核心层包括 `DeepseekV2AttentionMLA`、`DeepseekV2MoE`、`DeepseekV2DecoderLayer` 和 `DeepseekV2Model`。因此，很多命名为 `deepseek_v2` 的修复实际会影响 V3、R1、V3.1 甚至 V3.2。
+
+当前主线最重要的共享模块是：
+
+- `python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py`：处理 stacked qkv/gate_up、expert 参数映射、`kv_b_proj` 后处理、W4AFP8 scale 映射、DeepGEMM BMM 所需权重变换。
+- `python/sglang/srt/models/deepseek_common/attention_backend_handler.py`：根据 backend、deterministic、PCG、MHA/MLA 选择 forward 方法。
+- `python/sglang/srt/models/deepseek_common/attention_forward_methods/`：承接 `#19122` 后的 MLA/MHA forward 逻辑。
+- `python/sglang/srt/models/deepseek_nextn.py`：MTP/NextN 草稿层。
+- `python/sglang/srt/parser/reasoning_parser.py`：`deepseek-r1` 和 `deepseek-v3` reasoning parser 的分界。
+- `python/sglang/srt/function_call/deepseekv3_detector.py`：V3/R1 tool call parser。
+- `python/sglang/srt/managers/schedule_batch.py` 和 `python/sglang/srt/mem_cache/common.py`：thinking token radix-cache strip 的当前主线路径。
+- `python/sglang/srt/server_args.py`：DeepSeek 系默认 attention backend、KV cache dtype、量化 backend、DeepEP/DP attention guard 的主要入口。
+
+`server_args.py` 现在对 DeepSeek V3/R1 做了几类自动选择：在 Blackwell SM100 上，如果没有手动指定 MLA backend，会默认选 `trtllm_mla`；官方 FP8 或 ModelOpt FP8/FP4 量化在合适条件下会倾向 `flashinfer_trtllm` MoE runner；如果启用 piecewise CUDA graph，V3/R1 会记录 “use MLA for prefill” 的路径；ROCm 则会走 AITER 相关 allreduce fusion 和 FP4/EAGLE 的 backend 默认值。这些默认值意味着排查性能问题时不能只看模型文件，必须把启动参数和 server-side 自动改写一起看。
+
+## 4. MLA 与权重加载：从基础支持到 Backend-Aware
+
+DeepSeek V3/R1 的注意力主线是 MLA。`DeepseekV2AttentionMLA` 会根据 `q_lora_rank`、`kv_lora_rank`、`qk_nope_head_dim`、`qk_rope_head_dim`、`v_head_dim` 构造 q/k/v latent projection。当前 main 中，`q_a_proj` 和 `kv_a_proj_with_mqa` 可以融合为 `fused_qkv_a_proj_with_mqa`，`kv_b_proj` 则在加载后被拆出 `w_kc`、`w_vc` 等 backend 需要的组件。
+
+`#16649` 把权重加载抽成 `DeepseekV2WeightLoaderMixin` 后，DeepSeek 系后续模型都复用这套逻辑。它的关键细节包括：
+
+- `gate_proj/up_proj` 堆叠到 `gate_up_proj`，q/k/v 相关权重按 MLA 结构做特殊映射。
+- expert 参数通过 `make_expert_params_mapping` 和 W4AFP8 input scale mapping 映射。
+- shared expert fusion 时，`mlp.shared_experts` 可以映射到 `mlp.experts.256`。
+- `kv_b_proj` 对 AWQ、FP8 block scale、DeepGEMM BMM 都有 post-load 处理。
+- R1 MXFP4 / NextN 某些 checkpoint 使用 `model.layers.61*` 命名，需要在 `deepseek_nextn.py` 做特殊处理。
+
+`#17744` 属于实用的 OOM 修复：它避免在加载大模型时直接 `dict(weights)`，减少内存尖峰。`#23195` 仍 open，它提示当前量化层可能没有 `.weight` 属性；如果 AWQ 或 compressed-tensors checkpoint 出现 MLA 初始化报错，应先检查这个方向，而不是误判为权重缺失。
+
+`#19122` 之后，MLA forward 被拆到 `attention_forward_methods`。这让 backend 切换更清楚，但也带来兼容性回归风险，因此 open `#22938` 仍在恢复 MI300X 的 DeepSeek MLA 路径，open `#21530` 仍在修 ROCm fused MLA decode RoPE。
+
+## 5. MoE 路由、共享专家与通信边界
+
+DeepSeek V3/R1 的 MoE 由 256 个 routed experts 加 shared experts 组成。当前 main 的 `DeepseekV2MoE` 会根据 config 和 server args 计算 `num_fused_shared_experts`。当共享专家融合启用时，loader 会把 `mlp.shared_experts` 重映射到 `mlp.experts.256`，让普通 routed expert 和 shared expert 进入同一个 fused MoE 计算表面。
+
+这个融合不是无条件开启：
+
+- TBO/SBO 会关闭融合。
+- DeepEP 默认关闭融合，除非显式设置 `--enforce-shared-experts-fusion`。
+- W4AFP8 会关闭融合，因为 routed experts 和 shared experts 可能使用不同量化方法。
+- 架构、expert 数、后端能力不匹配时也会关闭。
+
+DeepEP 下共享专家融合更复杂。普通融合是 `256 + 1`；DeepEP 融合会把本地 expert layout 扩成 `256 + EP_size`，TopK 需要处理 shared expert 在 EP rank 上的交错和映射。这个地方的 bug 往往表现为输出正确性或 double reduce，而不是单个 kernel 速度慢。`#23257` 仍 open，正是修 CuteDSL EP + DP attention 组合下 MoE 内部 allreduce 和外层 DP attention reduce 重叠的问题。
+
+路由侧的主线变化是 `#15347`。DeepSeek 的 biased grouped top-k 不再优先走通用 `moe_fused_gate`，而是在满足条件时用 `fused_topk_deepseek`。`#17707` 增加了 Blackwell router benchmark，`#22933` 扩展了无 scaling factor 时的 CPU shared-expert 接口，属于 CPU parity 清理而不是 H200 GPU 吞吐优化；open `#21531` 则把 `dsv3_router_gemm` 从 AOT sgl-kernel 迁到 JIT，是未来 router 维护性和部署便利性的重点。
+
+## 6. MTP / NextN：草稿层是独立运行面
+
+DeepSeek V3/R1 的 MTP 通过 EAGLE 和 `DeepseekV3ForCausalLMNextN` 实现。它不是简单复用主模型最后一层，而是有独立的 NextN layer、共享 embed/head、独立加载逻辑和可能不同的量化配置。
+
+当前 `deepseek_nextn.py` 的关键约束是：
+
+- 只支持一个 NextN layer。
+- target model 是 `DeepseekV3ForCausalLM`，draft model 是 `DeepseekV3ForCausalLMNextN`。
+- draft 层可能是 BF16，也可能有与 target 不同的量化处理。
+- AMD R1 MXFP4 有特殊命名和 shape 修复。
+- 某些 DeepEP BF16 dispatch 环境变量需要围绕 NextN 执行切换。
+
+`#7376` 修了 R1 FP4 MTP，`#13548` 修了 B200 V3 MTP，`#18607` 修了 AMD TP4 V3 MTP 精度，`#19425` 修了 R1-0528-MXFP4 的 draft loading shape。当前验证面里，H200 V3 MTP 注册测试要求 GSM8K 高于 `0.935`，平均 spec accept length 高于 `2.8`，并且 batch-size-1 吞吐超过普通 V3 lane。
+
+较新的 spec 线还补充了两个需要单独记录的约束：`#21599` 让 EAGLE top-k=1 的 draft step 数可以自适应，`#22128` 让 PCG 可以和 speculative decoding 共存。open `#23336` 还会继续改 spec v2 worker 的自适应路径。写 skill 或排查性能时，要把 target model、draft model、spec v1/v2、PCG 和 DP attention 一起记录。
+
+## 7. R1 W4AFP8 / W4A8 DeepEP：单独的量化优化梯子
+
+R1 W4AFP8 不能按普通 FP8 来理解。`#7762` 引入的 `W4AFp8Config` 会根据 quant config 判断 mixed precision，把普通 Linear 映射到 FP8 或非量化方法，把 MoE experts 映射到 W4A8。`cutlass_w4a8_moe.py` 处理 packed int4 expert weight、FP8 activation、input scale 和 grouped MoE runner。
+
+后续几个 PR 让这条路径完整起来：
+
+- `#8118` 给 R1-W4AFP8 加 TP mode。
+- `#8247` 加 normal DeepEP，核心是让 DeepEP dispatch metadata 能进入 W4A8 MoE 的 `apply_deepep_normal`。
+- `#8464` 加 low-latency DeepEP。
+- `#10027` 和 `#12921` 优化 W4AFP8 glue kernel 和 DeepSeek-V3-0324 的 W4AFP8 性能。
+
+low-latency DeepEP 的 FP8 通信线必须按 revert history 阅读：`#14162` 合入过 R1 W4A8 DeepEP LL FP8 communication，`#21719` 回滚，`#22316` 重新合入。只读 `#14162` 会得到错误结论，当前 main 的状态要以 `#22316` 之后的代码为准。
+
+## 8. 量化、平台和 parser 支持
+
+DeepSeek V3/R1 当前量化面很宽：
+
+- 官方 V3 FP8：不需要再手动声明 `--quantization fp8`，server 会识别量化配置。
+- FP4/NVFP4：`#11512`、`#11708`、`#12778` 让 Blackwell/SM120 默认值和 backend 选择更合理。
+- W4AFP8/W4A8：以 `w4afp8.py`、`cutlass_w4a8_moe.py`、DeepEP normal/LL 为中心。
+- MXFP4：`#15304` 修 AMD EP 精度，`#19425` 修 R1-0528-MXFP4 draft loading，open `#21529` 继续推进 ROCm Quark W4A4。
+- MXFP8：`#21280` 给 routed MoE 增加 MXFP8 支持。
+- LoRA：`#22323` 重构 LoRA quant info 并支持 DeepSeek V3 MLA LoRA；open `#22268` 指向 `prepare_qkv_latent` 可能绕过 adapter 的问题。
+
+parser 也要分清：V3/R1 tool calling 使用 `--tool-call-parser deepseekv3`，V3-style thinking 使用 `--reasoning-parser deepseek-v3`，R1 使用 `--reasoning-parser deepseek-r1`。R1 parser 会处理没有起始 `<think>` 的场景，在遇到 `</think>` 前强制当作 reasoning；这和 V3/V3.1 的 Qwen3-style thinking parser 不同。
+
+thinking parser 之外还要单独看 radix cache。`#23315` 的 opt-in strip 是 cache 层行为：它决定 thinking tokens 是否可以作为 prefix cache 内容复用；它不是 `deepseekv3_detector.py` 或 `reasoning_parser.py` 的 parser 格式变化。遇到多轮 reasoning 输出异常时，要同时记录 parser、strip flag 和缓存命中情况。
+
+## 9. 当前验证面与未合入方向
+
+当前 main 里的验证面包括：
+
+- `test/registered/8-gpu-models/test_deepseek_v3_basic.py`：H200 V3 基础精度和性能，GSM8K 阈值高于 `0.935`。
+- `test/registered/8-gpu-models/test_deepseek_v3_mtp.py`：H200 V3 MTP，检查 avg spec accept length 和吞吐。
+- `test/registered/amd/test_deepseek_v3_basic.py`、`test/registered/amd/test_deepseek_v3_mtp.py`、`test/registered/amd/test_deepseek_r1_mxfp4_8gpu.py`：AMD 基础、MTP、R1 MXFP4。
+- `test/registered/backends/test_deepseek_r1_fp8_trtllm_backend.py`：R1 FP8 TRTLLM backend。
+- `test/registered/quant/test_deepseek_v3_fp4_4gpu.py`、`test/registered/quant/test_w4a8_deepseek_v3.py`：FP4 和 W4A8。
+- `test/registered/mla/test_mla_deepseek_v3.py`、`test/registered/mla/test_mla_int8_deepseek_v3.py`：MLA 和 INT8 MLA。
+- `test/registered/lora/test_lora_deepseek_v3_base_logprob_diff.py`：LoRA logprob regression。
+- `test/registered/kernels/test_fused_topk_deepseek.py`：DeepSeek fused top-k。
+
+需要跟进的 open PR：
+
+- `#14194`：DeepSeek V2/V3 DCP。
+- `#15315`、`#15380`：DeepSeek-R1-W4AFP8 group GEMM。
+- `#18892`：DeepSeek V3 GEMM JIT。
+- `#21526`：ROCm AITER router GEMM regression。
+- `#21529`：ROCm DeepSeek 架构 MXFP4/Quark W4A4。
+- `#21530`：ROCm fused MLA decode RoPE。
+- `#21531`：`dsv3_router_gemm` JIT 迁移。
+- `#22268`：DeepSeek MLA LoRA adapter 旁路。
+- `#22774`：MUSA backend。
+- `#22938`：MLA refactor 后 MI300X DeepSeek path 恢复。
+- `#23195`：量化层 `.weight` 访问保护。
+- `#23257`：CuteDSL EP + DP attention double reduce。
+- `#23336`：spec v2 adaptive speculative decoding。

--- a/model-pr-optimization-history/deepseek-v31/README.en.md
+++ b/model-pr-optimization-history/deepseek-v31/README.en.md
@@ -1,0 +1,170 @@
+# SGLang DeepSeek V3.1 Support and Optimization Timeline
+
+This document is based on SGLang `origin/main` snapshot `929e00eea`, sgl-cookbook `origin/main` snapshot `8ec4d03`, and patch-level reading of DeepSeek V3.1 merged and open PRs. The scope only covers the independent DeepSeek V3.1 / DeepSeek-V3.1-Terminus differences: tool calling, thinking mode, chat template, streaming parser, structural tags, loading fixes, MTP validation, and MoE configs. The DeepSeek V3/R1 MLA, MoE, quantization, and DeepEP mainline is not repeated here, and DeepSeek V3.2 DSA/NSA sparse attention is documented separately.
+
+Conclusion: as of `929e00eea`, DeepSeek V3.1 still reuses `DeepseekV3ForCausalLM` and the `deepseek_v2.py` main model path. The independent pieces are the `deepseekv31` tool parser, `tool_chat_template_deepseekv31.jinja`, and the `thinking` chat-template parameter. V3.1's tool-call format differs from V3: it does not contain the `function` literal and does not use fenced JSON. Current main already has basic tool calling, thinking parser support, dict/string argument handling, structural trigger fix, and H200 TP8/MTP validation. Additional runtime items include thinking-token radix-cache stripping and inherited V3/R1 adaptive EAGLE, PCG plus speculative decoding, and spec-v2 adaptive spec. The open items are streaming argument loss, missing Assistant token after tool output, NPU deployment docs, parser CPU tests, and spec-v2 adaptive speculative decoding.
+
+## 1. Timeline Overview
+
+| Created | PR | State | Track | Code Area | Effect |
+| --- | ---: | --- | --- | --- | --- |
+| 2025-08-21 | [#9446](https://github.com/sgl-project/sglang/pull/9446) | merged | tool calling | `deepseekv31_detector.py`, V3.1 template, parser registration | Added the DeepSeek V3.1 tool-call parser and chat template. |
+| 2025-08-21 | [#9464](https://github.com/sgl-project/sglang/pull/9464) | merged | thinking parser | `serving_chat.py`, reasoning parser, docs | Added DeepSeek V3.1 thinking-mode support with `--reasoning-parser deepseek-v3`. |
+| 2025-08-23 | [#9544](https://github.com/sgl-project/sglang/pull/9544) | merged | docs | benchmark / basic usage docs | Added DeepSeek V3.1 support documentation. |
+| 2025-10-25 | [#12123](https://github.com/sgl-project/sglang/pull/12123) | merged | chat template | V3/V3.1/V3.2 templates, template test | Fixed double escaping when tool arguments are dicts or strings. |
+| 2025-11-13 | [#13190](https://github.com/sgl-project/sglang/pull/13190) | merged | nightly test | V3.1/V3.2 perf tests | Removed stale `enable_dp_attention`. |
+| 2025-11-17 | [#13394](https://github.com/sgl-project/sglang/pull/13394) | merged | structural tag | `DeepSeekV31Detector.structure_info` | Changed the structural trigger to generic `<｜tool▁call▁begin｜>`. |
+| 2025-11-26 | [#13954](https://github.com/sgl-project/sglang/pull/13954) | merged | loading | `deepseek_v2.py` | Fixed a DeepSeek V3.1 loading issue. |
+| 2026-01-07 | [#16660](https://github.com/sgl-project/sglang/pull/16660) | merged | CI | `test/registered/8-gpu-models/test_deepseek_v31.py` | Enabled DeepSeek V3.1 H200 nightly testing. |
+| 2026-01-15 | [#17133](https://github.com/sgl-project/sglang/pull/17133) | merged | MoE tuning | fused MoE Triton configs | Added H20/H20-3E FP8 MoE tuning configs for V3.1/V3.2 shapes. |
+| 2026-01-26 | [#17761](https://github.com/sgl-project/sglang/pull/17761) | open | chat template | V3.1/V3.2 templates | Fixes missing Assistant token after tool output. |
+| 2026-02-04 | [#18236](https://github.com/sgl-project/sglang/pull/18236) | open | streaming parser | `deepseekv31_detector.py` | Fixes missing first-chunk arguments and dropped normal text in streaming. |
+| 2026-03-28 | [#21599](https://github.com/sgl-project/sglang/pull/21599) | merged | MTP/spec | EAGLE runtime, spec workers | Added adaptive `speculative_num_steps` for EAGLE top-k=1, inherited by V3.1 MTP. |
+| 2026-03-31 | [#21739](https://github.com/sgl-project/sglang/pull/21739) | open | NPU docs | Ascend best-practice docs | Updates V3.1/V3.2 NPU deployment instructions. |
+| 2026-04-05 | [#22128](https://github.com/sgl-project/sglang/pull/22128) | merged | PCG/spec | model runner, PCG runner | Allowed piecewise CUDA graph to run with speculative decoding. |
+| 2026-04-09 | [#22433](https://github.com/sgl-project/sglang/pull/22433) | open | parser tests | `test_deepseekv31_detector.py` | Adds CPU unit tests for `DeepSeekV31Detector`. |
+| 2026-04-16 | [#22981](https://github.com/sgl-project/sglang/pull/22981) | open | parser tests | function-call detectors | Adds CPU tests for several missing function-call detectors. |
+| 2026-04-16 | [#22950](https://github.com/sgl-project/sglang/pull/22950) | closed | reasoning cache | model config, scheduler, radix cache, reasoning parser | Explored parser-gated two-phase reasoning radix-cache stripping and closed. |
+| 2026-04-21 | [#23315](https://github.com/sgl-project/sglang/pull/23315) | merged | reasoning cache | `schedule_batch.py`, `mem_cache/common.py`, `server_args.py` | Added opt-in thinking-token stripping from radix cache. |
+| 2026-04-21 | [#23336](https://github.com/sgl-project/sglang/pull/23336) | open | spec v2 | scheduler output processor, EAGLE v2 workers | Extends adaptive speculative decoding to spec v2. |
+
+## 1.1 Parser/Template Adjacent PRs
+
+The V3.1 parser/template coverage also includes these adjacent PRs:
+
+- `#9468`: updated reasoning-parser docs after `#9464` landed thinking-parser support.
+- `#9895` and `#14837`: updated `tool_chat_template_deepseekv31.jinja`; `#14837` is the 2025-12-10 auto-sync.
+- `#10550`, `#11223`, `#11589`, and `#21593`: tool-choice, tool-parser docs, `tool_choice="auto"` argument handling, and native-format constrained decoding/parser fixes that affect V3.1 tool serving.
+- `#10875`, `#11189`, and `#17178`: request-level thinking enablement, eval `--thinking-mode`, and removal of `deepseek-r1` from thinking-mode choices, which clarify the V3.1 thinking vs R1 parser boundary.
+- `#17141`, `#17320`, and `#17558`: closed attempts around `finish_reason="stop"` / Assistant-token behavior after tool content; open `#17761` remains the current tracker.
+- `#22950` and `#23315`: distinguish the closed reasoning-cache strip exploration from the current merged thinking-token radix-cache strip.
+- `#21599`, `#22128`, and `#23336`: speculative-decoding infrastructure inherited by V3.1 MTP, covering adaptive EAGLE, PCG plus speculative decoding, and spec-v2 adaptive spec.
+
+## 2. Why V3.1 Needs Its Own Document
+
+DeepSeek V3.1 still uses the shared DeepSeek V3/R1 compute backbone: `DeepseekV3ForCausalLM`, `DeepseekV2AttentionMLA`, `DeepseekV2MoE`, the shared DeepSeek weight loader, NextN/MTP, and server-side backend selection. If the issue is MLA backend, FP8/FP4/W4AFP8, shared-expert fusion, DeepEP, LoRA, MTP draft loading, or DP attention, use the DeepSeek V3/R1 document.
+
+However, V3.1 changes the user-visible serving behavior:
+
+- hybrid thinking: the same model can switch between thinking and non-thinking through the `thinking` parameter.
+- changed tool-call format: the function name comes immediately after `<｜tool▁call▁begin｜>`, with `<｜tool▁sep｜>` separating JSON arguments.
+- the chat template must handle system prompts, tools, assistant prefixes, tool outputs, thinking markers, and multi-turn tool calls.
+- the streaming parser is custom and is not equivalent to non-streaming parsing.
+- constrained decoding requires the correct `structure_info.trigger`.
+
+The main V3.1 value is not a new MLA kernel. It is the serving layer that turns the DeepSeek V3 backbone into an OpenAI-compatible agent and hybrid-reasoning model.
+
+## 3. `#9446`: V3.1 Tool-Call Parser and Template
+
+`#9446` added `examples/chat_template/tool_chat_template_deepseekv31.jinja`, `python/sglang/srt/function_call/deepseekv31_detector.py`, and the `deepseekv31` parser registration.
+
+The V3.1 tool-call format is:
+
+```text
+<｜tool▁calls▁begin｜>
+<｜tool▁call▁begin｜>{tool_name}<｜tool▁sep｜>{json_arguments}<｜tool▁call▁end｜>
+<｜tool▁calls▁end｜>
+```
+
+The differences from V3 are important:
+
+- V3.1 does not have the `function` literal in `<｜tool▁call▁begin｜>function<｜tool▁sep｜>`.
+- V3.1 arguments are direct JSON strings, not fenced in a Markdown `json` block.
+- Multiple tool calls are concatenated directly without extra separators.
+
+`DeepSeekV31Detector.detect_and_parse` first finds the outer `<｜tool▁calls▁begin｜>`, then uses `func_call_regex` to collect each `<｜tool▁call▁begin｜>...<｜tool▁call▁end｜>`, and finally uses `func_detail_regex` to split the function name and arguments. Arguments are parsed with `json.loads` and then passed to `parse_base_json` to match the OpenAI tool schema.
+
+This stage is about format correctness, not throughput. If V3 and V3.1 parsers are swapped, symptoms include parse failure, wrong function names, or arguments being returned as plain text.
+
+## 4. `#9464`: Thinking Mode Is Not the R1 Parser
+
+`#9464` added DeepSeek V3.1 thinking-parser support and docs. It established that V3.1 uses:
+
+```shell
+--reasoning-parser deepseek-v3
+```
+
+and enables thinking in requests with:
+
+```json
+{"chat_template_kwargs": {"thinking": true}}
+```
+
+This differs from R1. R1 uses the `deepseek-r1` parser, and that parser handles reasoning without an opening `<think>` tag. V3.1 is closer to Qwen3-style hybrid thinking: the chat template decides whether to inject `<think>` or `</think>`.
+
+In current `tool_chat_template_deepseekv31.jinja`, after the last user message, `add_generation_prompt` emits `<｜Assistant｜>` and then appends `<think>` or `</think>` based on `thinking`. If a previous assistant message contains `</think>`, the template strips the reasoning portion and preserves only content. This keeps historical messages and the next generation prompt in the same format.
+
+DeepSeek-V3.1-Speciale is an important exception. Current cookbook docs state that Speciale does not support tool calling; it should be treated as a deep-reasoning model, not a V3.1 tool-use target.
+
+Thinking mode also intersects with radix cache. `#22950` is the closed parser-gated reasoning-cache strip design; current main should be read from `#23315`, which adds an opt-in strip in `server_args.py`, `schedule_batch.py`, and `mem_cache/common.py` so thinking tokens can be removed from radix-cache entries. For V3.1, this is not a `deepseekv31` tool-parser change; it is cache-layer behavior that decides whether `<think>` / `</think>` can be reused through prefix cache.
+
+## 5. `#12123`: Avoid Double-Escaping Dict/String Arguments
+
+In multi-turn tool calling, `tool["function"]["arguments"]` can be a dict or an already serialized JSON string. If the template always applies `tojson`, an already serialized string becomes an escaped JSON string.
+
+`#12123` made the same fix across the V3, V3.1, and V3.2 DeepSeek templates:
+
+```jinja
+{% set formatted_args = tool['function']['arguments'] if tool['function']['arguments'] is string else tool['function']['arguments']|tojson %}
+```
+
+It also added `test_deepseek_chat_templates.py`, covering:
+
+- dict arguments must be JSON-encoded normally.
+- string arguments must be used as-is.
+- mixed dict and string arguments across multiple tool calls must not double-escape.
+
+This does not affect model throughput, but it directly affects agent multi-turn tool use because malformed historical tool calls poison the next prompt.
+
+## 6. `#13394`, `#18236`, and `#22433`: Structural Tags and Streaming Parser
+
+`#13394` fixed the constrained-decoding trigger. Previously `structure_info.trigger` included the concrete function name and `<｜tool▁sep｜>`, which meant structural constraints could only trigger after the function name was known. The fix made the trigger generic:
+
+```python
+trigger="<｜tool▁call▁begin｜>"
+```
+
+`begin` remains name-specific:
+
+```python
+begin="<｜tool▁call▁begin｜>" + name + "<｜tool▁sep｜>"
+```
+
+`#18236` is still open, but it documents two current streaming-parser risks. First, when the function name and JSON arguments arrive in the same chunk, current code may emit only the name and skip the first argument diff. Second, when plain text appears before the tool marker, streaming can return empty normal text even though non-streaming preserves the prefix. The PR adds `_normal_text_sent`, extracts normal text before the first `<｜tool▁call▁begin｜>`, and processes argument diffs whenever `func_args_raw` is non-empty.
+
+`#22433` is also open, but it defines the CPU tests that should remain long term: `has_tool_call`, no-tool plain text, single tool, multiple tools, invalid JSON fallback, unknown tool, unicode arguments, streaming chunks, tool index, `structure_info`, and structural tag support. Future V3.1 parser changes should start with this kind of CPU validation before running 8-GPU model tests.
+
+## 7. Loading, MTP, and MoE Configs
+
+`#13954` fixed a DeepSeek V3.1 loading issue in `deepseek_v2.py`. This reinforces that V3.1's compute path is shared DeepSeek infrastructure, while parser/template is the independent OpenAI-serving surface. If V3.1 launch fails during weight loading, MLA initialization, or MoE parameter mapping, do not focus only on `deepseekv31_detector.py`.
+
+`#16660` added DeepSeek V3.1 to H200 nightly testing with:
+
+- TP8 base.
+- TP8 plus EAGLE MTP with `SGLANG_ENABLE_SPEC_V2=1`.
+- GSM8K accuracy baseline `0.935`.
+- performance profiles written to `performance_profiles_deepseek_v31`.
+
+`#13190` removed stale `enable_dp_attention` from V3.1/V3.2 nightly perf tests so benchmark shapes match current server args.
+
+Inherited MTP infrastructure must also be checked: `#21599` makes EAGLE top-k=1 draft steps adaptive, `#22128` lets PCG coexist with speculative decoding, and open `#23336` carries adaptive spec into spec-v2 workers. Because the `#16660` V3.1 MTP lane explicitly uses `SGLANG_ENABLE_SPEC_V2=1`, these PRs are not V3.1 parser work, but they affect the real V3.1 TP8+MTP serving shape.
+
+`#17133` is the MoE-config performance line. It added H20 and H20-3E fused MoE configs for DeepSeek-family V3.1/V3.2 shapes. Typical filenames contain `E=257,N=256,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128]`. The `257` corresponds to 256 routed experts plus one fused shared expert.
+
+## 8. Current Validation Surface and Open PRs
+
+Current validation surface:
+
+- `test/manual/test_deepseek_v31.py`: TP8 and TP8+MTP, GSM8K baseline `0.935`.
+- `test/manual/nightly/test_deepseek_v31_perf.py`: V3.1 nightly performance.
+- `test/manual/test_deepseek_chat_templates.py`: V3/V3.1/V3.2 template dict/string argument tests.
+- open `#22433`'s `test/registered/unit/function_call/test_deepseekv31_detector.py`: recommended parser CPU test baseline.
+
+Open PRs to track:
+
+- `#17761`: missing Assistant token after V3.1/V3.2 tool output.
+- `#18236`: missing V3.1 streaming function-call arguments and normal text.
+- `#21739`: V3.1/V3.2 NPU deployment docs.
+- `#22433`: DeepSeekV31Detector CPU tests.
+- `#22981`: CPU tests for several missing function-call detectors.
+- `#23336`: spec-v2 adaptive speculative decoding.

--- a/model-pr-optimization-history/deepseek-v31/README.zh.md
+++ b/model-pr-optimization-history/deepseek-v31/README.zh.md
@@ -1,0 +1,170 @@
+# SGLang DeepSeek V3.1 支持与优化时间线
+
+本文基于 SGLang `origin/main` 最新快照 `929e00eea`、sgl-cookbook `origin/main` 快照 `8ec4d03`，以及 DeepSeek V3.1 相关 merged 和 open PR 的 patch 阅读结果整理。范围只覆盖 DeepSeek V3.1 / DeepSeek-V3.1-Terminus 的独立差异：tool calling、thinking mode、chat template、streaming parser、结构化标签、加载修复、MTP 验证和 MoE config。DeepSeek V3/R1 的 MLA、MoE、量化、DeepEP 主线不在本文重复，DeepSeek V3.2 的 DSA/NSA 稀疏注意力也单独成文。
+
+结论：截至 `929e00eea`，DeepSeek V3.1 仍复用 `DeepseekV3ForCausalLM` 和 `deepseek_v2.py` 的主模型路径，独立部分是 `deepseekv31` tool parser、`tool_chat_template_deepseekv31.jinja` 和 `thinking` chat-template 参数。V3.1 的 tool-call 格式和 V3 不同，不包含 `function` literal，也不使用 fenced JSON。当前 main 已有基础 tool calling、thinking parser、dict/string argument 类型处理、结构化标签 trigger 修复和 H200 TP8/MTP 验证；新增运行时内容包括 thinking token radix-cache strip，以及继承自 V3/R1 的 adaptive EAGLE、PCG + speculative decoding、spec v2 adaptive spec。后续需要跟进 open PR 里的 streaming 参数丢失、tool 输出后缺 Assistant token、NPU 部署文档、parser CPU 单测和 spec v2 自适应 speculative decoding。
+
+## 1. 时间线总览
+
+| 创建日期 | PR | 状态 | 主线 | 代码区域 | 作用 |
+| --- | ---: | --- | --- | --- | --- |
+| 2025-08-21 | [#9446](https://github.com/sgl-project/sglang/pull/9446) | merged | tool calling | `deepseekv31_detector.py`、V3.1 template、parser 注册 | 新增 DeepSeek V3.1 tool-call parser 和 chat template。 |
+| 2025-08-21 | [#9464](https://github.com/sgl-project/sglang/pull/9464) | merged | thinking parser | `serving_chat.py`、reasoning parser、docs | 增加 DeepSeek V3.1 thinking mode 支持，使用 `--reasoning-parser deepseek-v3`。 |
+| 2025-08-23 | [#9544](https://github.com/sgl-project/sglang/pull/9544) | merged | docs | benchmark / basic usage docs | 补充 DeepSeek V3.1 支持文档。 |
+| 2025-10-25 | [#12123](https://github.com/sgl-project/sglang/pull/12123) | merged | chat template | V3/V3.1/V3.2 templates、template test | 修复 tool arguments 是 dict 或 string 时的 double-escape 问题。 |
+| 2025-11-13 | [#13190](https://github.com/sgl-project/sglang/pull/13190) | merged | nightly test | V3.1/V3.2 perf tests | 移除过时的 `enable_dp_attention`。 |
+| 2025-11-17 | [#13394](https://github.com/sgl-project/sglang/pull/13394) | merged | structural tag | `DeepSeekV31Detector.structure_info` | 将 structural trigger 改成泛化的 `<｜tool▁call▁begin｜>`。 |
+| 2025-11-26 | [#13954](https://github.com/sgl-project/sglang/pull/13954) | merged | loading | `deepseek_v2.py` | 修复 DeepSeek V3.1 加载问题。 |
+| 2026-01-07 | [#16660](https://github.com/sgl-project/sglang/pull/16660) | merged | CI | `test/registered/8-gpu-models/test_deepseek_v31.py` | 开启 DeepSeek V3.1 H200 nightly 测试。 |
+| 2026-01-15 | [#17133](https://github.com/sgl-project/sglang/pull/17133) | merged | MoE tuning | fused MoE Triton configs | 为 V3.1/V3.2 的 H20/H20-3E FP8 MoE shape 增加 tuning config。 |
+| 2026-01-26 | [#17761](https://github.com/sgl-project/sglang/pull/17761) | open | chat template | V3.1/V3.2 templates | 修复 tool output 后缺少 Assistant token 的问题。 |
+| 2026-02-04 | [#18236](https://github.com/sgl-project/sglang/pull/18236) | open | streaming parser | `deepseekv31_detector.py` | 修复 streaming 下首 chunk 参数丢失和 normal text 丢失。 |
+| 2026-03-28 | [#21599](https://github.com/sgl-project/sglang/pull/21599) | merged | MTP/spec | EAGLE runtime、spec workers | 增加 EAGLE top-k=1 自适应 `speculative_num_steps`，V3.1 MTP 继承受益。 |
+| 2026-03-31 | [#21739](https://github.com/sgl-project/sglang/pull/21739) | open | NPU docs | Ascend best practice docs | 更新 V3.1/V3.2 NPU 部署说明。 |
+| 2026-04-05 | [#22128](https://github.com/sgl-project/sglang/pull/22128) | merged | PCG/spec | model runner、PCG runner | 允许 piecewise CUDA graph 和 speculative decoding 同时使用。 |
+| 2026-04-09 | [#22433](https://github.com/sgl-project/sglang/pull/22433) | open | parser tests | `test_deepseekv31_detector.py` | 增加 DeepSeekV31Detector CPU 单测。 |
+| 2026-04-16 | [#22981](https://github.com/sgl-project/sglang/pull/22981) | open | parser tests | function-call detectors | 给多个缺失的 function-call detector 增加 CPU 单测。 |
+| 2026-04-16 | [#22950](https://github.com/sgl-project/sglang/pull/22950) | closed | reasoning cache | model config、scheduler、radix cache、reasoning parser | 探索 parser-gated 两阶段 reasoning radix-cache stripping，已关闭。 |
+| 2026-04-21 | [#23315](https://github.com/sgl-project/sglang/pull/23315) | merged | reasoning cache | `schedule_batch.py`、`mem_cache/common.py`、`server_args.py` | 增加可选的 thinking token radix-cache strip。 |
+| 2026-04-21 | [#23336](https://github.com/sgl-project/sglang/pull/23336) | open | spec v2 | scheduler output processor、EAGLE v2 workers | 把 adaptive speculative decoding 扩展到 spec v2。 |
+
+## 1.1 Parser/Template 周边 PR
+
+V3.1 的 parser/template 周边还需要显式记录这些 PR：
+
+- `#9468`：更新 reasoning parser 文档，承接 `#9464` 的 thinking parser 支持。
+- `#9895`、`#14837`：两次更新 `tool_chat_template_deepseekv31.jinja`，其中 `#14837` 是 2025-12-10 的 auto-sync。
+- `#10550`、`#11223`、`#11589`、`#21593`：tool-choice、tool parser 文档、`tool_choice="auto"` 参数处理、native-format constrained decoding/parser 修复，都会影响 V3.1 tool serving。
+- `#10875`、`#11189`、`#17178`：请求级 thinking 开关、eval `--thinking-mode`、以及移除 `deepseek-r1` thinking-mode choice，帮助界定 V3.1 thinking 与 R1 parser 的边界。
+- `#17141`、`#17320`、`#17558`：tool 内容后 `finish_reason="stop"` / Assistant token 的 closed 尝试；当前仍以 open `#17761` 作为跟踪入口。
+- `#22950`、`#23315`：区分已关闭的 reasoning-cache strip 探索和当前 merged 的 thinking token radix-cache strip。
+- `#21599`、`#22128`、`#23336`：V3.1 MTP 继承的 speculative decoding 基础设施，分别对应 adaptive EAGLE、PCG + speculative decoding、spec v2 adaptive spec。
+
+## 2. 为什么 V3.1 要单独写
+
+DeepSeek V3.1 的模型计算主干仍然是 DeepSeek V3/R1 共享路径：`DeepseekV3ForCausalLM`、`DeepseekV2AttentionMLA`、`DeepseekV2MoE`、共享的 DeepSeek weight loader、NextN/MTP 和 server-side backend 选择。因此，如果问题是 MLA backend、FP8/FP4/W4AFP8、shared expert fusion、DeepEP、LoRA、MTP draft loading 或 DP attention，应回到 DeepSeek V3/R1 文档排查。
+
+但 V3.1 的用户可见行为发生了明显变化：
+
+- hybrid thinking：同一个模型可以通过 `thinking` 参数切换思考和非思考。
+- tool-call 格式变了：函数名直接跟在 `<｜tool▁call▁begin｜>` 后面，中间用 `<｜tool▁sep｜>` 分隔 JSON 参数。
+- chat template 需要同时处理 system prompt、tools、assistant prefix、tool output、thinking 标记和多轮 tool call。
+- streaming parser 是自定义的，不等价于 non-streaming parser。
+- constrained decoding 需要正确的 `structure_info.trigger`。
+
+所以 V3.1 的核心价值不是新 MLA kernel，而是把 DeepSeek V3 主干包装成可用于 agent 和 hybrid reasoning 的 OpenAI-compatible serving 形态。
+
+## 3. `#9446`：V3.1 tool-call parser 和 template
+
+`#9446` 新增了 `examples/chat_template/tool_chat_template_deepseekv31.jinja`、`python/sglang/srt/function_call/deepseekv31_detector.py`，并把 `deepseekv31` 注册进 function-call parser 表。
+
+V3.1 的 tool-call 格式是：
+
+```text
+<｜tool▁calls▁begin｜>
+<｜tool▁call▁begin｜>{tool_name}<｜tool▁sep｜>{json_arguments}<｜tool▁call▁end｜>
+<｜tool▁calls▁end｜>
+```
+
+和 V3 的区别很关键：
+
+- V3.1 没有 `<｜tool▁call▁begin｜>function<｜tool▁sep｜>` 里的 `function` literal。
+- V3.1 参数是直接 JSON 字符串，不包在 ```json fenced block 里。
+- 多个 tool call 直接连续拼接，不插入额外分隔符。
+
+`DeepSeekV31Detector.detect_and_parse` 的逻辑是先找到外层 `<｜tool▁calls▁begin｜>`，再用 `func_call_regex` 抓每个 `<｜tool▁call▁begin｜>...<｜tool▁call▁end｜>`，最后用 `func_detail_regex` 拆出函数名和参数。参数通过 `json.loads` 解析后，再交给 `parse_base_json` 对齐 OpenAI tool schema。
+
+这一阶段的重点是格式正确，而不是性能。只要 V3/V3.1 parser 互换，就会出现无法解析、函数名不对或参数被当普通文本的症状。
+
+## 4. `#9464`：thinking mode 不是 R1 parser
+
+`#9464` 增加了 DeepSeek V3.1 thinking parser 支持和文档。它明确了 V3.1 使用：
+
+```shell
+--reasoning-parser deepseek-v3
+```
+
+并在请求里通过：
+
+```json
+{"chat_template_kwargs": {"thinking": true}}
+```
+
+打开 thinking。这个行为和 R1 不同。R1 使用 `deepseek-r1` parser，且 R1 parser 会处理没有 `<think>` 开头的 reasoning；V3.1 更接近 Qwen3-style hybrid thinking，由 chat template 决定是否注入 `<think>` 或 `</think>`。
+
+当前 `tool_chat_template_deepseekv31.jinja` 中，最后 user 后如果 `add_generation_prompt` 为 true，会输出 `<｜Assistant｜>`，然后根据 `thinking` 决定追加 `<think>` 或 `</think>`。assistant 消息自身如果包含 `</think>`，模板会切掉 reasoning 部分，只保留 content 输出。这是为了让历史消息和下一轮 generation 的格式保持一致。
+
+DeepSeek-V3.1-Speciale 是重要例外。cookbook 当前明确写了 Speciale 不支持 tool calling，应视为 deep reasoning 模型，而不是 V3.1 tool-use 目标。
+
+thinking mode 还会和 radix cache 交叉。`#22950` 是 closed 的 parser-gated reasoning cache strip 方案；当前 main 要看 `#23315`，它在 `server_args.py`、`schedule_batch.py` 和 `mem_cache/common.py` 增加 opt-in strip，把 thinking tokens 从 radix-cache entry 中剥离。对 V3.1 来说，这不是 `deepseekv31` tool parser 变化，而是决定 `<think>` / `</think>` 是否会被 prefix cache 复用的缓存层行为。
+
+## 5. `#12123`：dict/string 参数不 double-escape
+
+多轮 tool calling 里，OpenAI API 对象中的 `tool["function"]["arguments"]` 有时是 dict，有时已经是 JSON 字符串。如果模板一律 `tojson`，已经序列化过的字符串会变成带反斜杠的 JSON string。
+
+`#12123` 对 V3、V3.1、V3.2 三个 DeepSeek template 做了同样修复：
+
+```jinja
+{% set formatted_args = tool['function']['arguments'] if tool['function']['arguments'] is string else tool['function']['arguments']|tojson %}
+```
+
+同时补了 `test_deepseek_chat_templates.py`，覆盖：
+
+- dict 参数要被正常 JSON 编码。
+- string 参数要原样使用。
+- 多个 tool call 中 dict 和 string 混合时都不能 double-escape。
+
+这类问题不会体现在模型吞吐上，但会直接破坏 agent 多轮 tool-use，因为下一轮 prompt 里的历史 tool call 会变成错误 JSON。
+
+## 6. `#13394`、`#18236`、`#22433`：结构化标签与 streaming parser
+
+`#13394` 修的是 constrained decoding 触发点。原来 `structure_info.trigger` 包含函数名和 `<｜tool▁sep｜>`，这意味着 parser 只有在知道具体函数名后才触发结构约束。修复后 trigger 是通用的：
+
+```python
+trigger="<｜tool▁call▁begin｜>"
+```
+
+`begin` 仍然是 name-specific：
+
+```python
+begin="<｜tool▁call▁begin｜>" + name + "<｜tool▁sep｜>"
+```
+
+`#18236` 仍 open，但它指出了当前 streaming parser 的两个风险。第一，如果函数名和 JSON 参数出现在同一个 chunk，当前代码可能只发出 name，不处理首个参数 diff。第二，如果 tool marker 前有普通文本，streaming 路径可能返回空 normal_text，而 non-streaming 是能保留前缀文本的。PR 方案是增加 `_normal_text_sent`，并在第一次看到 `<｜tool▁call▁begin｜>` 时切出 marker 前的 normal text，同时只要 `func_args_raw` 非空就处理参数 diff。
+
+`#22433` 也是 open，但它补齐了长期应保留的 CPU 单测形状：`has_tool_call`、无 tool call 普通文本、单 tool、多 tool、invalid JSON fallback、unknown tool、unicode 参数、streaming chunk、tool index、`structure_info` 和 structural tag support。后续修改 V3.1 parser 时，最小验证面应先覆盖这类 CPU 单测，再运行 8 卡模型验证。
+
+## 7. 加载、MTP 和 MoE config
+
+`#13954` 修复 DeepSeek V3.1 loading issue，落点是 `deepseek_v2.py`。这再次说明 V3.1 的模型计算面是共享 DeepSeek 主干，parser/template 只是独立的 OpenAI serving 面。如果 V3.1 launch 在权重加载、MLA 初始化、MoE 参数映射上失败，不应只看 `deepseekv31_detector.py`。
+
+`#16660` 把 DeepSeek V3.1 纳入 H200 nightly，测试包含：
+
+- TP8 base。
+- TP8 + EAGLE MTP，附带 `SGLANG_ENABLE_SPEC_V2=1`。
+- accuracy 使用 GSM8K，baseline `0.935`。
+- performance profile 输出到 `performance_profiles_deepseek_v31`。
+
+`#13190` 移除 V3.1/V3.2 nightly perf 里的过时 `enable_dp_attention`，避免性能测试还带着旧 server args 时代的配置。
+
+继承的 MTP 基础设施也要一起看：`#21599` 让 EAGLE top-k=1 draft step 数可自适应，`#22128` 让 PCG 可以和 speculative decoding 共存，open `#23336` 把 adaptive spec 推到 spec v2 workers。因为 `#16660` 的 V3.1 MTP lane 明确带 `SGLANG_ENABLE_SPEC_V2=1`，这些 PR 不是 V3.1 parser 工作，但会影响 V3.1 TP8+MTP 的真实运行形态。
+
+`#17133` 则是 MoE config 性能线。它为 V3.1/V3.2 的 DeepSeek-family shape 加入 H20 和 H20-3E fused MoE config，典型文件名包含 `E=257,N=256,device_name=NVIDIA_H20,dtype=fp8_w8a8,block_shape=[128, 128]`。这里的 `257` 对应 256 routed experts 加 fused shared expert 的形态。
+
+## 8. 当前验证面与未合入方向
+
+当前验证面：
+
+- `test/manual/test_deepseek_v31.py`：TP8 和 TP8+MTP，GSM8K baseline `0.935`。
+- `test/manual/nightly/test_deepseek_v31_perf.py`：V3.1 nightly perf。
+- `test/manual/test_deepseek_chat_templates.py`：V3/V3.1/V3.2 template dict/string 参数测试。
+- open `#22433` 的 `test/registered/unit/function_call/test_deepseekv31_detector.py`：可作为 parser CPU 单测基线。
+
+需要跟进的 open PR：
+
+- `#17761`：V3.1/V3.2 tool output 后缺 Assistant token。
+- `#18236`：V3.1 streaming function-call 参数和 normal text 丢失。
+- `#21739`：V3.1/V3.2 NPU 部署文档。
+- `#22433`：DeepSeekV31Detector CPU 单测。
+- `#22981`：多个 function-call detector 的 CPU 单测补齐。
+- `#23336`：spec v2 adaptive speculative decoding。

--- a/model-pr-optimization-history/deepseek-v32/README.en.md
+++ b/model-pr-optimization-history/deepseek-v32/README.en.md
@@ -1,0 +1,359 @@
+# SGLang DeepSeek V3.2 Support and Optimization Timeline
+
+This document is based on SGLang `origin/main` snapshot `929e00eea`, sgl-cookbook `origin/main` snapshot `8ec4d03`, and patch-level reading of DeepSeek V3.2 / DSA / NSA merged and open PRs. The scope covers DeepSeek-V3.2-Exp, DeepSeek-V3.2, DeepSeek-V3.2-Speciale, DeepSeek-V3.2-NVFP4, DeepSeek-V3.2-MXFP4, and their SGLang evolution across DSA/NSA, Indexer, KV cache, Context Parallel, MTP, IndexCache, DSML parser, AMD/NPU/Blackwell backends, tests, and docs.
+
+Conclusion: as of `929e00eea`, DeepSeek V3.2 is a separate DeepSeek architecture path. It enters the DSA/NSA sparse-attention stack through `is_deepseek_nsa(config)`. The current main runtime entry is `DeepseekV32ForCausalLM`, and the core runtime surface is `nsa_indexer.py`, `nsa_backend.py`, `deepseek_v2.py`, `deepseek_nextn.py`, and `server_args.py`. Main already supports base DSA, NSA backend auto-selection, BF16/FP8 KV cache, MTP, CP, PP, DP attention, TRTLLM/FlashMLA/FA3/TileLang/AITER backends, NVFP4, AMD MXFP4/FP8 KV, NPU, HiSparse/HiCache, IndexCache, and the DSML tool parser. Additional runtime items include CP all-reduce fusion, `moe_dp_size=1` with `attention_cp_size`, adaptive EAGLE, PCG plus speculative decoding, shared `deepseek_nextn.py` changes, and thinking-token radix-cache stripping. The main open tracks are NSA PCG, spec-v2 adaptive spec, CPU/GPU sparse KV scheduling, TP-SP, V3.2 DCP, AMD CP round-robin, IndexCache/top-k backend work, short-sequence dense fallback, partial JSON parsing, and HiCache/3FS.
+
+## 1. Timeline Overview
+
+| Created | PR | State | Track | Effect |
+| --- | ---: | --- | --- | --- |
+| 2025-09-25 | [#10912](https://github.com/sgl-project/sglang/pull/10912) | merged | PD | Added PD support for hybrid models including DeepSeek V3.2 Exp. |
+| 2025-09-29 | [#11061](https://github.com/sgl-project/sglang/pull/11061) | merged | bring-up | Supported DeepSeek V3.2 Exp and added NSA backend, Indexer, sparse attention plumbing, KV quant/dequant, memory pool, runner, and tests. |
+| 2025-10-03 | [#11191](https://github.com/sgl-project/sglang/pull/11191) | open | sparse KV | Supports CPU/GPU KV-cache scheduling for GQA/DSA sparse attention. |
+| 2025-10-12 | [#11510](https://github.com/sgl-project/sglang/pull/11510) | merged | bugfix | Fixed Qwen3/DSV3/DSV3.2 model support. |
+| 2025-10-15 | [#11652](https://github.com/sgl-project/sglang/pull/11652) | merged | MTP | Added MTP for DSV3.2. |
+| 2025-10-20 | [#11877](https://github.com/sgl-project/sglang/pull/11877) | merged | docs | Added DeepSeek V3.2 documentation. |
+| 2025-10-21 | [#11936](https://github.com/sgl-project/sglang/pull/11936) | merged | NSA tests | Added V3.2 NSA backend testing. |
+| 2025-10-24 | [#12044](https://github.com/sgl-project/sglang/pull/12044) | merged | Indexer | Enabled the mixed-type LayerNorm kernel for NSA Indexer. |
+| 2025-10-24 | [#12065](https://github.com/sgl-project/sglang/pull/12065) | merged | CP | Added initial Context Parallel support for DeepSeek V3.2 DSA. |
+| 2025-10-25 | [#12123](https://github.com/sgl-project/sglang/pull/12123) | merged | template | Fixed dict/string handling for tool arguments in DeepSeek templates. |
+| 2025-10-28 | [#12296](https://github.com/sgl-project/sglang/pull/12296) | merged | docs | Updated `deepseek_v32.md`. |
+| 2025-11-08 | [#12868](https://github.com/sgl-project/sglang/pull/12868) | merged | docs | Documented V3.2 MHA short-sequence prefill. |
+| 2025-11-20 | [#13646](https://github.com/sgl-project/sglang/pull/13646) | merged | TP/DP attention | Enabled pure TP and partial DP attention. |
+| 2025-11-23 | [#13812](https://github.com/sgl-project/sglang/pull/13812) | merged | Indexer perf | Optimized NSA Indexer K/S buffer access with fused Triton kernels. |
+| 2025-11-26 | [#13959](https://github.com/sgl-project/sglang/pull/13959) | merged | CP perf | Optimized CP with fused MoE, multi-batch, and FP8 KV cache. |
+| 2025-12-06 | [#14541](https://github.com/sgl-project/sglang/pull/14541) | merged | NPU CP | Added V3.2 CP support for NPU. |
+| 2025-12-07 | [#14572](https://github.com/sgl-project/sglang/pull/14572) | merged | NPU perf | Added V3.2 NPU optimizations. |
+| 2025-12-14 | [#15088](https://github.com/sgl-project/sglang/pull/15088) | merged | MTP tests | Added pure TP + MTP testing. |
+| 2025-12-17 | [#15307](https://github.com/sgl-project/sglang/pull/15307) | merged | spec overlap | Supported overlap speculative decoding plus NSA. |
+| 2025-12-18 | [#15381](https://github.com/sgl-project/sglang/pull/15381) | merged | NPU | Added NPU MLA prolog support. |
+| 2025-12-27 | [#15938](https://github.com/sgl-project/sglang/pull/15938) | merged | env cleanup | Cleaned V3.2 environment variables. |
+| 2025-12-30 | [#16119](https://github.com/sgl-project/sglang/pull/16119) | merged | CP bugfix | Fixed V3.2 CP issues. |
+| 2025-12-30 | [#16156](https://github.com/sgl-project/sglang/pull/16156) | merged | CP guard | Added assertion for V3.2 CP in PD decode mode. |
+| 2026-01-02 | [#16305](https://github.com/sgl-project/sglang/pull/16305) | merged | V32/CP updates | Added multiple DeepSeek V32 and CP updates. |
+| 2026-01-02 | [#16306](https://github.com/sgl-project/sglang/pull/16306) | merged | refactor | Refactored DeepSeek attention backend handlers and forward-method definitions. |
+| 2026-01-04 | [#16380](https://github.com/sgl-project/sglang/pull/16380) | merged | PP/CP | Supported and optimized PP when context pipeline is enabled. |
+| 2026-01-07 | [#16637](https://github.com/sgl-project/sglang/pull/16637) | merged | Indexer overlap | Overlapped Indexer `weights_proj` during dual-stream decode. |
+| 2026-01-11 | [#16907](https://github.com/sgl-project/sglang/pull/16907) | merged | AWQ loading | Fixed DeepSeek-V3.2-AWQ loading. |
+| 2026-01-12 | [#16916](https://github.com/sgl-project/sglang/pull/16916) | merged | docs | Added V3.2 CP+PP documentation. |
+| 2026-01-12 | [#16961](https://github.com/sgl-project/sglang/pull/16961) | merged | MTP perf | Optimized MTP decode CUDA batch sizes and NSA implementation. |
+| 2026-01-13 | [#16990](https://github.com/sgl-project/sglang/pull/16990) | merged | NPU bugfix | Fixed V3.2 weight-cast bug. |
+| 2026-01-13 | [#17007](https://github.com/sgl-project/sglang/pull/17007) | merged | NPU bugfix | Fixed V3.2 and DSVL2 NPU issues. |
+| 2026-01-14 | [#17076](https://github.com/sgl-project/sglang/pull/17076) | merged | Indexer/FA3 | Fixed sliced indexer and FA3 padding when CUDA graph cannot run. |
+| 2026-01-15 | [#17133](https://github.com/sgl-project/sglang/pull/17133) | merged | MoE tuning | Added H20/H20-3E fused MoE configs for V3.1/V3.2. |
+| 2026-01-23 | [#17657](https://github.com/sgl-project/sglang/pull/17657) | merged | NVFP4 | Updated tests and docs for V3.2 NVFP4 checkpoint. |
+| 2026-01-23 | [#17662](https://github.com/sgl-project/sglang/pull/17662) | merged | TRTLLM NSA | Fixed TRT-LLM NSA in target_verify/draft_extend. |
+| 2026-01-25 | [#17688](https://github.com/sgl-project/sglang/pull/17688) | merged | Indexer overlap | Overlapped Indexer q/k projection and activation quantization. |
+| 2026-01-26 | [#17783](https://github.com/sgl-project/sglang/pull/17783) | merged | AMD docs | Updated V3.2 AMD GPU docs and unified the ROCm TileLang build. |
+| 2026-02-05 | [#18280](https://github.com/sgl-project/sglang/pull/18280) | merged | CP scale | Added CP support for `get_index_k_scale_buffer`. |
+| 2026-02-07 | [#18389](https://github.com/sgl-project/sglang/pull/18389) | merged | NVFP4/TRTLLM | Added NSA TRTLLM sparse MLA FP8 support for DeepSeek V3.2 NVFP4. |
+| 2026-02-10 | [#18553](https://github.com/sgl-project/sglang/pull/18553) | merged | bugfix | Fixed a V3.2 bug. |
+| 2026-02-11 | [#18613](https://github.com/sgl-project/sglang/pull/18613) | merged | CP default | Changed default CP token split to `round-robin-split`. |
+| 2026-02-16 | [#18876](https://github.com/sgl-project/sglang/pull/18876) | merged | MoE tune | Added DeepSeek3.2 and GLM-MoE-DSA into MoE tuning. |
+| 2026-02-17 | [#18931](https://github.com/sgl-project/sglang/pull/18931) | merged | FP8 KV | Fixed NSA FP8 KV-cache path for both-TRTLLM MHA one-shot. |
+| 2026-02-18 | [#18978](https://github.com/sgl-project/sglang/pull/18978) | merged | AMD MTP | Fixed MI35x V3.2 MTP nightly. |
+| 2026-02-19 | [#19016](https://github.com/sgl-project/sglang/pull/19016) | merged | spec bugfix | Fixed NSA backend page-table overflow in target_verify. |
+| 2026-02-20 | [#19041](https://github.com/sgl-project/sglang/pull/19041) | merged | quality | Avoided FP32 precision loss in `weights_proj`. |
+| 2026-02-20 | [#19062](https://github.com/sgl-project/sglang/pull/19062) | merged | MTP/CP | Fixed MTP and CP compatibility. |
+| 2026-02-21 | [#19122](https://github.com/sgl-project/sglang/pull/19122) | merged | MLA refactor | Migrated DeepSeek MLA forward methods. |
+| 2026-02-22 | [#19148](https://github.com/sgl-project/sglang/pull/19148) | merged | JIT kernel | Added NSA fused-store Indexer K-cache JIT kernel. |
+| 2026-02-25 | [#19319](https://github.com/sgl-project/sglang/pull/19319) | merged | 128K bugfix | Fixed `get_k_and_s_triton` for 128K sequence length. |
+| 2026-02-25 | [#19367](https://github.com/sgl-project/sglang/pull/19367) | merged | MTP/CP | Fixed NSA CP position mismatch in EAGLE NextN. |
+| 2026-02-26 | [#19428](https://github.com/sgl-project/sglang/pull/19428) | merged | qlora/ag | Added `mla_ag_after_qlora` for V3.2. |
+| 2026-02-28 | [#19536](https://github.com/sgl-project/sglang/pull/19536) | merged | MTP metadata | Optimized NSA backend metadata under MTP. |
+| 2026-03-05 | [#19945](https://github.com/sgl-project/sglang/pull/19945) | merged | AMD TileLang | Added TileLang sparse forward for V3.2 MI355/MI300. |
+| 2026-03-07 | [#20086](https://github.com/sgl-project/sglang/pull/20086) | merged | NVFP4 default | Changed V3.2 NVFP4 TP4 defaults. |
+| 2026-03-11 | [#20326](https://github.com/sgl-project/sglang/pull/20326) | merged | docs | Added DSA/NSA attention backend to the support matrix. |
+| 2026-03-12 | [#20438](https://github.com/sgl-project/sglang/pull/20438) | merged | CP perf | Overlapped NSA-CP key all-gather with query computation. |
+| 2026-03-13 | [#20492](https://github.com/sgl-project/sglang/pull/20492) | merged | EAGLE3/DP | Fixed DeepSeek Eagle3 in Attn-DP mode. |
+| 2026-03-15 | [#20606](https://github.com/sgl-project/sglang/pull/20606) | merged | FP8 KV offset | Computed `topk_indices_offset` for flashmla_sparse with FP8 KV cache. |
+| 2026-03-18 | [#20840](https://github.com/sgl-project/sglang/pull/20840) | merged | AMD accuracy | Fixed V3.2 accuracy on MI355. |
+| 2026-03-20 | [#20984](https://github.com/sgl-project/sglang/pull/20984) | merged | FP4 test | Fixed DeepSeek V32 FP4 test. |
+| 2026-03-20 | [#21003](https://github.com/sgl-project/sglang/pull/21003) | merged | revert | Reverted `#20984`. |
+| 2026-03-23 | [#21192](https://github.com/sgl-project/sglang/pull/21192) | merged | CP tests | Fixed CP in-seq-split and updated tests. |
+| 2026-03-24 | [#21249](https://github.com/sgl-project/sglang/pull/21249) | merged | CP/all-reduce | Supported all-reduce fusion with context parallel. |
+| 2026-03-24 | [#21259](https://github.com/sgl-project/sglang/pull/21259) | merged | HiCache | Added mooncake backend support for DSA and mamba hybrid models. |
+| 2026-03-24 | [#21337](https://github.com/sgl-project/sglang/pull/21337) | merged | B200+DP perf | Added a workaround for DSA performance drop on B200 + DP. |
+| 2026-03-25 | [#21405](https://github.com/sgl-project/sglang/pull/21405) | merged | IndexCache | Enabled IndexCache for DeepSeek V3.2. |
+| 2026-03-26 | [#21468](https://github.com/sgl-project/sglang/pull/21468) | merged | NPU docs | Updated V3.2 NPU deployment docs. |
+| 2026-03-27 | [#21511](https://github.com/sgl-project/sglang/pull/21511) | merged | AMD FP8 KV | Enabled FP8 KV cache and FP8 attention kernel for NSA TileLang. |
+| 2026-03-28 | [#21585](https://github.com/sgl-project/sglang/pull/21585) | merged | CI | Moved V3.2 CP test to the DeepEP suite. |
+| 2026-03-28 | [#21599](https://github.com/sgl-project/sglang/pull/21599) | merged | MTP/spec | Added adaptive `speculative_num_steps` for EAGLE top-k=1. |
+| 2026-03-31 | [#21783](https://github.com/sgl-project/sglang/pull/21783) | merged | TRTLLM prefill | Supported TRTLLM sparse MLA kernel for DSA prefill batches. |
+| 2026-04-02 | [#21914](https://github.com/sgl-project/sglang/pull/21914) | merged | Blackwell default | Set TRTLLM kernels as the default for Blackwell DSA. |
+| 2026-04-03 | [#22003](https://github.com/sgl-project/sglang/pull/22003) | merged | CP topology | Supported `moe_dp_size = 1` with different `attention_cp_size` values. |
+| 2026-04-03 | [#22065](https://github.com/sgl-project/sglang/pull/22065) | merged | HiSparse guard | Temporarily allowed HiSparse only for DSA models. |
+| 2026-04-05 | [#22128](https://github.com/sgl-project/sglang/pull/22128) | merged | PCG/spec | Allowed piecewise CUDA graph to run with speculative decoding. |
+| 2026-04-06 | [#22179](https://github.com/sgl-project/sglang/pull/22179) | merged | docs | Improved DeepSeek V3.2 / GLM-5 docs. |
+| 2026-04-07 | [#22232](https://github.com/sgl-project/sglang/pull/22232) | merged | Indexer perf | Reduced unnecessary kernels and copies in NSA Indexer. |
+| 2026-04-07 | [#22258](https://github.com/sgl-project/sglang/pull/22258) | merged | AMD perf | Added BF16 passthrough from RMSNorm in AMD/HIP NSA to avoid FP8 dequantization. |
+| 2026-04-08 | [#22372](https://github.com/sgl-project/sglang/pull/22372) | merged | Hopper FP8 KV | Added Hopper FP8 FlashMLA KV padding. |
+| 2026-04-08 | [#22390](https://github.com/sgl-project/sglang/pull/22390) | merged | AR fusion | Enabled all-reduce fusion for DSA models. |
+| 2026-04-09 | [#22424](https://github.com/sgl-project/sglang/pull/22424) | merged | AMD LayerNorm | Used AITER CK LayerNorm2D to reduce NSA Indexer kernel launches. |
+| 2026-04-09 | [#22425](https://github.com/sgl-project/sglang/pull/22425) | merged | HiSparse CI | Added HiSparse-DSA nightly CI. |
+| 2026-04-09 | [#22430](https://github.com/sgl-project/sglang/pull/22430) | merged | DSA bugfix | Fixed several DSA model bugs. |
+| 2026-04-15 | [#22850](https://github.com/sgl-project/sglang/pull/22850) | merged | AMD Indexer perf | Fused weights projection and K-cache store to reduce NSA Indexer kernels. |
+| 2026-04-16 | [#22914](https://github.com/sgl-project/sglang/pull/22914) | merged | CP refactor | Deduplicated NSA utils into CP utils. |
+| 2026-04-16 | [#22950](https://github.com/sgl-project/sglang/pull/22950) | closed | reasoning cache | Explored parser-gated two-phase reasoning radix-cache stripping and closed. |
+| 2026-04-20 | [#23219](https://github.com/sgl-project/sglang/pull/23219) | merged | shared NextN | Enabled MTP for GLM-5 MXFP4 by touching shared `deepseek_nextn.py`. |
+| 2026-04-21 | [#23315](https://github.com/sgl-project/sglang/pull/23315) | merged | reasoning cache | Added opt-in thinking-token stripping from radix cache. |
+| 2026-04-21 | [#23336](https://github.com/sgl-project/sglang/pull/23336) | open | spec v2 | Extends adaptive speculative decoding to spec v2. |
+| 2026-04-21 | [#23351](https://github.com/sgl-project/sglang/pull/23351) | open | PCG | Supports piecewise CUDA graph with NSA. |
+
+## 1.1 V3.2-Related PRs Outside the Main Timeline
+
+Additional PRs directly related to V3.2 / DSA / NSA / tool parsing / platform backends include:
+
+- Early bring-up polish: `#11063`, `#11194`, `#11308`, `#11309`, `#11450`, `#11557`, `#11565`, `#11682`, `#11815`, and `#11835`. These cover the V3.2 tool template, fast-topk, basic tests, KV-cache estimation, NSA act-quant kernels, default config, `_get_logits_head_gate` torch.compile, Indexer cleanup, ragged fast-topk transform, and MTP CI.
+- Short-sequence MHA / Indexer fixes: `#11892`, `#12094`, `#12582`, `#12583`, `#12645`, `#12788`, `#12816`, `#12964`, `#13022`, `#13459`, and `#13544`. These add adaptive MHA short-sequence prefill, Indexer `wk+weight_proj` fusion, top-k row starts, Indexer accuracy fixes, KV-buffer shape fixes, B200 short-sequence MHA, extend-without-spec logits skipping, MHA FP8, NSA `torch.cat` compile, FP32 Indexer weight projection, and centralized NSA dispatch.
+- DSML / tool / parser path: `#14304`, `#14307`, `#14353`, `#14573`, `#14750`, `#15064`, `#15278`, `#16091`, `#17951`, `#18126`, and `#18174`. These cover OpenAI developer role, DS32 role support, encoder error handling, no-parameter function streaming, function-call parameter streamlining, default drop_thinking, streaming tool-call output, JSON argument streaming, tool-call nightly tests, `encode_messages` fixes, and malformed-JSON tolerance.
+- NSA backend / metadata / sparse-cache work: `#14781`, `#14901`, `#15040`, `#15086`, `#15242`, `#15429`, `#16520`, `#16758`, `#16841`, `#17205`, `#17554`, and `#18319`. These cover multi-step speculative metadata, prefill TBO, paged-MQA logits metadata initialization, PP plus radix-cache assertion fixes, FlashMLA sparse FP8, V1 MTP fixes, BaseIndexerMetadata methods, TRTLLM NSA BF16 KV, AMD CUDA graph / FP8 RMSNorm, Indexer `weight_proj` MMA optimization, NSA multi-spec fused metadata kernels, and AMD TileLang default NSA dispatch.
+- HiSparse / HiCache and platform fixes: `#14741`, `#17409`, `#17518`, `#17523`, `#17633`, `#18297`, `#18526`, `#20343`, `#21932`, and `#22238`. These connect sparse interface work, fused-MoE config lookup, AMD dtype mismatch, MI325 CI, Transformers v5 compatibility, AITER NSA CUDA graph, HiSparse, decode-backup scheduling, and HiSparse docs.
+- Additional open PRs: `#14332`, `#14524`, `#15322`, `#18094`, `#18542`, `#19987`, `#20534`, `#21623`, `#22792`, and `#23268`. They track V32 tool parsing without DSML tags, NSA backend tests, `o_proj` TP, V3.2 PCG, EAGLE3 plus NSA CP aux-hidden-state issues, TileLang NSA FP8 KV, CP prefill-gather FP8 K/K-scale, `encoding_dsv32.py` tests, AITER `indexer_k_quant_and_cache`, and NPU NSA CP plus prefix-cache accuracy.
+- Closed / superseded history: `#11109`, `#11596`, `#11761`, `#12017`, `#12052`, `#13531`, `#13546`, `#14619`, `#14904`, `#15051`, `#15217`, `#15310`, `#15807`, `#16079`, `#16881`, `#17024`, `#17199`, `#17310`, and `#17647`. Do not count them as current support, but keep them as context when tracing history or successor PRs.
+- Runtime additions: `#21249` and `#22003` cover CP/all-reduce and topology constraints; `#21599`, `#22128`, and `#23336` cover adaptive speculative decoding and PCG combination; `#23219` is GLM-5 MXFP4-specific but touches shared `deepseek_nextn.py`, so it belongs to DSA/NextN-adjacent history; `#22950` and `#23315` distinguish closed/current thinking radix-cache stripping.
+
+## 2. What V3.2 Really Is: The DSA/NSA Runtime Surface
+
+The largest difference between V3.2 and V3/R1 is attention. When the model config satisfies `is_deepseek_nsa(config)`, SGLang treats it as a DSA/NSA model. Docs often call it DSA, while the code mostly uses NSA.
+
+`#11061` is the foundation of V3.2 support. It did not merely add `DeepseekV32ForCausalLM`; it introduced the full sparse-attention path:
+
+- model config detects DSA/NSA and reads fields such as `index_topk`, indexer head count, and index head dim.
+- `server_args.py` sets `attention_backend = "nsa"` for DSA.
+- `nsa_backend.py` adds `NativeSparseAttnBackend`.
+- `nsa_indexer.py` adds the Indexer that generates sparse-attention top-k indices.
+- `transform_index.py` and Triton/TileLang kernels convert top-k into paged/ragged structures required by backends.
+- `quant_k_cache.py` / `dequant_k_cache.py` handle FP8 K cache.
+- memory pool, model runner, CUDA graph, and forward-batch metadata all gained NSA-specific fields.
+
+This is why V3.2 performance or correctness issues usually cannot be solved by reading only `deepseek_v2.py`. The real call chain is: model layer calls the Indexer to generate or reuse top-k, NSA backend builds metadata from top-k and cache seqlens, and execution is dispatched to TRTLLM, FlashMLA, FA3, TileLang, or AITER.
+
+## 3. Server Args: Defaults Are Part of V3.2 Support
+
+Current `server_args.py` has dedicated logic for DSA models:
+
+- If no attention backend is specified, `attention_backend` becomes `nsa`.
+- If `SGLANG_NSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD` is not user-set, it defaults to the model `index_topk`.
+- DSA KV cache dtype defaults to `fp8_e4m3` on SM100 and `bfloat16` on other devices.
+- The main DSA path allows only `bfloat16` or `fp8_e4m3` KV cache dtype.
+- ROCm defaults NSA prefill/decode to TileLang.
+- FP8 KV + SM100 defaults to TRTLLM.
+- FP8 KV + Hopper can use `flashmla_kv`.
+- BF16 KV + SM100 can use `flashmla_sparse` + `trtllm`, and BF16 KV + Hopper can use `flashmla_sparse` + `fa3`.
+
+This means performance comparisons must record `--kv-cache-dtype`, `--nsa-prefill-backend`, `--nsa-decode-backend`, and hardware. If the user specifies an NSA backend but leaves KV dtype as `auto`, defaults can change the result.
+
+## 4. NSA Indexer: The Most Heavily Optimized V3.2 Area
+
+`nsa_indexer.py` is the core DSA hotspot. It:
+
+- computes q/k-related projections from hidden states.
+- computes indexing weights through `weights_proj`.
+- applies LayerNorm, RoPE, and activation quantization.
+- generates top-k sparse indices.
+- handles key all-gather, rerange, and round-robin/in-seq split under CP.
+- writes or quantizes K cache.
+
+Indexer optimization has been dense:
+
+- `#12044` enabled mixed-type LayerNorm kernel to avoid type conversion and extra kernels.
+- `#13812` optimized K/S buffer access with fused Triton kernels.
+- `#16637` overlapped `weights_proj` during dual-stream decode.
+- `#17688` overlapped q/k projection and activation quantization.
+- `#19041` avoided FP32 precision loss in `weights_proj`; it is a quality fix and also affects performance triage.
+- `#19148` added JIT NSA fused store for Indexer K cache.
+- `#19319` fixed `get_k_and_s_triton` for 128K sequence length.
+- `#22232` reduced extra kernels and copies in the Indexer.
+- `#22424` used AITER CK LayerNorm2D on AMD.
+- `#22850` fused `weights_proj` and K-cache store on AMD.
+
+If V3.2 has slow first token, abnormal decode kernel count, 128K long-context errors, FP8 KV scale issues, or too many Indexer kernels on AMD, the first place to read is usually `nsa_indexer.py` and the backend kernels.
+
+## 5. NSA Backend: Metadata, Top-K Transform, and Sparse MLA
+
+`NativeSparseAttnBackend` in `nsa_backend.py` converts Indexer results into metadata that attention backends can execute. Important fields include:
+
+- `nsa_cache_seqlens_int32`: cache seqlens clipped to top-k.
+- `nsa_cu_seqlens_q` / `nsa_cu_seqlens_k`: cumulative seqlens for prefill/decode.
+- `nsa_seqlens_expanded`: expanded real seqlens.
+- `nsa_extend_seq_lens_list`: CPU-side extend lengths.
+- FlashMLA metadata, paged MQA schedule, page table, and top-k offsets.
+
+`#11936` brought NSA backend into testing; `#18389` added TRTLLM sparse MLA FP8 for NVFP4; `#18931` fixed the both-TRTLLM MHA one-shot FP8 KV path; `#21783` added TRTLLM sparse MLA for DSA prefill batches; `#21914` made Blackwell default to TRTLLM kernels; `#22372` handled Hopper FP8 FlashMLA KV padding.
+
+If top-k indices look correct but attention output is wrong, the issue is often not the Indexer. It is usually top-k transform, cache seqlens, page-table offsets, or FP8 KV padding.
+
+## 6. Context Parallel, PP, and DP Attention
+
+`#12065` started V3.2 CP. It changed server args, pynccl, parallel state, NSA utils/backend, communicator, DP attention, schedule policy, CUDA graph, forward batch, `deepseek_v2.py`, `deepseek_nextn.py`, docs, and tests. CP therefore spans scheduling, attention metadata, model forward, and communication.
+
+Later CP evolution includes:
+
+- `#13959` supported fused MoE, multi-batch, and FP8 KV cache.
+- `#16119` fixed CP bugs.
+- `#16156` asserted V3.2 CP in PD decode mode.
+- `#16380` supported and optimized PP when context pipeline is enabled.
+- `#18613` changed the default CP token split to `round-robin-split`.
+- `#20438` overlapped NSA-CP key all-gather with query computation.
+- `#21192` fixed CP `in-seq-split` and updated tests.
+- `#21249` supported all-reduce fusion with CP by changing `communicator.py`, `flashinfer_comm_fusion.py`, `model_runner.py`, and server args.
+- `#22003` let `moe_dp_size = 1` work with different `attention_cp_size` values; read `parallel_state.py`, `dp_attention.py`, and CP utils together.
+- `#22914` deduplicated NSA utils into CP utils.
+
+Current constraints to remember:
+
+- `round-robin-split` is the default CP token split.
+- `in-seq-split` requires DeepEP and requires `ep_size == tp_size`.
+- CP is restricted in PD decode mode.
+- CP only makes sense for V3.2/DSA cases where `is_deepseek_nsa(config)` is true.
+- all-reduce fusion and CP should no longer be treated as categorically exclusive; check the active communicator and fusion backend.
+
+Open `#20360` and `#20531` show that AMD CP round-robin and ragged gather still have edge cases. Open `#17185` and `#19609` point to TP `o_proj` and TP Indexer weight work under CP NSA.
+
+## 7. MTP and Speculative Decoding: NSA Metadata Is in the Critical Path
+
+V3.2 MTP starts with `#11652`, but stabilization required many follow-ups:
+
+- `#15088` added pure TP + MTP testing.
+- `#15307` supported overlap spec + NSA.
+- `#16961` optimized MTP decode CUDA batch sizes and NSA implementation.
+- `#17662` fixed TRTLLM NSA in `target_verify` / `draft_extend`.
+- `#19016` fixed page-table overflow in speculative target_verify.
+- `#19062` fixed MTP + CP compatibility.
+- `#19367` fixed NSA CP position mismatch in EAGLE NextN.
+- `#19536` optimized NSA backend metadata under MTP.
+- `#20492` fixed DeepSeek Eagle3 in Attn-DP mode.
+- `#21599` made EAGLE top-k=1 draft steps adaptive.
+- `#22128` allowed PCG to coexist with speculative decoding.
+- `#23219` is GLM-5 MXFP4 MTP work, but it edits shared `deepseek_nextn.py`, so read it as DSA/NextN-adjacent history.
+- Open `#23336` carries adaptive spec into spec-v2 workers.
+
+So V3.2 MTP bugs cannot be debugged by looking only at `deepseek_nextn.py`. They may come from NSA metadata precompute, target verify, draft extend, page table, CP positions, DP attention, or backend auto-selection. Open `#20809` still tracks adding `DeepseekV32ForCausalLM` to MTP draft model mapping.
+
+## 8. Quantization and Platform Backends: NVFP4, AMD, NPU, HiSparse
+
+V3.2 has several platform tracks:
+
+NVFP4 / Blackwell:
+
+- `#17657` updated V3.2 NVFP4 checkpoint tests and docs.
+- `#18389` added NSA TRTLLM sparse MLA FP8 support.
+- `#20086` changed V3.2 NVFP4 defaults under TP4.
+- `#21914` made TRTLLM kernels the Blackwell default.
+
+AMD / ROCm:
+
+- `#17783` updated AMD GPU docs and unified the ROCm TileLang build.
+- `#19945` added TileLang sparse forward on MI355/MI300.
+- `#20840` fixed MI355 accuracy.
+- `#21511` enabled FP8 KV cache and FP8 attention kernel for NSA TileLang.
+- `#22258` passed BF16 through from RMSNorm to avoid FP8 dequantization.
+- `#22424` used CK LayerNorm2D to reduce Indexer kernel launches.
+- `#22850` fused weights projection and K-cache store.
+
+NPU:
+
+- `#14541` added V3.2 CP.
+- `#14572` added NPU optimizations.
+- `#15381` supported NPU MLA prolog.
+- `#16990` fixed a weight-cast bug.
+- `#17007` fixed V3.2 / DSVL2 NPU bugs.
+- `#21468` updated NPU deployment docs.
+
+HiSparse / HiCache:
+
+- `#21259` made mooncake backend support DSA and mamba hybrid models.
+- `#22065` restricted HiSparse checks to DSA models.
+- `#22425` added HiSparse-DSA nightly CI.
+- open `#23241` continues 3FS backend support for DSA/mamba.
+
+## 9. IndexCache: Skipping Top-K in Some Layers
+
+`#21405` enabled IndexCache for V3.2. Current `deepseek_v2.py` sets:
+
+- `skip_topk`: whether the current layer skips top-k and reuses previous top-k.
+- `next_skip_topk`: whether the next layer will reuse the current layer's top-k.
+- `index_topk_freq`: frequency-based top-k computation.
+- `index_topk_pattern`: explicit per-layer compute/skip pattern.
+
+Without a pattern, the logic computes top-k periodically using `index_topk_freq`. With a pattern, `S` means skip and other characters mean compute. `test_deepseek_v32_indexcache.py` covers both `index_topk_freq=4` and a long `index_topk_pattern`, using GSM8K threshold `0.935` to ensure top-k reuse does not break accuracy.
+
+IndexCache changes more than speed. It changes which layers compute top-k and which layers reuse it, so model accuracy validation is required.
+
+## 10. DSML Tool Parser and Reasoning Interaction
+
+Standard DeepSeek V3.2 uses `DeepSeekV32Detector`, with DSML tool-call format:
+
+```text
+<｜DSML｜function_calls>
+<｜DSML｜invoke name="get_weather">
+<｜DSML｜parameter name="location" string="true">Beijing</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜function_calls>
+```
+
+The detector supports two parameter forms:
+
+- XML parameter tags.
+- Direct JSON inside the invoke block.
+
+The streaming parser emits the tool name once, then computes argument diffs from previous arguments and the common prefix. `_parse_parameters_from_xml(..., allow_partial=True)` uses a partial JSON parser to handle unclosed JSON or unclosed parameter tags.
+
+One cookbook detail matters: the DeepSeek-V3.2-Exp tool path may use `deepseekv31` with `tool_chat_template_deepseekv32.jinja`, while standard DeepSeek-V3.2 uses `--tool-call-parser deepseekv32` and removes the custom chat template. DeepSeek-V3.2-Speciale does not support tool calling.
+
+Open `#21179` says the reasoning parser may swallow V3.2 tool-call markers. Open `#21546` fixes exception handling for malformed JSON during partial parsing.
+
+## 10.1 Thinking Radix Cache: Cache Semantics Outside the Parser
+
+For V3.2 reasoning/tool output, also check whether prefix cache reuses thinking tokens. `#22950` is the closed early parser-gated reasoning-cache strip design; current main is `#23315`, which adds an opt-in flag in `server_args.py` and supports stripping thinking tokens from radix-cache entries in `schedule_batch.py` and `mem_cache/common.py`.
+
+This is a different layer from DSML parsing. If V3.2 tool-call markers are swallowed by the reasoning parser, inspect `deepseekv32_detector.py` / `reasoning_parser.py`; if multi-turn requests reuse an unintended `<think>` / `</think>` prefix, inspect the `#23315` radix-cache stripping path.
+
+## 11. Current Validation Surface and Open PRs
+
+Current validation surface:
+
+- `test/registered/8-gpu-models/test_deepseek_v32.py`: DP8, DP8+MTP, TP8, TP8+MTP, with `deepseekv32` tool parser and `deepseek-v3` reasoning parser.
+- `test_deepseek_v32_nsa_backends` inside the same file: tests `flashmla_sparse+flashmla_kv`, `fa3+fa3`, and FP8 KV cache on H200.
+- B200 GPQA test inside the same file: reasoning mode, GPQA baseline `0.83`.
+- `test/registered/8-gpu-models/test_deepseek_v32_indexcache.py`: `index_topk_pattern` and `index_topk_freq=4`.
+- `test/manual/test_deepseek_chat_templates.py`: DeepSeek V3/V3.1/V3.2 template argument types.
+
+Open PRs to track:
+
+- `#11191`: DSA sparse attention and CPU/GPU KV-cache scheduling.
+- `#12820`: TP-SP support for DeepSeek V2/V3/V3.2.
+- `#16148`: V3.2 W4AFP8 MTP using FP8 draft model.
+- `#17185`: TP `o_proj` linear in context-parallel NSA.
+- `#17761`: missing Assistant token after V3.1/V3.2 tool output.
+- `#18167`: V3.2 DCP.
+- `#18275`: NPU allgather after qlora.
+- `#18733`: V3.2 PD disaggregation test.
+- `#19211`: extract `DeepseekV32Mixin` to reduce V3.2/NSA complexity inside `deepseek_v2.py`.
+- `#19299`: O(1) expert weight matching in the DeepSeek weight loader.
+- `#19609`: TP Indexer weight in NSA attention.
+- `#19975`: context parallel for V3.2 on AMD.
+- `#20360`: AMD CP round-robin-split output corruption.
+- `#20531`: NSA Indexer ragged gather batch-view mismatch in CP round-robin.
+- `#20809`: add `DeepseekV32ForCausalLM` to MTP draft model mapping.
+- `#20880`: reject HiCache L3 at NSA model initialization.
+- `#21179`: preserve V3.2 tool-call markers during reasoning parsing.
+- `#21194`: AMD AITER gfx95 `PPMissingLayer` fix for DeepSeek paths.
+- `#21506`: V3.2 NPU torch compile.
+- `#21529`: ROCm DeepSeek-architecture MXFP4 / Quark W4A4.
+- `#21530`: ROCm DeepSeek-variant fused MLA decode RoPE.
+- `#21546`: catch MalformedJSON during partial function-call parsing.
+- `#21889`: AMD TileLang NSA FP4 KV cache quantization.
+- `#22268`: DeepSeek MLA `prepare_qkv_latent` bypassing LoRA adapters.
+- `#22473`: dense MLA decode fallback for short sequences.
+- `#22774`: MUSA backend support for DeepSeek V2/V3/R1-class layers.
+- `#22851`: add `--nsa-topk-backend` and integrate FlashInfer/PyTorch top-k.
+- `#22865`: extend the sparsity framework for non-NSA sparse algorithms.
+- `#22938`: restore MI300X DeepSeek MLA paths after the MLA refactor.
+- `#23195`: guard DeepSeek MLA `.weight` access for AWQ/compressed-tensors.
+- `#23241`: 3FS backend support for DSA/mamba.
+- `#23257`: `DeepseekV2MoE` double-reduce with CuteDSL EP plus DP attention.
+- `#23336`: spec-v2 adaptive speculative decoding.
+- `#23351`: NSA piecewise CUDA graph.

--- a/model-pr-optimization-history/deepseek-v32/README.zh.md
+++ b/model-pr-optimization-history/deepseek-v32/README.zh.md
@@ -1,0 +1,359 @@
+# SGLang DeepSeek V3.2 支持与优化时间线
+
+本文基于 SGLang `origin/main` 最新快照 `929e00eea`、sgl-cookbook `origin/main` 快照 `8ec4d03`，以及 DeepSeek V3.2 / DSA / NSA 相关 merged 和 open PR 的 patch 阅读结果整理。范围覆盖 DeepSeek-V3.2-Exp、DeepSeek-V3.2、DeepSeek-V3.2-Speciale、DeepSeek-V3.2-NVFP4、DeepSeek-V3.2-MXFP4，以及这些模型在 SGLang 中的 DSA/NSA、Indexer、KV cache、Context Parallel、MTP、IndexCache、DSML parser、AMD/NPU/Blackwell 后端和测试文档演进。
+
+结论：截至 `929e00eea`，DeepSeek V3.2 已经不是普通 DeepSeek V3 新 checkpoint，而是通过 `is_deepseek_nsa(config)` 进入 DSA/NSA 稀疏注意力体系。当前主线入口是 `DeepseekV32ForCausalLM`，核心运行面是 `nsa_indexer.py`、`nsa_backend.py`、`deepseek_v2.py`、`deepseek_nextn.py` 和 `server_args.py`。V3.2 已经具备基础 DSA、NSA backend auto-selection、BF16/FP8 KV cache、MTP、CP、PP、DP attention、TRTLLM/FlashMLA/FA3/TileLang/AITER backend、NVFP4、AMD MXFP4/FP8 KV、NPU、HiSparse/HiCache、IndexCache 和 DSML tool parser 支持。新增运行时内容包括 CP all-reduce fusion、`moe_dp_size=1` 与 `attention_cp_size` 组合、adaptive EAGLE、PCG + speculative decoding、shared `deepseek_nextn.py` 变化和 thinking token radix-cache strip。后续需要跟进的是 NSA PCG、spec v2 adaptive spec、CPU/GPU sparse KV 调度、TP-SP、V3.2 DCP、CP AMD round-robin、IndexCache/top-k backend、short-seq dense fallback、partial JSON parser 和 HiCache/3FS 等 open 方向。
+
+## 1. 时间线总览
+
+| 创建日期 | PR | 状态 | 主线 | 作用 |
+| --- | ---: | --- | --- | --- |
+| 2025-09-25 | [#10912](https://github.com/sgl-project/sglang/pull/10912) | merged | PD | 给 Qwen3-Next 和 DeepSeek V3.2 Exp 等 hybrid model 增加 PD 支持。 |
+| 2025-09-29 | [#11061](https://github.com/sgl-project/sglang/pull/11061) | merged | bring-up | 支持 DeepSeek V3.2 Exp，新增 NSA backend、Indexer、sparse attention plumbing、KV quant/dequant、memory pool、runner 和测试。 |
+| 2025-10-03 | [#11191](https://github.com/sgl-project/sglang/pull/11191) | open | sparse KV | 支持 GQA/DSA sparse attention 的 CPU/GPU KV cache 调度。 |
+| 2025-10-12 | [#11510](https://github.com/sgl-project/sglang/pull/11510) | merged | bugfix | 修复 Qwen3/DSV3/DSV3.2 模型支持。 |
+| 2025-10-15 | [#11652](https://github.com/sgl-project/sglang/pull/11652) | merged | MTP | 给 DSV3.2 增加 MTP。 |
+| 2025-10-20 | [#11877](https://github.com/sgl-project/sglang/pull/11877) | merged | docs | 增加 DeepSeek V3.2 文档。 |
+| 2025-10-21 | [#11936](https://github.com/sgl-project/sglang/pull/11936) | merged | NSA tests | 增加 V3.2 NSA backend 测试。 |
+| 2025-10-24 | [#12044](https://github.com/sgl-project/sglang/pull/12044) | merged | Indexer | 给 NSA Indexer 启用 mixed type LayerNorm kernel。 |
+| 2025-10-24 | [#12065](https://github.com/sgl-project/sglang/pull/12065) | merged | CP | 初始支持 DeepSeek V3.2 DSA Context Parallel。 |
+| 2025-10-25 | [#12123](https://github.com/sgl-project/sglang/pull/12123) | merged | template | 修复 DeepSeek template 中 tool arguments 的 dict/string 类型处理。 |
+| 2025-10-28 | [#12296](https://github.com/sgl-project/sglang/pull/12296) | merged | docs | 更新 `deepseek_v32.md`。 |
+| 2025-11-08 | [#12868](https://github.com/sgl-project/sglang/pull/12868) | merged | docs | 补充 V3.2 MHA short-seq prefill 文档。 |
+| 2025-11-20 | [#13646](https://github.com/sgl-project/sglang/pull/13646) | merged | TP/DP attention | 启用 pure TP 和 partial DP attention。 |
+| 2025-11-23 | [#13812](https://github.com/sgl-project/sglang/pull/13812) | merged | Indexer perf | 用 fused Triton kernels 优化 NSA Indexer K/S buffer 访问。 |
+| 2025-11-26 | [#13959](https://github.com/sgl-project/sglang/pull/13959) | merged | CP perf | 优化 CP，支持 fused MoE、multi-batch 和 FP8 KV cache。 |
+| 2025-12-06 | [#14541](https://github.com/sgl-project/sglang/pull/14541) | merged | NPU CP | 给 NPU 增加 V3.2 CP 支持。 |
+| 2025-12-07 | [#14572](https://github.com/sgl-project/sglang/pull/14572) | merged | NPU perf | 增加 V3.2 NPU 优化。 |
+| 2025-12-14 | [#15088](https://github.com/sgl-project/sglang/pull/15088) | merged | MTP tests | 增加 pure TP + MTP 测试。 |
+| 2025-12-17 | [#15307](https://github.com/sgl-project/sglang/pull/15307) | merged | spec overlap | 支持 overlap speculative decoding + NSA。 |
+| 2025-12-18 | [#15381](https://github.com/sgl-project/sglang/pull/15381) | merged | NPU | 支持 NPU MLA prolog。 |
+| 2025-12-27 | [#15938](https://github.com/sgl-project/sglang/pull/15938) | merged | env cleanup | 清理 V3.2 环境变量。 |
+| 2025-12-30 | [#16119](https://github.com/sgl-project/sglang/pull/16119) | merged | CP bugfix | 修复 V3.2 CP。 |
+| 2025-12-30 | [#16156](https://github.com/sgl-project/sglang/pull/16156) | merged | CP guard | 在 PD decode mode 下对 V3.2 CP 加 assert。 |
+| 2026-01-02 | [#16305](https://github.com/sgl-project/sglang/pull/16305) | merged | V32/CP updates | 多项 DeepSeek V32 和 CP 更新。 |
+| 2026-01-02 | [#16306](https://github.com/sgl-project/sglang/pull/16306) | merged | refactor | 重构 DeepSeek attention backend handlers 和 forward method 定义。 |
+| 2026-01-04 | [#16380](https://github.com/sgl-project/sglang/pull/16380) | merged | PP/CP | context pipeline 启用时支持并优化 PP。 |
+| 2026-01-07 | [#16637](https://github.com/sgl-project/sglang/pull/16637) | merged | Indexer overlap | dual-stream decode 中 overlap Indexer `weights_proj`。 |
+| 2026-01-11 | [#16907](https://github.com/sgl-project/sglang/pull/16907) | merged | AWQ loading | 修复 DeepSeek-V3.2-AWQ 加载。 |
+| 2026-01-12 | [#16916](https://github.com/sgl-project/sglang/pull/16916) | merged | docs | 增加 V3.2 CP+PP 文档。 |
+| 2026-01-12 | [#16961](https://github.com/sgl-project/sglang/pull/16961) | merged | MTP perf | 优化 MTP decode CUDA batch sizes 和 NSA 实现。 |
+| 2026-01-13 | [#16990](https://github.com/sgl-project/sglang/pull/16990) | merged | NPU bugfix | 修复 V3.2 weight cast bug。 |
+| 2026-01-13 | [#17007](https://github.com/sgl-project/sglang/pull/17007) | merged | NPU bugfix | 修复 V3.2 和 DSVL2 NPU 问题。 |
+| 2026-01-14 | [#17076](https://github.com/sgl-project/sglang/pull/17076) | merged | Indexer/FA3 | 修复 slice indexer 和无法 CUDA graph 时的 FA3 padding。 |
+| 2026-01-15 | [#17133](https://github.com/sgl-project/sglang/pull/17133) | merged | MoE tuning | 为 V3.1/V3.2 增加 H20/H20-3E fused MoE configs。 |
+| 2026-01-23 | [#17657](https://github.com/sgl-project/sglang/pull/17657) | merged | NVFP4 | 更新 V3.2 NVFP4 checkpoint 测试和文档。 |
+| 2026-01-23 | [#17662](https://github.com/sgl-project/sglang/pull/17662) | merged | TRTLLM NSA | 修复 target_verify/draft_extend 里的 TRT-LLM NSA。 |
+| 2026-01-25 | [#17688](https://github.com/sgl-project/sglang/pull/17688) | merged | Indexer overlap | overlap Indexer q/k projection 和 activation quant。 |
+| 2026-01-26 | [#17783](https://github.com/sgl-project/sglang/pull/17783) | merged | AMD docs | 更新 V3.2 AMD GPU 文档并统一 ROCm TileLang build。 |
+| 2026-02-05 | [#18280](https://github.com/sgl-project/sglang/pull/18280) | merged | CP scale | `get_index_k_scale_buffer` 支持 CP。 |
+| 2026-02-07 | [#18389](https://github.com/sgl-project/sglang/pull/18389) | merged | NVFP4/TRTLLM | DeepSeek V3.2 NVFP4 支持 NSA TRTLLM sparse MLA FP8。 |
+| 2026-02-10 | [#18553](https://github.com/sgl-project/sglang/pull/18553) | merged | bugfix | 修复 V3.2 bug。 |
+| 2026-02-11 | [#18613](https://github.com/sgl-project/sglang/pull/18613) | merged | CP default | 将 CP token split 默认改成 `round-robin-split`。 |
+| 2026-02-16 | [#18876](https://github.com/sgl-project/sglang/pull/18876) | merged | MoE tune | 将 DeepSeek3.2 和 GLM-MoE-DSA 加入 MoE tune。 |
+| 2026-02-17 | [#18931](https://github.com/sgl-project/sglang/pull/18931) | merged | FP8 KV | 修复 both-TRTLLM MHA one-shot 下 NSA FP8 KV cache path。 |
+| 2026-02-18 | [#18978](https://github.com/sgl-project/sglang/pull/18978) | merged | AMD MTP | 修复 MI35x V3.2 MTP nightly。 |
+| 2026-02-19 | [#19016](https://github.com/sgl-project/sglang/pull/19016) | merged | spec bugfix | 修复 target_verify 中 NSA backend page-table overflow。 |
+| 2026-02-20 | [#19041](https://github.com/sgl-project/sglang/pull/19041) | merged | quality | 避免 `weights_proj` 中 FP32 精度损失。 |
+| 2026-02-20 | [#19062](https://github.com/sgl-project/sglang/pull/19062) | merged | MTP/CP | 修复 MTP 和 CP 兼容性。 |
+| 2026-02-21 | [#19122](https://github.com/sgl-project/sglang/pull/19122) | merged | MLA refactor | 迁移 DeepSeek MLA forward method。 |
+| 2026-02-22 | [#19148](https://github.com/sgl-project/sglang/pull/19148) | merged | JIT kernel | 增加 NSA fused store indexer K cache JIT kernel。 |
+| 2026-02-25 | [#19319](https://github.com/sgl-project/sglang/pull/19319) | merged | 128K bugfix | 修复 128K seqlen 下 `get_k_and_s_triton` bug。 |
+| 2026-02-25 | [#19367](https://github.com/sgl-project/sglang/pull/19367) | merged | MTP/CP | 修复 EAGLE NextN 中 NSA CP positions mismatch。 |
+| 2026-02-26 | [#19428](https://github.com/sgl-project/sglang/pull/19428) | merged | qlora/ag | 给 V3.2 增加 `mla_ag_after_qlora`。 |
+| 2026-02-28 | [#19536](https://github.com/sgl-project/sglang/pull/19536) | merged | MTP metadata | 优化 MTP 下 NSA backend metadata。 |
+| 2026-03-05 | [#19945](https://github.com/sgl-project/sglang/pull/19945) | merged | AMD TileLang | 给 V3.2 MI355/MI300 增加 TileLang sparse forward。 |
+| 2026-03-07 | [#20086](https://github.com/sgl-project/sglang/pull/20086) | merged | NVFP4 default | 调整 V3.2 NVFP4 TP4 默认设置。 |
+| 2026-03-11 | [#20326](https://github.com/sgl-project/sglang/pull/20326) | merged | docs | 在 support matrix 中加入 DSA/NSA attention backend。 |
+| 2026-03-12 | [#20438](https://github.com/sgl-project/sglang/pull/20438) | merged | CP perf | overlap NSA-CP key all-gather 和 query computation。 |
+| 2026-03-13 | [#20492](https://github.com/sgl-project/sglang/pull/20492) | merged | EAGLE3/DP | 修复 Attn-DP 模式下 DeepSeek Eagle3。 |
+| 2026-03-15 | [#20606](https://github.com/sgl-project/sglang/pull/20606) | merged | FP8 KV offset | flashmla_sparse + FP8 KV cache 时计算 `topk_indices_offset`。 |
+| 2026-03-18 | [#20840](https://github.com/sgl-project/sglang/pull/20840) | merged | AMD accuracy | 修复 MI355 上 V3.2 精度。 |
+| 2026-03-20 | [#20984](https://github.com/sgl-project/sglang/pull/20984) | merged | FP4 test | 修复 DeepSeek V32 FP4 test。 |
+| 2026-03-20 | [#21003](https://github.com/sgl-project/sglang/pull/21003) | merged | revert | 回滚 `#20984`。 |
+| 2026-03-23 | [#21192](https://github.com/sgl-project/sglang/pull/21192) | merged | CP tests | 修复 CP in-seq-split 并更新测试。 |
+| 2026-03-24 | [#21249](https://github.com/sgl-project/sglang/pull/21249) | merged | CP/all-reduce | 支持 context parallel 下的 all-reduce fusion。 |
+| 2026-03-24 | [#21259](https://github.com/sgl-project/sglang/pull/21259) | merged | HiCache | mooncake backend 支持 DSA 和 mamba hybrid model。 |
+| 2026-03-24 | [#21337](https://github.com/sgl-project/sglang/pull/21337) | merged | B200+DP perf | 绕过 B200 + DP 下 DSA 性能下降。 |
+| 2026-03-25 | [#21405](https://github.com/sgl-project/sglang/pull/21405) | merged | IndexCache | 给 DeepSeek V3.2 启用 IndexCache。 |
+| 2026-03-26 | [#21468](https://github.com/sgl-project/sglang/pull/21468) | merged | NPU docs | 更新 V3.2 NPU 部署文档。 |
+| 2026-03-27 | [#21511](https://github.com/sgl-project/sglang/pull/21511) | merged | AMD FP8 KV | 给 NSA TileLang 启用 FP8 KV cache 和 FP8 attention kernel。 |
+| 2026-03-28 | [#21585](https://github.com/sgl-project/sglang/pull/21585) | merged | CI | 将 V3.2 CP test 移到 DeepEP suite。 |
+| 2026-03-28 | [#21599](https://github.com/sgl-project/sglang/pull/21599) | merged | MTP/spec | 给 EAGLE top-k=1 增加自适应 `speculative_num_steps`。 |
+| 2026-03-31 | [#21783](https://github.com/sgl-project/sglang/pull/21783) | merged | TRTLLM prefill | DSA prefill batch 支持 TRTLLM sparse MLA kernel。 |
+| 2026-04-02 | [#21914](https://github.com/sgl-project/sglang/pull/21914) | merged | Blackwell default | Blackwell DSA 默认使用 TRTLLM kernels。 |
+| 2026-04-03 | [#22003](https://github.com/sgl-project/sglang/pull/22003) | merged | CP topology | 支持 `moe_dp_size = 1` 搭配不同 `attention_cp_size`。 |
+| 2026-04-03 | [#22065](https://github.com/sgl-project/sglang/pull/22065) | merged | HiSparse guard | HiSparse 暂时只允许 DSA model。 |
+| 2026-04-05 | [#22128](https://github.com/sgl-project/sglang/pull/22128) | merged | PCG/spec | 允许 piecewise CUDA graph 和 speculative decoding 同时使用。 |
+| 2026-04-06 | [#22179](https://github.com/sgl-project/sglang/pull/22179) | merged | docs | 改进 DeepSeek V3.2 / GLM-5 文档。 |
+| 2026-04-07 | [#22232](https://github.com/sgl-project/sglang/pull/22232) | merged | Indexer perf | 减少 NSA Indexer 中不必要的 kernels 和 copies。 |
+| 2026-04-07 | [#22258](https://github.com/sgl-project/sglang/pull/22258) | merged | AMD perf | AMD/HIP NSA 中 BF16 从 RMSNorm 直通，避免 FP8 dequant。 |
+| 2026-04-08 | [#22372](https://github.com/sgl-project/sglang/pull/22372) | merged | Hopper FP8 KV | 增加 Hopper FP8 FlashMLA KV padding。 |
+| 2026-04-08 | [#22390](https://github.com/sgl-project/sglang/pull/22390) | merged | AR fusion | 给 DSA model 启用 all-reduce fusion。 |
+| 2026-04-09 | [#22424](https://github.com/sgl-project/sglang/pull/22424) | merged | AMD LayerNorm | 使用 AITER CK LayerNorm2D 降低 NSA Indexer kernel 数。 |
+| 2026-04-09 | [#22425](https://github.com/sgl-project/sglang/pull/22425) | merged | HiSparse CI | 增加 HiSparse-DSA nightly CI。 |
+| 2026-04-09 | [#22430](https://github.com/sgl-project/sglang/pull/22430) | merged | DSA bugfix | 修复多个 DSA model bug。 |
+| 2026-04-15 | [#22850](https://github.com/sgl-project/sglang/pull/22850) | merged | AMD Indexer perf | 融合 weights_proj 和 K-cache store，减少 NSA Indexer kernels。 |
+| 2026-04-16 | [#22914](https://github.com/sgl-project/sglang/pull/22914) | merged | CP refactor | 将 NSA utils 去重到 CP utils。 |
+| 2026-04-16 | [#22950](https://github.com/sgl-project/sglang/pull/22950) | closed | reasoning cache | 探索 parser-gated 两阶段 reasoning radix-cache stripping，已关闭。 |
+| 2026-04-20 | [#23219](https://github.com/sgl-project/sglang/pull/23219) | merged | shared NextN | 为 GLM-5 MXFP4 启用 MTP，改动共享 `deepseek_nextn.py`。 |
+| 2026-04-21 | [#23315](https://github.com/sgl-project/sglang/pull/23315) | merged | reasoning cache | 增加可选的 thinking token radix-cache strip。 |
+| 2026-04-21 | [#23336](https://github.com/sgl-project/sglang/pull/23336) | open | spec v2 | 把 adaptive speculative decoding 扩展到 spec v2。 |
+| 2026-04-21 | [#23351](https://github.com/sgl-project/sglang/pull/23351) | open | PCG | 支持 NSA 的 piecewise CUDA graph。 |
+
+## 1.1 主时间线之外的 V3.2 相关 PR
+
+主时间线之外还包括一组和 V3.2/DSA/NSA/tool/parser/平台后端直接相关的 PR：
+
+- 早期 bring-up polish：`#11063`、`#11194`、`#11308`、`#11309`、`#11450`、`#11557`、`#11565`、`#11682`、`#11815`、`#11835`。它们分别覆盖 V3.2 tool template、fast-topk、基础测试、KV cache 估算、NSA act quant kernel、默认 config、`_get_logits_head_gate` torch.compile、Indexer cleanup、ragged fast-topk transform 和 MTP CI。
+- Short-seq MHA / Indexer 修复：`#11892`、`#12094`、`#12582`、`#12583`、`#12645`、`#12788`、`#12816`、`#12964`、`#13022`、`#13459`、`#13544`。这些 PR 补齐 adaptive MHA short-seq prefill、Indexer `wk+weight_proj`、top-k row starts、Indexer accuracy、KV-buffer shape、B200 short-seq MHA、extend-without-spec skip logits、MHA FP8、NSA `torch.cat` compile、Indexer FP32 权重投影和 NSA dispatch 集中化。
+- DSML/tool/parser 路径：`#14304`、`#14307`、`#14353`、`#14573`、`#14750`、`#15064`、`#15278`、`#16091`、`#17951`、`#18126`、`#18174`。它们覆盖 OpenAI developer role、DS32 role 支持、encoder 错误处理、无参数函数 streaming bug、function-call 参数 streamlining、默认 drop_thinking、streaming tool-call 输出、JSON 参数 streaming、tool-call nightly、`encode_messages` 修复和 malformed JSON 容错。
+- NSA backend / metadata / sparse-cache 工作：`#14781`、`#14901`、`#15040`、`#15086`、`#15242`、`#15429`、`#16520`、`#16758`、`#16841`、`#17205`、`#17554`、`#18319`。这些 PR 补充 multi-step speculative metadata、prefill TBO、paged MQA logits metadata 初始化、PP + radix-cache assertion、FlashMLA sparse FP8、V1 MTP 修复、BaseIndexerMetadata 方法、TRTLLM NSA BF16 KV、AMD CUDA graph/FP8 RMSNorm、Indexer `weight_proj` MMA 优化、NSA multi-spec fused metadata kernels 和 AMD TileLang 默认 NSA dispatch。
+- HiSparse/HiCache 与平台修复：`#14741`、`#17409`、`#17518`、`#17523`、`#17633`、`#18297`、`#18526`、`#20343`、`#21932`、`#22238`。这些 PR 连接 sparse interface、fused-MoE config lookup、AMD dtype mismatch、MI325 CI、transformers v5 兼容、AITER NSA CUDA graph、HiSparse、decode backup scheduling 和 HiSparse 文档。
+- 额外 open PR：`#14332`、`#14524`、`#15322`、`#18094`、`#18542`、`#19987`、`#20534`、`#21623`、`#22792`、`#23268`。分别指向无 DSML tag 的 V32 tool-call parsing、NSA backend test suite、`o_proj` TP、V3.2 PCG、EAGLE3+NSA CP aux hidden state、TileLang NSA FP8 KV、CP prefill gather FP8 K/K-scale、`encoding_dsv32.py` 单测、AITER `indexer_k_quant_and_cache`、以及 NPU NSA CP + prefix cache 精度。
+- closed / superseded 历史：`#11109`、`#11596`、`#11761`、`#12017`、`#12052`、`#13531`、`#13546`、`#14619`、`#14904`、`#15051`、`#15217`、`#15310`、`#15807`、`#16079`、`#16881`、`#17024`、`#17199`、`#17310`、`#17647`。这些不能当当前主线支持，但排查历史和 open PR 继承关系时应作为背景。
+- 运行时增量：`#21249` 和 `#22003` 补齐 CP/all-reduce 与拓扑约束；`#21599`、`#22128`、`#23336` 补齐 speculative decoding 自适应和 PCG 组合；`#23219` 是 GLM-5 MXFP4 方向，但改动共享 `deepseek_nextn.py`，因此属于 DSA/NextN 邻近历史；`#22950`、`#23315` 则区分 closed/current 的 thinking radix-cache strip。
+
+## 2. V3.2 的本质：DSA/NSA 运行面
+
+V3.2 和 V3/R1 的最大区别是 attention。模型配置满足 `is_deepseek_nsa(config)` 时，SGLang 将其视为 DSA/NSA 模型。docs 里常称 DSA，代码里主要叫 NSA。
+
+`#11061` 是整个 V3.2 支持的基石。该 PR 增加了 `DeepseekV32ForCausalLM`，并引入完整的稀疏注意力路径：
+
+- model config 中识别 DSA/NSA，并读取 `index_topk`、indexer head 数、index head dim 等字段。
+- `server_args.py` 为 DSA 设置 `attention_backend = "nsa"`。
+- `nsa_backend.py` 新增 `NativeSparseAttnBackend`。
+- `nsa_indexer.py` 新增 Indexer，负责生成稀疏 attention 的 top-k 索引。
+- `transform_index.py`、Triton/TileLang kernels 负责把 top-k 转成 backend 需要的 paged/ragged 结构。
+- `quant_k_cache.py` / `dequant_k_cache.py` 处理 FP8 K cache。
+- memory pool、model runner、CUDA graph、forward batch metadata 都为 NSA 增加了必要字段。
+
+因此，V3.2 的性能或正确性问题通常不能只看 `deepseek_v2.py`。运行时调用链是：model layer 调 Indexer 生成/复用 top-k，NSA backend 依据 top-k 和 cache seqlens 构造 metadata，最后再分发给 TRTLLM、FlashMLA、FA3、TileLang 或 AITER。
+
+## 3. Server args：默认值是 V3.2 支持的一部分
+
+当前 `server_args.py` 对 DSA model 有专门逻辑：
+
+- 如果没有手动设置 attention backend，会把 `attention_backend` 设置为 `nsa`。
+- 如果用户没设置 `SGLANG_NSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD`，会把它设置成模型的 `index_topk`。
+- DSA KV cache dtype 在 SM100 默认 `fp8_e4m3`，其他设备默认 `bfloat16`。
+- DSA 主线只允许 `bfloat16` 或 `fp8_e4m3` KV cache dtype。
+- ROCm 上 NSA prefill/decode 默认 TileLang。
+- FP8 KV + SM100 默认 TRTLLM。
+- FP8 KV + Hopper 可以走 `flashmla_kv`。
+- BF16 KV + SM100 可以用 `flashmla_sparse` + `trtllm`，BF16 KV + Hopper 可以用 `flashmla_sparse` + `fa3`。
+
+这意味着比较性能时必须同时记录 `--kv-cache-dtype`、`--nsa-prefill-backend`、`--nsa-decode-backend` 和硬件。用户指定了 NSA backend 但 KV dtype 仍是 `auto` 时，结果可能被默认值影响。
+
+## 4. NSA Indexer：V3.2 优化最密集的区域
+
+`nsa_indexer.py` 是 DSA 的核心热点。它做几件事：
+
+- 对 hidden states 做 q/k 相关 projection。
+- 通过 `weights_proj` 计算索引权重。
+- 做 LayerNorm、RoPE、activation quant。
+- 生成 top-k sparse indices。
+- 处理 CP 下的 key all-gather、rerange、round-robin/in-seq split。
+- 写入或量化 K cache。
+
+围绕 Indexer 的优化较为密集：
+
+- `#12044` 启用 mixed type LayerNorm kernel，避免类型转换和多余 kernel。
+- `#13812` 用 fused Triton kernels 优化 K/S buffer 访问。
+- `#16637` 在 dual-stream decode 中 overlap `weights_proj`。
+- `#17688` overlap q/k projection 和 activation quant。
+- `#19041` 避免 `weights_proj` 中 FP32 精度损失，属于质量修复，也会影响性能排查。
+- `#19148` 增加 JIT NSA fused store indexer K cache。
+- `#19319` 修复 128K seqlen 下 `get_k_and_s_triton` bug。
+- `#22232` 减少 Indexer 中多余 kernels 和 copies。
+- `#22424` AMD 上使用 AITER CK LayerNorm2D。
+- `#22850` AMD 上进一步融合 `weights_proj` 和 K-cache store。
+
+如果遇到 V3.2 首 token 慢、decode kernel 数异常、128K 长上下文错误、FP8 KV scale 错、AMD 上 Indexer kernel 太多，第一优先级通常都是读 `nsa_indexer.py` 和对应 backend kernels。
+
+## 5. NSA backend：metadata、top-k transform 和 sparse MLA
+
+`nsa_backend.py` 的 `NativeSparseAttnBackend` 负责把 Indexer 结果转成 attention backend 能执行的 metadata。关键字段包括：
+
+- `nsa_cache_seqlens_int32`：裁剪到 top-k 的 cache seqlens。
+- `nsa_cu_seqlens_q` / `nsa_cu_seqlens_k`：prefill/decode 所需 cumulative seqlens。
+- `nsa_seqlens_expanded`：扩展后的真实 seqlens。
+- `nsa_extend_seq_lens_list`：extend 阶段 CPU 侧长度。
+- FlashMLA metadata、paged MQA schedule、page table、top-k offsets。
+
+`#11936` 让 NSA backend 进入测试；`#18389` 给 NVFP4 方向加入 TRTLLM sparse MLA FP8；`#18931` 修 both-TRTLLM MHA one-shot 下 FP8 KV path；`#21783` 支持 DSA prefill batch 的 TRTLLM sparse MLA；`#21914` 把 Blackwell 默认推向 TRTLLM kernels；`#22372` 处理 Hopper FP8 FlashMLA KV padding。
+
+如果 top-k indices 看起来正确但 attention 输出错，问题经常不在 Indexer，而在 top-k transform、cache seqlens、page-table offset 或 FP8 KV padding。
+
+## 6. Context Parallel、PP 与 DP Attention
+
+`#12065` 是 V3.2 CP 的起点。它同时改了 server args、pynccl、parallel state、NSA utils/backend、communicator、DP attention、schedule policy、CUDA graph、forward batch、`deepseek_v2.py`、`deepseek_nextn.py`、docs 和 tests。这说明 CP 不是简单加一个通信 op，而是贯穿调度、attention metadata 和模型 forward。
+
+后续 CP 演进包括：
+
+- `#13959` 支持 fused MoE、multi-batch、FP8 KV cache。
+- `#16119` 修 CP bug。
+- `#16156` 在 PD decode mode 下 assert V3.2 CP。
+- `#16380` 在 context pipeline 启用时支持并优化 PP。
+- `#18613` 将 CP token split 默认改成 `round-robin-split`。
+- `#20438` overlap NSA-CP key all-gather 和 query computation。
+- `#21192` 修 CP `in-seq-split` 并更新测试。
+- `#21249` 支持 CP 下的 all-reduce fusion，改动 `communicator.py`、`flashinfer_comm_fusion.py`、`model_runner.py` 和 server args。
+- `#22003` 让 `moe_dp_size = 1` 能搭配不同 `attention_cp_size`，需要同时读 `parallel_state.py`、`dp_attention.py` 和 CP utils。
+- `#22914` 将 NSA utils 去重到 CP utils。
+
+当前要记住的约束：
+
+- `round-robin-split` 是默认 CP token split。
+- `in-seq-split` 要求 DeepEP，并要求 `ep_size == tp_size`。
+- CP in PD decode mode 受限制。
+- CP 只在 V3.2/DSA 这种 `is_deepseek_nsa(config)` 场景下成立。
+- all-reduce fusion 与 CP 不应视为互斥；排查时要看当前 communicator 和 fusion backend 是否启用。
+
+open `#20360` 和 `#20531` 说明 AMD CP round-robin 和 ragged gather 仍有边界问题；open `#17185` 和 `#19609` 则分别指向 CP NSA 下的 TP `o_proj` 和 TP indexer weight。
+
+## 7. MTP 与 speculative decoding：NSA metadata 也在关键路径
+
+V3.2 MTP 从 `#11652` 开始，稳定化依赖一组后续修复：
+
+- `#15088` 增加 pure TP + MTP test。
+- `#15307` 支持 overlap spec + NSA。
+- `#16961` 优化 MTP decode CUDA batch sizes 和 NSA implementation。
+- `#17662` 修复 TRTLLM NSA 在 `target_verify` / `draft_extend` 中的问题。
+- `#19016` 修复 speculative target_verify 的 page_table overflow。
+- `#19062` 修复 MTP + CP 兼容性。
+- `#19367` 修复 EAGLE NextN 中 NSA CP positions mismatch。
+- `#19536` 优化 MTP 下 NSA backend metadata。
+- `#20492` 修复 Attn-DP 模式下 DeepSeek Eagle3。
+- `#21599` 让 EAGLE top-k=1 的 draft step 数自适应。
+- `#22128` 允许 PCG 和 speculative decoding 共存。
+- `#23219` 虽然是 GLM-5 MXFP4 MTP，但改动共享的 `deepseek_nextn.py`，要作为 DSA/NextN 邻近历史阅读。
+- open `#23336` 把 adaptive spec 推到 spec v2 workers。
+
+因此，V3.2 的 MTP bug 不能只查 `deepseek_nextn.py`。它可能来自 NSA metadata 预计算、target verify、draft extend、page table、CP positions、DP attention 或 backend auto-selection。open `#20809` 还在跟踪把 `DeepseekV32ForCausalLM` 加入 MTP draft model mapping 的方向。
+
+## 8. 量化与平台后端：NVFP4、AMD、NPU、HiSparse
+
+V3.2 的平台线很丰富：
+
+NVFP4 / Blackwell：
+
+- `#17657` 更新 V3.2 NVFP4 checkpoint 的测试和文档。
+- `#18389` 增加 NSA TRTLLM sparse MLA FP8 支持。
+- `#20086` 调整 TP4 下 V3.2 NVFP4 默认配置。
+- `#21914` 将 Blackwell 默认设置为 TRTLLM kernels。
+
+AMD / ROCm：
+
+- `#17783` 更新 AMD GPU docs 并统一 ROCm TileLang build。
+- `#19945` 增加 MI355/MI300 TileLang sparse forward。
+- `#20840` 修 MI355 精度。
+- `#21511` 启用 NSA TileLang 的 FP8 KV cache 和 FP8 attention kernel。
+- `#22258` 让 BF16 从 RMSNorm 直通，避免 FP8 dequant。
+- `#22424` 用 CK LayerNorm2D 减少 Indexer kernel launches。
+- `#22850` 融合 weights_proj 和 K-cache store。
+
+NPU：
+
+- `#14541` 加 V3.2 CP。
+- `#14572` 加 NPU 优化。
+- `#15381` 支持 NPU MLA prolog。
+- `#16990` 修 weight cast bug。
+- `#17007` 修 V3.2 / DSVL2 NPU bug。
+- `#21468` 更新 NPU 部署文档。
+
+HiSparse / HiCache：
+
+- `#21259` 让 mooncake backend 支持 DSA 和 mamba hybrid model。
+- `#22065` 把 HiSparse 检查限制在 DSA model。
+- `#22425` 增加 HiSparse-DSA nightly CI。
+- open `#23241` 继续推进 3FS backend 支持 DSA/mamba。
+
+## 9. IndexCache：跳过部分层 top-k
+
+`#21405` 给 V3.2 启用 IndexCache。当前 `deepseek_v2.py` 中每层会设置：
+
+- `skip_topk`：当前层是否跳过 top-k 计算并复用上一层 top-k。
+- `next_skip_topk`：下一层是否会复用当前层 top-k。
+- `index_topk_freq`：按频率决定哪些层计算 top-k。
+- `index_topk_pattern`：用显式字符串控制每层是计算还是跳过。
+
+如果没有 pattern，逻辑大致是按 `index_topk_freq` 周期计算；如果给了 pattern，`S` 表示 skip，其他字符表示计算。`test_deepseek_v32_indexcache.py` 覆盖了 `index_topk_freq=4` 和一个长的 `index_topk_pattern`，并用 GSM8K 阈值 `0.935` 保证复用 top-k 不破坏精度。
+
+IndexCache 不是单纯性能 knob。它改变了哪些层生成 top-k，哪些层复用 top-k，因此必须做模型精度验证。
+
+## 10. DSML tool parser 与 reasoning 交互
+
+标准 DeepSeek V3.2 使用 `DeepSeekV32Detector`，tool-call 格式是 DSML：
+
+```text
+<｜DSML｜function_calls>
+<｜DSML｜invoke name="get_weather">
+<｜DSML｜parameter name="location" string="true">Beijing</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜function_calls>
+```
+
+detector 支持两种参数形态：
+
+- XML parameter tags。
+- invoke 内直接 JSON。
+
+streaming parser 会先发 tool name，再通过 previous arguments 和 common prefix 计算参数 diff。`_parse_parameters_from_xml(..., allow_partial=True)` 用 partial JSON parser 处理未闭合 JSON 或未闭合 parameter tag。
+
+cookbook 当前写法需要区分：DeepSeek-V3.2-Exp 的 tool path 可能使用 `deepseekv31` 加 `tool_chat_template_deepseekv32.jinja`；标准 DeepSeek-V3.2 使用 `--tool-call-parser deepseekv32` 并移除自定义 chat template。DeepSeek-V3.2-Speciale 不支持 tool calling。
+
+open `#21179` 指出 reasoning parser 可能吞掉 V3.2 tool-call markers；open `#21546` 则修 partial parsing 遇到 malformed JSON 的异常处理。
+
+## 10.1 Thinking radix cache：parser 之外的缓存层语义
+
+V3.2 的 reasoning/tool 输出除了 parser 外，还要看 prefix cache 是否复用 thinking tokens。`#22950` 是 closed 的 parser-gated reasoning cache strip 早期方案；当前主线是 `#23315`，它在 `server_args.py` 加 opt-in flag，并在 `schedule_batch.py`、`mem_cache/common.py` 中支持从 radix-cache entry 里剥离 thinking tokens。
+
+这条线和 DSML parser 是两层问题：如果 V3.2 tool-call marker 被 reasoning parser 吞掉，要看 `deepseekv32_detector.py` / `reasoning_parser.py`；如果多轮请求复用了不该复用的 `<think>` / `</think>` 前缀，要看 `#23315` 的 radix-cache strip 行为。
+
+## 11. 当前验证面与未合入方向
+
+当前验证面：
+
+- `test/registered/8-gpu-models/test_deepseek_v32.py`：DP8、DP8+MTP、TP8、TP8+MTP，带 `deepseekv32` tool parser 和 `deepseek-v3` reasoning parser。
+- 同文件的 `test_deepseek_v32_nsa_backends`：H200 上测试 `flashmla_sparse+flashmla_kv`、`fa3+fa3` 和 FP8 KV cache。
+- 同文件的 B200 GPQA 测试：reasoning mode，GPQA baseline `0.83`。
+- `test/registered/8-gpu-models/test_deepseek_v32_indexcache.py`：`index_topk_pattern` 和 `index_topk_freq=4`。
+- `test/manual/test_deepseek_chat_templates.py`：DeepSeek V3/V3.1/V3.2 template 参数类型。
+
+需要跟进的 open PR：
+
+- `#11191`：DSA sparse attention 与 CPU/GPU KV cache scheduling。
+- `#12820`：TP-SP 支持 DeepSeek V2/V3/V3.2。
+- `#16148`：V3.2 W4AFP8 MTP 使用 FP8 draft model。
+- `#17185`：context parallel NSA 中 TP `o_proj` linear。
+- `#17761`：V3.1/V3.2 tool output 后缺 Assistant token。
+- `#18167`：V3.2 DCP。
+- `#18275`：NPU allgather after qlora。
+- `#18733`：V3.2 PD disaggregation test。
+- `#19211`：抽出 `DeepseekV32Mixin`，降低 `deepseek_v2.py` 中 V3.2/NSA 逻辑复杂度。
+- `#19299`：DeepSeek weight loader 中 O(1) expert weight matching。
+- `#19609`：NSA attention 中 TP indexer weight。
+- `#19975`：AMD 上 V3.2 context parallel。
+- `#20360`：AMD CP round-robin-split 输出异常。
+- `#20531`：CP round-robin 下 NSA indexer ragged gather batch-view mismatch。
+- `#20809`：MTP draft model mapping 加 `DeepseekV32ForCausalLM`。
+- `#20880`：NSA model 初始化时拒绝 HiCache L3。
+- `#21179`：reasoning parsing 保留 V3.2 tool-call markers。
+- `#21194`：AMD AITER gfx95 路径中 DeepSeek `PPMissingLayer` 修复。
+- `#21506`：V3.2 NPU torch compile。
+- `#21529`：ROCm DeepSeek 架构 MXFP4 / Quark W4A4。
+- `#21530`：ROCm DeepSeek-variant fused MLA decode RoPE。
+- `#21546`：partial function-call parsing 捕获 MalformedJSON。
+- `#21889`：AMD TileLang NSA FP4 KV cache quantization。
+- `#22268`：DeepSeek MLA `prepare_qkv_latent` 绕过 LoRA adapter。
+- `#22473`：short sequences 的 dense MLA decode fallback。
+- `#22774`：MUSA backend 支持 DeepSeek V2/V3/R1-class layers。
+- `#22851`：新增 `--nsa-topk-backend`，接入 FlashInfer 和 PyTorch top-k。
+- `#22865`：扩展 sparsity framework 支持非 NSA sparse algorithms。
+- `#22938`：MLA refactor 后恢复 MI300X DeepSeek MLA 路径。
+- `#23195`：AWQ/compressed-tensors 下 DeepSeek MLA `.weight` 访问保护。
+- `#23241`：3FS backend 支持 DSA/mamba。
+- `#23257`：`DeepseekV2MoE` 在 CuteDSL EP + DP attention 下的 double-reduce。
+- `#23336`：spec v2 adaptive speculative decoding。
+- `#23351`：NSA piecewise CUDA graph。

--- a/skills/sglang-deepseek-v3-r1-optimization/SKILL.md
+++ b/skills/sglang-deepseek-v3-r1-optimization/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: sglang-deepseek-v3-r1-optimization
+description: PR-backed and current-main optimization manual for DeepSeek V3 and DeepSeek R1 in SGLang. Use when Codex needs to recover, extend, or audit DeepSeek V3/R1 MLA, MoE, shared experts, FP8/FP4/W4AFP8/MXFP4/NVFP4 loading, MTP, DeepEP, DP attention, LoRA, backend selection, or validation lanes.
+---
+
+# SGLang DeepSeek V3/R1 Optimization
+
+## Overview
+
+This skill covers the DeepSeek V3/R1 optimization ladder that is active in SGLang main. It intentionally excludes the V3.1 parser delta and the V3.2 DSA/NSA sparse-attention stack, which have separate skills.
+
+Current-main snapshot:
+
+- SGLang `origin/main`: `929e00eea` on `2026-04-21`
+- sgl-cookbook `origin/main`: `8ec4d03` on `2026-04-21`
+- active runtime entry: `python/sglang/srt/models/deepseek_v2.py`
+- DeepSeek V3/R1 entry class: `DeepseekV3ForCausalLM`
+- NextN/MTP entry class: `DeepseekV3ForCausalLMNextN`
+
+The historical evidence lives in:
+
+- [references/pr-history.md](references/pr-history.md): chronological PR evidence and code-level notes
+- [references/playbook.md](references/playbook.md): investigation order, symptom mapping, validation commands
+
+## Before You Change Anything
+
+Record the exact serving shape first:
+
+- model: V3, V3-0324, R1, R1-0528, R1-distill, or vendor quantized checkpoint
+- native FP8, BF16, INT8, AWQ, W4A8/W4AFP8, NVFP4, MXFP4, MXFP8, or LoRA
+- TP / DP / EP / PP / PD topology
+- DP attention enabled or not
+- DeepEP mode: none, normal, low_latency, or auto
+- MoE runner backend: triton, deep_gemm, flashinfer_trtllm, flashinfer_cutlass, flashinfer_cutedsl, cutlass_w4afp8, aiter, or auto
+- MLA attention backend: fa3, flashinfer, flashmla, cutlass_mla, trtllm_mla, aiter, triton, CPU/XPU/NPU fallback
+- MTP enabled or not, and whether the NextN layer is quantized differently from the target model
+- parser pair: `--reasoning-parser deepseek-v3` for V3 thinking-style output, `--reasoning-parser deepseek-r1` for R1, and `--tool-call-parser deepseekv3` for V3/R1 tool calls
+- exact registered/manual test lane and hardware
+
+## Core Principle
+
+Do not treat DeepSeek V3/R1 as only one optimization.
+
+- The V3/R1 base path is an MLA plus MoE throughput problem.
+- R1 adds a reasoning-parser contract and heavier quantized deployment tracks.
+- W4AFP8 is its own loader, kernel, EP, TP, and DeepEP story.
+- MTP is a NextN-model story; target model and draft layer can have different quantization or backend requirements.
+- Shared expert fusion is powerful but topology-sensitive. On current main it is disabled under DeepEP unless `--enforce-shared-experts-fusion` is set.
+- On Blackwell, server defaults may automatically select `trtllm_mla` and `flashinfer_trtllm`; on ROCm, AITER and TileLang paths are separate validation surfaces.
+
+The optimization order matters:
+
+1. confirm the loader and quant config
+2. confirm MLA backend and KV cache dtype
+3. confirm MoE runner and shared expert behavior
+4. add or validate MTP
+5. add DP attention, EP, PP, PD, or DeepEP only after the single-shape path is correct
+6. harden PCG, deterministic, LoRA, and backend-specific tests
+
+## Main Runtime Surfaces
+
+Start from these files before changing behavior:
+
+- `python/sglang/srt/models/deepseek_v2.py`
+- `python/sglang/srt/models/deepseek_nextn.py`
+- `python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py`
+- `python/sglang/srt/models/deepseek_common/attention_backend_handler.py`
+- `python/sglang/srt/models/deepseek_common/attention_forward_methods/`
+- `python/sglang/srt/layers/attention/flashattention_backend.py`
+- `python/sglang/srt/layers/radix_attention.py`
+- `python/sglang/srt/mem_cache/memory_pool.py`
+- `python/sglang/srt/layers/quantization/fp8_kernel.py`
+- `python/sglang/srt/layers/quantization/deep_gemm.py`
+- `python/sglang/compile_deep_gemm.py`
+- `python/sglang/srt/layers/moe/topk.py`
+- `python/sglang/srt/layers/moe/fused_moe_triton/fused_moe.py`
+- `python/sglang/srt/layers/moe/cutlass_w4a8_moe.py`
+- `python/sglang/srt/layers/moe/ep_moe/layer.py`
+- `python/sglang/srt/layers/moe/token_dispatcher/deepep.py`
+- `python/sglang/srt/layers/quantization/w4afp8.py`
+- `python/sglang/srt/layers/rotary_embedding.py`
+- `python/sglang/srt/server_args.py`
+- `python/sglang/srt/managers/schedule_batch.py`
+- `python/sglang/srt/mem_cache/common.py`
+- `python/sglang/srt/parser/reasoning_parser.py`
+- `python/sglang/srt/function_call/deepseekv3_detector.py`
+- `sgl-kernel/csrc/moe/moe_fused_gate.cu`
+- `sgl-kernel/csrc/moe/moe_align_kernel.cu`
+- `sgl-kernel/csrc/attention/merge_attn_states.cu`
+- `sgl-kernel/include/sgl_kernel_ops.h`
+
+## Open PRs to Track
+
+Check these before declaring a V3/R1 gap:
+
+- [#14194](https://github.com/sgl-project/sglang/pull/14194): DCP for `deepseek_v2`, open.
+- [#15315](https://github.com/sgl-project/sglang/pull/15315) and [#15380](https://github.com/sgl-project/sglang/pull/15380): group GEMM work for DeepSeek-R1-W4AFP8, open.
+- [#18892](https://github.com/sgl-project/sglang/pull/18892): JIT support for DeepSeek V3 GEMM, open.
+- [#6011](https://github.com/sgl-project/sglang/pull/6011): FlashInfer MLA speculative-decoding custom mask, open.
+- [#6738](https://github.com/sgl-project/sglang/pull/6738): partial MHA-kernel support in MLA forward when page size is greater than one, open.
+- [#7005](https://github.com/sgl-project/sglang/pull/7005): FlowMLA zero-overhead DP MLA memory optimization, open.
+- [#23336](https://github.com/sgl-project/sglang/pull/23336): adaptive speculative-num-steps support for spec v2 EAGLE workers, open.
+- [#21526](https://github.com/sgl-project/sglang/pull/21526): ROCm AITER router GEMM regression for non-DSR1 MoE, open.
+- [#21529](https://github.com/sgl-project/sglang/pull/21529): MXFP4 / Quark W4A4 support for DeepSeek architecture on ROCm, open.
+- [#21530](https://github.com/sgl-project/sglang/pull/21530): ROCm fused MLA decode RoPE fix for DeepSeek variants, open.
+- [#21531](https://github.com/sgl-project/sglang/pull/21531): migrate `dsv3_router_gemm` from AOT `sgl-kernel` to JIT, open.
+- [#22268](https://github.com/sgl-project/sglang/pull/22268): fix LoRA adapters bypassed in DeepSeek MLA `prepare_qkv_latent`, open.
+- [#22774](https://github.com/sgl-project/sglang/pull/22774): MUSA backend support for DeepSeek V2/V3/R1, open.
+- [#22938](https://github.com/sgl-project/sglang/pull/22938): restore DeepSeek MLA MI300X paths after the MLA refactor, open.
+- [#23195](https://github.com/sgl-project/sglang/pull/23195): guard `.weight` access in `DeepseekV2AttentionMLA` for AWQ/compressed-tensors, open.
+- [#23257](https://github.com/sgl-project/sglang/pull/23257): double-reduce in `DeepseekV2MoE` with CuteDSL EP plus DP attention, open.
+
+Known reverted track:
+
+- [#14162](https://github.com/sgl-project/sglang/pull/14162) enabled FP8 communication for R1 W4A8 DeepEP low-latency, was reverted by [#21719](https://github.com/sgl-project/sglang/pull/21719), then relanded by [#22316](https://github.com/sgl-project/sglang/pull/22316).
+
+Known exploratory or closed tracks:
+
+- [#5432](https://github.com/sgl-project/sglang/pull/5432) introduced a DeepGEMM `group_gemm_masked` BMM path for MLA FP8 quantization. Treat it as an explored path, not as the default production H200 speed path.
+- [#6151](https://github.com/sgl-project/sglang/pull/6151) explored hybrid attention backend wiring and closed without becoming the main V3/R1 path.
+- [#22950](https://github.com/sgl-project/sglang/pull/22950) explored parser-gated two-phase reasoning radix-cache stripping and closed before becoming current support; read [#23315](https://github.com/sgl-project/sglang/pull/23315) for the merged path.
+- [#22933](https://github.com/sgl-project/sglang/pull/22933) is current-main CPU shared-expert interface cleanup. It matters for CPU shared-expert parity, not for H200 GPU throughput.
+
+## Runtime Addendum
+
+Additional current-main runtime tracks should be checked in addition to the original H200 ladder:
+
+- [#21599](https://github.com/sgl-project/sglang/pull/21599) adds adaptive `speculative_num_steps` for EAGLE top-k=1. For V3/R1 MTP, inspect `server_args.py`, speculative runtime params, and EAGLE worker state before assuming the number of draft steps is static.
+- [#22128](https://github.com/sgl-project/sglang/pull/22128) allows piecewise CUDA graph to run with speculative decoding. When auditing PCG plus MTP failures, check `model_runner.py`, `piecewise_cuda_graph_runner.py`, and the server flag gate instead of treating the combination as unsupported.
+- [#23315](https://github.com/sgl-project/sglang/pull/23315) adds opt-in stripping of thinking tokens from radix cache. This touches `schedule_batch.py`, `mem_cache/common.py`, and `server_args.py`; it matters for DeepSeek V3/R1 reasoning-parser cache reuse, especially when thinking tokens should not become a reusable prefix.
+- [#22950](https://github.com/sgl-project/sglang/pull/22950) is the closed predecessor for that reasoning-cache behavior, and [#23336](https://github.com/sgl-project/sglang/pull/23336) is the open spec-v2 extension for adaptive speculative decoding.
+
+## H200 Single-Node Optimization Findings
+
+The single-node H200 optimization notes explicitly name a March-May 2025 H200 optimization ladder. A complete V3/R1 audit must include those PRs because many later abstractions hide the original performance reason.
+
+Required H200 PR coverage:
+
+- FP8 Block GEMM and DeepGEMM: [#3893](https://github.com/sgl-project/sglang/pull/3893), [#4165](https://github.com/sgl-project/sglang/pull/4165), [#4199](https://github.com/sgl-project/sglang/pull/4199), [#4613](https://github.com/sgl-project/sglang/pull/4613), [#5263](https://github.com/sgl-project/sglang/pull/5263), [#5310](https://github.com/sgl-project/sglang/pull/5310), [#5432](https://github.com/sgl-project/sglang/pull/5432), [#5473](https://github.com/sgl-project/sglang/pull/5473), [#5549](https://github.com/sgl-project/sglang/pull/5549), [#5628](https://github.com/sgl-project/sglang/pull/5628), [#6890](https://github.com/sgl-project/sglang/pull/6890).
+- Fused MoE, top-k, and shared experts: [#4530](https://github.com/sgl-project/sglang/pull/4530), [#5086](https://github.com/sgl-project/sglang/pull/5086), [#5371](https://github.com/sgl-project/sglang/pull/5371), [#5571](https://github.com/sgl-project/sglang/pull/5571), [#5716](https://github.com/sgl-project/sglang/pull/5716), [#5740](https://github.com/sgl-project/sglang/pull/5740), [#6220](https://github.com/sgl-project/sglang/pull/6220), [#6970](https://github.com/sgl-project/sglang/pull/6970).
+- MLA and attention backends: [#4472](https://github.com/sgl-project/sglang/pull/4472), [#4514](https://github.com/sgl-project/sglang/pull/4514), [#4831](https://github.com/sgl-project/sglang/pull/4831), [#5113](https://github.com/sgl-project/sglang/pull/5113), [#5210](https://github.com/sgl-project/sglang/pull/5210), [#5381](https://github.com/sgl-project/sglang/pull/5381), [#5385](https://github.com/sgl-project/sglang/pull/5385), [#5390](https://github.com/sgl-project/sglang/pull/5390), [#5578](https://github.com/sgl-project/sglang/pull/5578), [#5619](https://github.com/sgl-project/sglang/pull/5619), [#5748](https://github.com/sgl-project/sglang/pull/5748), [#5977](https://github.com/sgl-project/sglang/pull/5977), [#6034](https://github.com/sgl-project/sglang/pull/6034), [#6109](https://github.com/sgl-project/sglang/pull/6109).
+- MTP and backend interaction: [#3582](https://github.com/sgl-project/sglang/pull/3582), [#4218](https://github.com/sgl-project/sglang/pull/4218), [#4631](https://github.com/sgl-project/sglang/pull/4631), [#5707](https://github.com/sgl-project/sglang/pull/5707), [#5793](https://github.com/sgl-project/sglang/pull/5793), [#5952](https://github.com/sgl-project/sglang/pull/5952), [#6081](https://github.com/sgl-project/sglang/pull/6081), [#6109](https://github.com/sgl-project/sglang/pull/6109).
+
+When updating this skill, explicitly mark whether an H200 optimization is still current-main default, current-main optional, hardware-specific, or only an explored/closed path.
+
+## Evolution Path
+
+### Stage V3R1-H200: Single-node H200 performance ladder
+
+The H200 ladder is the missing context behind many later V3/R1 defaults.
+
+- FP8 Block GEMM evolved from Triton/Cutlass experiments into DeepGEMM-backed paths. Current main exposes DeepGEMM through `fp8_kernel.py`, `deep_gemm.py`, and `compile_deep_gemm.py`; Hopper/Blackwell defaults should be checked with `SGLANG_ENABLE_JIT_DEEPGEMM`.
+- Fused MoE acceleration starts before the current `fused_topk_deepseek` abstraction. `moe_fused_gate.cu`, `moe_align_kernel.cu`, `per_token_group_quant_8bit`, routed scaling fusion, and shared-expert fusion all belong to this stage.
+- MLA backend selection was built across FlashMLA, Cutlass MLA, FA3 MLA, and later MHA-chunked prefill paths. Do not conclude that a backend is current based only on an early support PR; check `server_args.py`, `attention_backend_handler.py`, and `docs/basic_usage/deepseek_v3.md`.
+- Small model-file optimizations matter: DeepSeek CUDA RoPE, removing `forward_absorb` copies, fusing `q_a_proj` with `kv_a_proj_with_mqa`, fusing MLA KV-cache writes, overlapping q/k norm, and removing scalar/allocator overhead all live on the hot path.
+- The closed hybrid-attention PR [#6151](https://github.com/sgl-project/sglang/pull/6151) should be cited as non-mainline context, not as shipped V3/R1 support.
+
+Success check:
+
+- every H200-note PR is either in the timeline, in a closed/exploratory note, or explicitly marked out of scope
+- current source paths have replaced historical file names where refactors moved the code
+- DeepGEMM, FA3/FlashMLA/Cutlass MLA, fused MoE, shared experts, and MTP interactions are checked together
+
+### Stage V3R1-0: Basic V3/R1 support is not enough
+
+Early DeepSeek support can launch, but the optimized path needs hardware-specific MLA, MoE, and quant handling.
+
+- AMD bring-up: [#2601](https://github.com/sgl-project/sglang/pull/2601), [#2667](https://github.com/sgl-project/sglang/pull/2667)
+- docs and launch recipes: [#3314](https://github.com/sgl-project/sglang/pull/3314), [#3522](https://github.com/sgl-project/sglang/pull/3522), [#4079](https://github.com/sgl-project/sglang/pull/4079)
+- current usage doc: `docs/basic_usage/deepseek_v3.md`
+
+Success check:
+
+- `DeepseekV3ForCausalLM` is selected
+- the loader recognizes the quant config
+- launch docs and current server defaults agree
+
+### Stage V3R1-1: MLA backend and FP8 correctness
+
+DeepSeek V3/R1 performance depends on MLA path selection, weight absorption, KV-cache dtype, DeepGEMM, and backend fallback.
+
+- block-wise FP8 and BMM paths feed the MLA absorbed path
+- `server_args.py` selects `trtllm_mla` on SM100 when no attention backend is set
+- `deepseek_weight_loader.py` requantizes or dequantizes `kv_b_proj` according to quant format
+- deterministic mode forces supported DeepSeek attention backends
+
+Key PRs:
+
+- [#9744](https://github.com/sgl-project/sglang/pull/9744)
+- [#11708](https://github.com/sgl-project/sglang/pull/11708)
+- [#14897](https://github.com/sgl-project/sglang/pull/14897)
+- [#15531](https://github.com/sgl-project/sglang/pull/15531)
+- [#19122](https://github.com/sgl-project/sglang/pull/19122)
+- [#23195](https://github.com/sgl-project/sglang/pull/23195), open
+
+### Stage V3R1-2: MoE routing and shared experts
+
+The main model has `256` routed experts plus one shared expert. Current main can remap `mlp.shared_experts` into expert slot `256` when shared-expert fusion is active.
+
+- `DeepseekV2MoE` computes `num_fused_shared_experts`
+- `TopK` is configured with grouped top-k, correction bias, routed scaling, and optional fused shared expert slots
+- `determine_num_fused_shared_experts()` disables fusion for incompatible shapes, W4AFP8 shared/routed mismatch, TBO/SBO, or DeepEP unless explicitly enforced
+- DeepEP fusion expands the local expert layout from `256` routed experts to `256 + EP_size` slots
+
+Key PRs:
+
+- [#15347](https://github.com/sgl-project/sglang/pull/15347)
+- [#17707](https://github.com/sgl-project/sglang/pull/17707)
+- [#18451](https://github.com/sgl-project/sglang/pull/18451)
+- [#20089](https://github.com/sgl-project/sglang/pull/20089)
+- [#21657](https://github.com/sgl-project/sglang/pull/21657)
+- [#21531](https://github.com/sgl-project/sglang/pull/21531), open
+
+### Stage V3R1-3: MTP and NextN
+
+DeepSeek V3/R1 MTP uses the NextN model as an EAGLE draft path.
+
+- target model: `DeepseekV3ForCausalLM`
+- draft model: `DeepseekV3ForCausalLMNextN`
+- `deepseek_nextn.py` handles the single NextN layer, shared head/embed reuse, quant override, and AMD R1 MXFP4 naming
+- current main allows quantized target and BF16 or differently quantized NextN layers, but validate the exact backend pair
+
+Key PRs:
+
+- [#7376](https://github.com/sgl-project/sglang/pull/7376)
+- [#13548](https://github.com/sgl-project/sglang/pull/13548)
+- [#18607](https://github.com/sgl-project/sglang/pull/18607)
+- [#19425](https://github.com/sgl-project/sglang/pull/19425)
+
+Validation:
+
+- `test/registered/8-gpu-models/test_deepseek_v3_mtp.py`
+- `test/registered/amd/test_deepseek_v3_mtp.py`
+- `test/registered/spec/eagle/test_deepseek_v3_fp4_mtp_small.py`
+
+### Stage V3R1-4: R1 W4AFP8 and DeepEP
+
+R1 W4AFP8 is a separate ladder from native FP8.
+
+- `W4AFp8Config` detects mixed precision and maps linear layers to FP8 while MoE experts use W4A8
+- `cutlass_w4a8_moe.py` handles packed int4 expert weights and FP8 activations
+- EP support maps global experts to local partitions
+- normal DeepEP uses dispatch output metadata and `apply_deepep_normal`
+- low-latency DeepEP has special communication behavior and must be checked against the revert/reland sequence
+
+Key PRs:
+
+- [#7762](https://github.com/sgl-project/sglang/pull/7762)
+- [#8118](https://github.com/sgl-project/sglang/pull/8118)
+- [#8247](https://github.com/sgl-project/sglang/pull/8247)
+- [#8464](https://github.com/sgl-project/sglang/pull/8464)
+- [#10027](https://github.com/sgl-project/sglang/pull/10027)
+- [#14162](https://github.com/sgl-project/sglang/pull/14162)
+- [#21719](https://github.com/sgl-project/sglang/pull/21719)
+- [#22316](https://github.com/sgl-project/sglang/pull/22316)
+
+### Stage V3R1-5: Quantized backend coverage
+
+Treat each quantization format as a separate loader and backend contract.
+
+- W4AFP8: `w4afp8.py`, `cutlass_w4a8_moe.py`, DeepEP and TP variants
+- NVFP4 / ModelOpt FP4: server defaults and Blackwell backend selection
+- MXFP4 / Quark: AMD R1 and open ROCm DeepSeek-architecture work
+- MXFP8: FlashInfer TRTLLM routed MoE support
+- LoRA: quant-info refactor and DeepSeek MLA LoRA support
+
+Key PRs:
+
+- [#11512](https://github.com/sgl-project/sglang/pull/11512)
+- [#12778](https://github.com/sgl-project/sglang/pull/12778)
+- [#12921](https://github.com/sgl-project/sglang/pull/12921)
+- [#18242](https://github.com/sgl-project/sglang/pull/18242)
+- [#19425](https://github.com/sgl-project/sglang/pull/19425)
+- [#21280](https://github.com/sgl-project/sglang/pull/21280)
+- [#22323](https://github.com/sgl-project/sglang/pull/22323)
+- [#21529](https://github.com/sgl-project/sglang/pull/21529), open
+
+### Stage V3R1-6: Distributed and backend hardening
+
+The late-stage failures are usually topology bugs rather than model-architecture bugs.
+
+- DP attention plus torch.compile GPU faults
+- BF16 KV accuracy under DP
+- AITER correction-bias dtype conversion
+- XPU and MUSA backend compatibility
+- OOM during weight loading
+- PCG and deterministic test cleanup
+
+Key PRs:
+
+- [#10361](https://github.com/sgl-project/sglang/pull/10361)
+- [#12000](https://github.com/sgl-project/sglang/pull/12000)
+- [#17744](https://github.com/sgl-project/sglang/pull/17744)
+- [#18461](https://github.com/sgl-project/sglang/pull/18461)
+- [#19834](https://github.com/sgl-project/sglang/pull/19834)
+- [#19843](https://github.com/sgl-project/sglang/pull/19843)
+- [#20841](https://github.com/sgl-project/sglang/pull/20841)
+- [#22774](https://github.com/sgl-project/sglang/pull/22774), open
+
+## Validation Surface
+
+Use the narrowest lane that matches the change:
+
+- base V3: `test/registered/8-gpu-models/test_deepseek_v3_basic.py`
+- V3 MTP: `test/registered/8-gpu-models/test_deepseek_v3_mtp.py`
+- AMD V3: `test/registered/amd/test_deepseek_v3_basic.py`
+- AMD V3 KV FP8: `test/registered/amd/test_deepseek_v3_basic_kv_fp8.py`
+- R1 MXFP4: `test/registered/amd/test_deepseek_r1_mxfp4_8gpu.py`
+- R1 FP8 TRTLLM backend: `test/registered/backends/test_deepseek_r1_fp8_trtllm_backend.py`
+- FP4: `test/registered/quant/test_deepseek_v3_fp4_4gpu.py`
+- W4A8: `test/registered/quant/test_w4a8_deepseek_v3.py`
+- MLA: `test/registered/mla/test_mla_deepseek_v3.py`
+- INT8 MLA: `test/registered/mla/test_mla_int8_deepseek_v3.py`
+- LoRA: `test/registered/lora/test_lora_deepseek_v3_base_logprob_diff.py`
+- router/top-k kernel: `test/registered/kernels/test_fused_topk_deepseek.py`

--- a/skills/sglang-deepseek-v3-r1-optimization/agents/openai.yaml
+++ b/skills/sglang-deepseek-v3-r1-optimization/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SGLang DeepSeek V3/R1 Optimization"
+  short_description: "Current-main DeepSeek V3/R1 ladder for MLA, MoE, quantized R1, MTP, DeepEP, LoRA, and backend validation"
+  default_prompt: "Use $sglang-deepseek-v3-r1-optimization to optimize or debug DeepSeek V3 or DeepSeek R1 in SGLang, including MLA backend selection, shared-expert MoE behavior, FP8/FP4/W4AFP8/MXFP4/NVFP4 loading, MTP/NextN, DeepEP, DP attention, LoRA, and hardware-specific validation lanes."

--- a/skills/sglang-deepseek-v3-r1-optimization/references/playbook.md
+++ b/skills/sglang-deepseek-v3-r1-optimization/references/playbook.md
@@ -1,0 +1,145 @@
+# DeepSeek V3/R1 Playbook
+
+Use this playbook when a V3/R1 optimization or regression report is ambiguous. The goal is to map the symptom to the right layer before changing code.
+
+## 1. Identify The Model Shape
+
+Collect these first:
+
+- `hf_config.architectures`
+- `quantization_config`
+- `n_routed_experts`, `n_shared_experts`, `num_experts_per_tok`, `n_group`, `topk_group`
+- `q_lora_rank`, `kv_lora_rank`, `qk_nope_head_dim`, `qk_rope_head_dim`, `v_head_dim`
+- TP / DP / EP / PP / PD
+- `--enable-dp-attention`
+- `--moe-a2a-backend`, `--deepep-mode`, `--moe-runner-backend`
+- `--attention-backend`, `--prefill-attention-backend`, `--decode-attention-backend`
+- `--speculative-algorithm`, `--speculative-*`, `SGLANG_ENABLE_SPEC_V2`
+- `--reasoning-parser`, `--tool-call-parser`, chat template
+
+If `is_deepseek_nsa(config)` is true, switch to `sglang-deepseek-v32-optimization`.
+If the report is only about DeepSeek V3.1 tool/thinking behavior, switch to `sglang-deepseek-v31-optimization`.
+
+## 2. Loader Failures
+
+Check in this order:
+
+1. `python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py`
+2. `python/sglang/srt/layers/quantization/w4afp8.py`
+3. `python/sglang/srt/layers/quantization/modelopt_quant.py`
+4. `python/sglang/srt/layers/quantization/quark/`
+5. `python/sglang/srt/models/deepseek_nextn.py` when MTP is enabled
+
+Common clues:
+
+- missing `kv_b_proj` scale means the MLA post-load path did not remap `k_scale` / `v_scale`
+- `.weight` access on quantized layers may be an AWQ/compressed-tensors bug; see open [#23195](https://github.com/sgl-project/sglang/pull/23195)
+- R1 MXFP4 draft/NextN can use `model.layers.61*` naming; check `deepseek_nextn.py`
+- W4AFP8 shared and routed experts may use different quant methods, which disables shared expert fusion
+
+## 3. MLA Or Attention Regressions
+
+Start with:
+
+- `server_args.py` model-specific adjustments
+- `attention_backend_handler.py`
+- `attention_forward_methods/forward_mla.py`
+- `attention_forward_methods/forward_mha.py`
+- `deepseek_weight_loader.py` post-load `kv_b_proj` handling
+
+Useful distinctions:
+
+- SM100 defaults to `trtllm_mla` for V3/R1 when no MLA backend is set.
+- PCG and deterministic inference can force a different MLA/MHA method.
+- ROCm fused MLA decode RoPE is still tracked by open [#21530](https://github.com/sgl-project/sglang/pull/21530).
+- MI300X path restoration after the MLA refactor is still tracked by open [#22938](https://github.com/sgl-project/sglang/pull/22938).
+
+## 4. H200 Performance Ladder
+
+If the report is about single-node H200 DeepSeek V3/R1 throughput, compare against the local H200 note before changing code:
+
+- FP8 Block GEMM / DeepGEMM: check `fp8_kernel.py`, `deep_gemm.py`, `compile_deep_gemm.py`, [#5432](https://github.com/sgl-project/sglang/pull/5432), [#5473](https://github.com/sgl-project/sglang/pull/5473), [#5549](https://github.com/sgl-project/sglang/pull/5549), and [#5628](https://github.com/sgl-project/sglang/pull/5628). `#5432` is an explored BMM path, not automatically the default.
+- Fused MoE preprocessing: check `moe_fused_gate.cu`, `moe_align_kernel.cu`, `per_token_group_quant_8bit`, [#4530](https://github.com/sgl-project/sglang/pull/4530), [#5086](https://github.com/sgl-project/sglang/pull/5086), [#5716](https://github.com/sgl-project/sglang/pull/5716), [#5740](https://github.com/sgl-project/sglang/pull/5740), and routed-scaling fusion in [#6220](https://github.com/sgl-project/sglang/pull/6220) / [#6970](https://github.com/sgl-project/sglang/pull/6970).
+- MLA backend hot path: check FlashMLA [#4514](https://github.com/sgl-project/sglang/pull/4514), FA3 MLA [#4831](https://github.com/sgl-project/sglang/pull/4831) / [#5210](https://github.com/sgl-project/sglang/pull/5210), Cutlass MLA [#5390](https://github.com/sgl-project/sglang/pull/5390), and docs [#6034](https://github.com/sgl-project/sglang/pull/6034).
+- MLA model-file kernels: check chunked MHA prefill [#5113](https://github.com/sgl-project/sglang/pull/5113), merge-state kernel [#5381](https://github.com/sgl-project/sglang/pull/5381), DeepSeek CUDA RoPE [#5385](https://github.com/sgl-project/sglang/pull/5385), removed `forward_absorb` copy [#5578](https://github.com/sgl-project/sglang/pull/5578), fused `q_a_proj` / `kv_a_proj_with_mqa` [#5619](https://github.com/sgl-project/sglang/pull/5619), fused MLA KV-cache writes [#5748](https://github.com/sgl-project/sglang/pull/5748), and q/k norm overlap [#5977](https://github.com/sgl-project/sglang/pull/5977).
+- Closed or exploratory paths: hybrid attention [#6151](https://github.com/sgl-project/sglang/pull/6151) closed, and DeepGEMM BMM [#5432](https://github.com/sgl-project/sglang/pull/5432) must be checked against current defaults before being described as shipped throughput behavior.
+
+## 5. MoE Routing And Shared Experts
+
+Read `DeepseekV2MoE.__init__` and `DeepseekV2ForCausalLM.determine_num_fused_shared_experts()`.
+
+Check:
+
+- whether `num_fused_shared_experts` is `0` or `1`
+- whether DeepEP is active
+- whether `--enforce-shared-experts-fusion` was set
+- whether TBO/SBO disables fusion
+- whether W4AFP8 disables fusion because routed and shared experts have different quantization
+- whether `TopKOutputFormat.STANDARD` is being forced for unquantized MTP layers
+
+If the router is hot:
+
+- `fused_topk_deepseek` is the current preferred optimized path when its constraints are met
+- `dsv3_router_gemm` still has an open JIT migration track in [#21531](https://github.com/sgl-project/sglang/pull/21531)
+- AMD can select `aiter_dsv3_router_gemm` when expert count is at most `256`
+
+## 6. R1 W4AFP8 / W4A8
+
+Do not debug this as ordinary FP8.
+
+Checklist:
+
+- `W4AFp8Config` is selected from `hf_quant_config.json` or quantization config
+- `cutlass_w4a8_moe.py` has the active runner for the selected mode
+- `ep_moe/layer.py` maps experts correctly under EP
+- `token_dispatcher/deepep.py` emits the expected normal or low-latency dispatch format
+- if low-latency DeepEP is enabled, account for [#14162](https://github.com/sgl-project/sglang/pull/14162), [#21719](https://github.com/sgl-project/sglang/pull/21719), and [#22316](https://github.com/sgl-project/sglang/pull/22316)
+
+## 7. MTP / NextN
+
+If `--speculative-algorithm EAGLE` is set:
+
+- inspect `deepseek_nextn.py`
+- verify target and draft quant configs separately
+- check the MTP layer id and naming
+- check whether the draft MoE backend is overridden by server args
+- query `/server_info` for `avg_spec_accept_length`
+
+Expected H200 V3 MTP registered behavior:
+
+- GSM8K score above `0.935`
+- average spec accept length above `2.8`
+- batch-size-1 speed above the non-MTP lane
+
+## 8. Parser Issues
+
+For V3/R1:
+
+- V3 tool calling uses `--tool-call-parser deepseekv3`
+- V3 thinking-style output uses `--reasoning-parser deepseek-v3`
+- R1 reasoning uses `--reasoning-parser deepseek-r1`
+- R1 can produce reasoning without a starting `<think>` tag; `DeepSeekR1Detector` forces reasoning until `</think>`
+
+If the parser issue is specifically V3.1 or V3.2, switch skills.
+
+## 9. Validation Order
+
+Pick the smallest lane that covers the risk:
+
+1. loader-only: import or unit-level weight-loading test if available
+2. parser-only: function-call or reasoning parser unit tests
+3. MLA/backend: `test/registered/mla/test_mla_deepseek_v3.py`
+4. V3 base: `test/registered/8-gpu-models/test_deepseek_v3_basic.py`
+5. V3 MTP: `test/registered/8-gpu-models/test_deepseek_v3_mtp.py`
+6. W4A8/W4AFP8: `test/registered/quant/test_w4a8_deepseek_v3.py`
+7. R1 backend: `test/registered/backends/test_deepseek_r1_fp8_trtllm_backend.py`
+8. AMD/R1 MXFP4: `test/registered/amd/test_deepseek_r1_mxfp4_8gpu.py`
+9. LoRA: `test/registered/lora/test_lora_deepseek_v3_base_logprob_diff.py`
+
+## 10. Common False Conclusions
+
+- "DeepSeek V3 official weights need `--quantization fp8`." They do not; the official V3 checkpoint is already FP8.
+- "DeepEP automatically means shared experts are fused." Current main requires `--enforce-shared-experts-fusion` under DeepEP.
+- "R1 W4AFP8 equals FP8." It has its own quant config, Cutlass W4A8 MoE kernels, and DeepEP paths.
+- "MTP uses the same quant config as the target model." The NextN layer may be BF16 or have special quant handling.
+- "A PR title mentioning support means current main still contains that path." Check reverts and relands, especially [#14162](https://github.com/sgl-project/sglang/pull/14162), [#21719](https://github.com/sgl-project/sglang/pull/21719), and [#22316](https://github.com/sgl-project/sglang/pull/22316).

--- a/skills/sglang-deepseek-v3-r1-optimization/references/pr-history.md
+++ b/skills/sglang-deepseek-v3-r1-optimization/references/pr-history.md
@@ -1,0 +1,265 @@
+# DeepSeek V3/R1 PR History
+
+Snapshot:
+
+- SGLang `origin/main`: `929e00eea`
+- sgl-cookbook `origin/main`: `8ec4d03`
+- Date: `2026-04-21`
+
+This history covers DeepSeek V3 and R1 only. DeepSeek V3.1 and V3.2 have separate skills because their optimization problems are different.
+
+## Chronological Timeline
+
+| Date | PR | State | Area | Main effect |
+| --- | ---: | --- | --- | --- |
+| 2024-12-26 | [#2601](https://github.com/sgl-project/sglang/pull/2601) | merged | AMD | Enabled DeepSeek V3 on AMD by touching Triton decode attention and fused MoE. |
+| 2024-12-30 | [#2667](https://github.com/sgl-project/sglang/pull/2667) | merged | AMD accuracy | Fixed DeepSeek V3 FP8 numerical behavior in `deepseek_v2.py`. |
+| 2025-02-05 | [#3314](https://github.com/sgl-project/sglang/pull/3314) | merged | docs | Added DeepSeek usage and multi-node documentation. |
+| 2025-02-12 | [#3522](https://github.com/sgl-project/sglang/pull/3522) | merged | docs | Refined DeepSeek V3 launch-server docs. |
+| 2025-02-14 | [#3582](https://github.com/sgl-project/sglang/pull/3582) | merged | MTP | Added NextN/EAGLE speculative decoding support for DeepSeek V3/R1. |
+| 2025-02-26 | [#3893](https://github.com/sgl-project/sglang/pull/3893) | merged | FP8 GEMM | Added DeepGEMM and SGLang FP8 block-wise GEMM benchmarks. |
+| 2025-03-05 | [#4079](https://github.com/sgl-project/sglang/pull/4079) | merged | docs | Added INT8 launch example. |
+| 2025-03-07 | [#4165](https://github.com/sgl-project/sglang/pull/4165) | merged | DeepGEMM | Integrated DeepGEMM into `sgl-kernel`. |
+| 2025-03-08 | [#4199](https://github.com/sgl-project/sglang/pull/4199) | merged | DeepGEMM | Made linear layers support DeepGEMM. |
+| 2025-03-09 | [#4218](https://github.com/sgl-project/sglang/pull/4218) | merged | MTP/MLA | Added NextN support for the FlashInfer MLA backend. |
+| 2025-03-16 | [#4472](https://github.com/sgl-project/sglang/pull/4472) | merged | FlashMLA | Added the initial FlashMLA backend. |
+| 2025-03-17 | [#4514](https://github.com/sgl-project/sglang/pull/4514) | merged | FlashMLA/graph | Added CUDA graph support for the FlashMLA backend. |
+| 2025-03-18 | [#4530](https://github.com/sgl-project/sglang/pull/4530) | merged | fused MoE | Added the DeepSeek-style fused MoE group gate selection kernel. |
+| 2025-03-20 | [#4613](https://github.com/sgl-project/sglang/pull/4613) | merged | DeepGEMM default | Set DeepGEMM as the default on Hopper. |
+| 2025-03-20 | [#4631](https://github.com/sgl-project/sglang/pull/4631) | merged | ROCm MTP | Enabled MTP/NextN on AMD GPUs. |
+| 2025-03-27 | [#4831](https://github.com/sgl-project/sglang/pull/4831) | merged | FA3 MLA | Added FA3 backend support for MLA. |
+| 2025-04-05 | [#5086](https://github.com/sgl-project/sglang/pull/5086) | merged | MoE align | Reduced `moe_align_block_size_kernel` small-batch overhead. |
+| 2025-04-07 | [#5113](https://github.com/sgl-project/sglang/pull/5113) | merged | MHA chunked prefill | Added `MHA_CHUNKED_KV` for DeepSeek chunked prefill. |
+| 2025-04-09 | [#5210](https://github.com/sgl-project/sglang/pull/5210) | merged | FA3 default | Used FA3 MLA by default on Hopper. |
+| 2025-04-11 | [#5263](https://github.com/sgl-project/sglang/pull/5263) | merged | DeepGEMM guard | Temporarily turned off DeepGEMM by default. |
+| 2025-04-12 | [#5310](https://github.com/sgl-project/sglang/pull/5310) | merged | DeepGEMM guard | Limited DeepGEMM usage to Hopper. |
+| 2025-04-14 | [#5371](https://github.com/sgl-project/sglang/pull/5371) | merged | fused MoE | Applied the fused MoE gate in DeepSeek V3/R1. |
+| 2025-04-14 | [#5381](https://github.com/sgl-project/sglang/pull/5381) | merged | MLA kernel | Added the faster `merge_state_v2` CUDA merge-attention-state kernel. |
+| 2025-04-14 | [#5385](https://github.com/sgl-project/sglang/pull/5385) | merged | RoPE | Applied DeepSeek CUDA RoPE. |
+| 2025-04-14 | [#5390](https://github.com/sgl-project/sglang/pull/5390) | merged | Cutlass MLA | Added the Cutlass MLA attention backend. |
+| 2025-04-15 | [#5432](https://github.com/sgl-project/sglang/pull/5432) | merged | DeepGEMM BMM | Introduced DeepGEMM `group_gemm_masked` as an MLA BMM exploration. |
+| 2025-04-16 | [#5473](https://github.com/sgl-project/sglang/pull/5473) | merged | FP8 quant | Switched to `sglang_per_token_group_quant_fp8` from `sgl-kernel`. |
+| 2025-04-19 | [#5549](https://github.com/sgl-project/sglang/pull/5549) | merged | MLA FP8 quant | Removed one kernel in `per_tensor_quant_mla_fp8` with zero-scalar reuse. |
+| 2025-04-20 | [#5571](https://github.com/sgl-project/sglang/pull/5571) | merged | shared experts | Enabled DeepSeek V3 shared-expert fusion on SM90. |
+| 2025-04-20 | [#5578](https://github.com/sgl-project/sglang/pull/5578) | merged | MLA copy | Removed an extra copy in DeepSeek `forward_absorb`. |
+| 2025-04-22 | [#5619](https://github.com/sgl-project/sglang/pull/5619) | merged | MLA projection | Fused `q_a_proj` and `kv_a_proj_with_mqa` for DeepSeek. |
+| 2025-04-22 | [#5628](https://github.com/sgl-project/sglang/pull/5628) | merged | DeepGEMM default | Turned DeepGEMM back on by default and updated docs. |
+| 2025-04-24 | [#5707](https://github.com/sgl-project/sglang/pull/5707) | merged | MTP/fusion | Fixed the R1 combination of MTP and shared-expert fusion. |
+| 2025-04-24 | [#5716](https://github.com/sgl-project/sglang/pull/5716) | merged | MoE tuning | Updated H20 fused-MoE Triton configs for FP8 W8A8 DeepSeek/R1. |
+| 2025-04-25 | [#5740](https://github.com/sgl-project/sglang/pull/5740) | merged | MoE tuning | Updated H200 Triton 3.2 fused-MoE configs and warning behavior. |
+| 2025-04-25 | [#5748](https://github.com/sgl-project/sglang/pull/5748) | merged | MLA KV cache | Fused the MLA set-KV-cache kernel and removed K concat overhead. |
+| 2025-04-27 | [#5793](https://github.com/sgl-project/sglang/pull/5793) | merged | MTP ergonomics | Auto-set the MTP draft model path. |
+| 2025-05-01 | [#5952](https://github.com/sgl-project/sglang/pull/5952) | merged | MTP API | Updated CI tests and docs for the MTP API change. |
+| 2025-05-02 | [#5977](https://github.com/sgl-project/sglang/pull/5977) | merged | MLA streams | Overlapped q/k norm with two streams. |
+| 2025-05-05 | [#6034](https://github.com/sgl-project/sglang/pull/6034) | merged | docs | Documented MLA attention backend choices. |
+| 2025-05-07 | [#6081](https://github.com/sgl-project/sglang/pull/6081) | merged | MTP/DP attention | Added MTP support with DP attention. |
+| 2025-05-08 | [#6109](https://github.com/sgl-project/sglang/pull/6109) | merged | FlashMLA/MTP | Added FlashMLA backend support with MTP and FP8 KV cache. |
+| 2025-05-09 | [#6151](https://github.com/sgl-project/sglang/pull/6151) | closed | hybrid attention | Explored hybrid attention backend wiring; this did not become the main V3/R1 path. |
+| 2025-05-12 | [#6220](https://github.com/sgl-project/sglang/pull/6220) | merged | fused MoE | Fused the routed scaling factor into the top-k reduce kernel. |
+| 2025-06-05 | [#6890](https://github.com/sgl-project/sglang/pull/6890) | merged | DeepGEMM/MLA | Replaced Triton with DeepGEMM for `fused_qkv_a_proj_with_mqa`. |
+| 2025-06-08 | [#6970](https://github.com/sgl-project/sglang/pull/6970) | merged | routed scaling | Fused routed scaling factor in DeepSeek. |
+| 2025-06-13 | [#7146](https://github.com/sgl-project/sglang/pull/7146) | merged | DeepGEMM format | Supported the new DeepGEMM format in per-token-group quantization. |
+| 2025-06-13 | [#7150](https://github.com/sgl-project/sglang/pull/7150) | merged | DeepGEMM refactor | Refactored DeepGEMM integration. |
+| 2025-06-13 | [#7155](https://github.com/sgl-project/sglang/pull/7155) | merged | DeepGEMM format | Added SRT-side support for the new DeepGEMM quant format. |
+| 2025-06-13 | [#7156](https://github.com/sgl-project/sglang/pull/7156) | merged | DeepGEMM format | Re-quantized DeepSeek weights for the new DeepGEMM input format. |
+| 2025-06-14 | [#7172](https://github.com/sgl-project/sglang/pull/7172) | merged | DeepGEMM | Completed support for the new DeepGEMM path. |
+| 2025-06-20 | [#7376](https://github.com/sgl-project/sglang/pull/7376) | merged | MTP/FP4 | Fixed MTP with DeepSeek R1 FP4. |
+| 2025-07-04 | [#7762](https://github.com/sgl-project/sglang/pull/7762) | merged | W4AFP8 | Added W4AFP8 config, Cutlass W4A8 MoE, and EP-MoE path for R1. |
+| 2025-07-17 | [#8118](https://github.com/sgl-project/sglang/pull/8118) | merged | W4AFP8 TP | Added TP mode for R1-W4AFP8 and Cutlass grouped kernels. |
+| 2025-07-22 | [#8247](https://github.com/sgl-project/sglang/pull/8247) | merged | W4A8 DeepEP | Added normal DeepEP support for R1 W4A8/W4AFP8. |
+| 2025-07-28 | [#8464](https://github.com/sgl-project/sglang/pull/8464) | merged | W4A8 DeepEP LL | Added low-latency DeepEP support for R1 W4A8. |
+| 2025-09-04 | [#10027](https://github.com/sgl-project/sglang/pull/10027) | merged | W4AFP8 perf | Optimized R1 W4AFP8 glue kernels. |
+| 2025-09-12 | [#10361](https://github.com/sgl-project/sglang/pull/10361) | merged | DP/compile | Fixed GPU fault when DeepSeek V3 runs with DP and torch-compile. |
+| 2025-10-12 | [#11512](https://github.com/sgl-project/sglang/pull/11512) | merged | FP4 defaults | Updated R1-FP4 default config on Blackwell. |
+| 2025-10-16 | [#11708](https://github.com/sgl-project/sglang/pull/11708) | merged | FP4/SM120 | Enabled FP4 DeepSeek on SM120. |
+| 2025-10-23 | [#12000](https://github.com/sgl-project/sglang/pull/12000) | merged | deterministic | Added deterministic inference support for DeepSeek-architecture models on a single GPU. |
+| 2025-10-24 | [#12057](https://github.com/sgl-project/sglang/pull/12057) | merged | docs | Added W4FP8 usage example. |
+| 2025-11-06 | [#12778](https://github.com/sgl-project/sglang/pull/12778) | merged | quant defaults | Updated DeepSeek V3 quantization auto setting for SM100. |
+| 2025-11-09 | [#12921](https://github.com/sgl-project/sglang/pull/12921) | merged | W4AFP8 perf | Optimized W4AFP8 kernels on DeepSeek-V3-0324. |
+| 2025-11-19 | [#13548](https://github.com/sgl-project/sglang/pull/13548) | merged | MTP/B200 | Fixed DeepSeek V3 MTP on B200. |
+| 2025-11-30 | [#14162](https://github.com/sgl-project/sglang/pull/14162) | merged | DeepEP LL | Made R1 W4A8 DeepEP low-latency dispatch use FP8 communication. |
+| 2025-12-11 | [#14897](https://github.com/sgl-project/sglang/pull/14897) | merged | DP accuracy | Fixed DeepSeek V3 DP accuracy with BF16 KV. |
+| 2025-12-17 | [#15304](https://github.com/sgl-project/sglang/pull/15304) | merged | MXFP4 | Fixed accuracy when running MXFP4 DeepSeek V3 with EP. |
+| 2025-12-18 | [#15347](https://github.com/sgl-project/sglang/pull/15347) | merged | router/top-k | Switched to optimized `fused_topk_deepseek` instead of generic `moe_fused_gate`. |
+| 2025-12-20 | [#15531](https://github.com/sgl-project/sglang/pull/15531) | merged | PCG/FP4 | Added piecewise CUDA graph support for DeepSeek V3 FP4. |
+| 2026-01-07 | [#16649](https://github.com/sgl-project/sglang/pull/16649) | merged | loader refactor | Split DeepSeek V2/V3 weight loader into a mixin. |
+| 2026-01-15 | [#17133](https://github.com/sgl-project/sglang/pull/17133) | merged | MoE tuning | Added H20/H20-3E fused MoE configs for V3.1/V3.2 shapes. |
+| 2026-01-16 | [#17178](https://github.com/sgl-project/sglang/pull/17178) | merged | eval | Removed `deepseek-r1` from thinking-mode choices because R1 reasoning parser is different from V3-style thinking mode. |
+| 2026-01-25 | [#17707](https://github.com/sgl-project/sglang/pull/17707) | merged | router benchmark | Added Blackwell benchmark for `dsv3_router_gemm`. |
+| 2026-01-26 | [#17744](https://github.com/sgl-project/sglang/pull/17744) | merged | loader memory | Fixed OOM by deferring `dict(weights)` materialization. |
+| 2026-02-03 | [#18242](https://github.com/sgl-project/sglang/pull/18242) | merged | ROCm | Optimized DeepSeek R1 on MI300X. |
+| 2026-02-08 | [#18451](https://github.com/sgl-project/sglang/pull/18451) | merged | AMD router | Used `aiter_dsv3_router_gemm` when expert count is at most 256. |
+| 2026-02-09 | [#18461](https://github.com/sgl-project/sglang/pull/18461) | merged | XPU | Enabled R1 inference on Intel GPU. |
+| 2026-02-11 | [#18607](https://github.com/sgl-project/sglang/pull/18607) | merged | AMD MTP | Fixed TP4 DeepSeek V3 MTP accuracy on AMD. |
+| 2026-02-22 | [#19122](https://github.com/sgl-project/sglang/pull/19122) | merged | MLA refactor | Migrated DeepSeek MLA forward code into shared forward-method modules. |
+| 2026-02-26 | [#19425](https://github.com/sgl-project/sglang/pull/19425) | merged | R1 MXFP4 | Fixed AMD R1-0528-MXFP4 weight-load shape mismatch. |
+| 2026-03-04 | [#19834](https://github.com/sgl-project/sglang/pull/19834) | merged | AMD CI | Added MI35x tests for KV FP8 and all-reduce fusion in DeepSeek lanes. |
+| 2026-03-04 | [#19843](https://github.com/sgl-project/sglang/pull/19843) | merged | AMD perf | Used BF16 correction bias in AITER FP8 path to avoid runtime dtype conversion. |
+| 2026-03-18 | [#20841](https://github.com/sgl-project/sglang/pull/20841) | merged | DP bugfix | Fixed GPU fault when DeepSeek R1 runs with DP. |
+| 2026-03-24 | [#21280](https://github.com/sgl-project/sglang/pull/21280) | merged | MXFP8 | Added MXFP8 DeepSeek V3 support in routed MoE. |
+| 2026-03-28 | [#21599](https://github.com/sgl-project/sglang/pull/21599) | merged | MTP/spec | Added adaptive `speculative_num_steps` for EAGLE top-k=1. |
+| 2026-03-31 | [#21719](https://github.com/sgl-project/sglang/pull/21719) | merged | revert | Reverted #14162. |
+| 2026-04-05 | [#22128](https://github.com/sgl-project/sglang/pull/22128) | merged | PCG/spec | Allowed piecewise CUDA graph with speculative decoding. |
+| 2026-04-08 | [#22316](https://github.com/sgl-project/sglang/pull/22316) | merged | reland | Relanded R1 W4A8 DeepEP low-latency FP8 communication. |
+| 2026-04-08 | [#22323](https://github.com/sgl-project/sglang/pull/22323) | merged | LoRA | Refactored LoRA quant info and added DeepSeek V3 MLA LoRA support. |
+| 2026-04-16 | [#22933](https://github.com/sgl-project/sglang/pull/22933) | merged | CPU shared expert | Expanded CPU shared-expert interface when scaling factor is absent. |
+| 2026-04-16 | [#22950](https://github.com/sgl-project/sglang/pull/22950) | closed | reasoning cache | Explored parser-gated two-phase radix-cache stripping for reasoning tokens. |
+| 2026-04-20 | [#23195](https://github.com/sgl-project/sglang/pull/23195) | open | quant bugfix | Guards `.weight` access in DeepSeek MLA for AWQ/compressed-tensors. |
+| 2026-04-20 | [#23257](https://github.com/sgl-project/sglang/pull/23257) | open | MoE/DP | Fixes double-reduce with CuteDSL EP plus DP attention. |
+| 2026-04-21 | [#23315](https://github.com/sgl-project/sglang/pull/23315) | merged | reasoning cache | Added opt-in stripping of thinking tokens from radix cache. |
+| 2026-04-21 | [#23336](https://github.com/sgl-project/sglang/pull/23336) | open | spec v2 | Extends adaptive speculative decoding to spec v2 EAGLE workers. |
+
+## Code-Level Narrative
+
+### 1. AMD and early FP8 enablement
+
+[#2601](https://github.com/sgl-project/sglang/pull/2601) and [#2667](https://github.com/sgl-project/sglang/pull/2667) made the DeepSeek V3 path viable on AMD. The changes landed in Triton decode attention, fused MoE, and `deepseek_v2.py`. ROCm regressions should therefore be checked against attention, MoE, and the model file.
+
+The later AMD line is not one PR:
+
+- [#15304](https://github.com/sgl-project/sglang/pull/15304) fixed MXFP4 accuracy with EP.
+- [#18242](https://github.com/sgl-project/sglang/pull/18242) optimized R1 on MI300X.
+- [#18451](https://github.com/sgl-project/sglang/pull/18451) selected AITER router GEMM for `<=256` experts.
+- [#19843](https://github.com/sgl-project/sglang/pull/19843) kept correction bias BF16 in AITER FP8 routing to avoid a decode-time dtype conversion.
+- [#19834](https://github.com/sgl-project/sglang/pull/19834) made KV FP8 and all-reduce fusion part of MI35x CI.
+
+### 2. Single-node H200 optimization ladder
+
+The H200 note covers a dense March-May 2025 performance push that was missing from the first version of this skill. The important point is that the shipped V3/R1 behavior is the result of several interacting tracks, not one PR.
+
+FP8 Block GEMM moved from benchmarking to default DeepGEMM use:
+
+- [#3893](https://github.com/sgl-project/sglang/pull/3893) added DeepGEMM and SGLang FP8 block-wise GEMM benchmarks.
+- [#4165](https://github.com/sgl-project/sglang/pull/4165) integrated DeepGEMM into `sgl-kernel`.
+- [#4199](https://github.com/sgl-project/sglang/pull/4199) made linear layers support DeepGEMM.
+- [#4613](https://github.com/sgl-project/sglang/pull/4613), [#5263](https://github.com/sgl-project/sglang/pull/5263), [#5310](https://github.com/sgl-project/sglang/pull/5310), and [#5628](https://github.com/sgl-project/sglang/pull/5628) show that the default was tuned carefully: enable on Hopper, temporarily disable when needed, restrict to the safe architecture set, then re-enable with docs.
+- [#5432](https://github.com/sgl-project/sglang/pull/5432) added a DeepGEMM `group_gemm_masked` BMM path and MLA FP8 quant kernels, but should be described as an explored path rather than the universal default.
+- [#5473](https://github.com/sgl-project/sglang/pull/5473) moved per-token-group FP8 quantization from Triton to `sgl-kernel`.
+- [#5549](https://github.com/sgl-project/sglang/pull/5549) added zero-scalar allocation reuse and removed a kernel from `per_tensor_quant_mla_fp8`.
+- [#6890](https://github.com/sgl-project/sglang/pull/6890) later replaced Triton with DeepGEMM for `fused_qkv_a_proj_with_mqa`.
+- [#7146](https://github.com/sgl-project/sglang/pull/7146), [#7150](https://github.com/sgl-project/sglang/pull/7150), [#7155](https://github.com/sgl-project/sglang/pull/7155), [#7156](https://github.com/sgl-project/sglang/pull/7156), and [#7172](https://github.com/sgl-project/sglang/pull/7172) migrated DeepSeek quantization to the new DeepGEMM input format.
+
+Fused MoE was optimized around top-k, alignment, routed scaling, and shared experts:
+
+- [#4530](https://github.com/sgl-project/sglang/pull/4530) added `sgl-kernel/csrc/moe/moe_fused_gate.cu`, tests, and benchmarks for the DeepSeek-style fused group gate.
+- [#5086](https://github.com/sgl-project/sglang/pull/5086) reduced `moe_align_block_size_kernel` overhead, which matters for small batches.
+- [#5371](https://github.com/sgl-project/sglang/pull/5371) applied the fused MoE gate in DeepSeek V3/R1.
+- [#5571](https://github.com/sgl-project/sglang/pull/5571) enabled shared-expert fusion on SM90.
+- [#5716](https://github.com/sgl-project/sglang/pull/5716) and [#5740](https://github.com/sgl-project/sglang/pull/5740) updated Triton fused-MoE configs for H20 and H200.
+- [#6220](https://github.com/sgl-project/sglang/pull/6220) fused routed scaling into the top-k reduce kernel, and [#6970](https://github.com/sgl-project/sglang/pull/6970) later fused the same scaling directly in DeepSeek.
+
+MLA backend and model-file hot-path changes were equally important:
+
+- [#4472](https://github.com/sgl-project/sglang/pull/4472) added FlashMLA, [#4514](https://github.com/sgl-project/sglang/pull/4514) made it CUDA-graph capable, and [#6109](https://github.com/sgl-project/sglang/pull/6109) connected FlashMLA with MTP and FP8 KV cache.
+- [#4831](https://github.com/sgl-project/sglang/pull/4831) added FA3 MLA and [#5210](https://github.com/sgl-project/sglang/pull/5210) made FA3 MLA the Hopper default.
+- [#5390](https://github.com/sgl-project/sglang/pull/5390) added Cutlass MLA, and [#6034](https://github.com/sgl-project/sglang/pull/6034) documented the backend choices.
+- [#5113](https://github.com/sgl-project/sglang/pull/5113) added `MHA_CHUNKED_KV` for chunked prefill, while [#5381](https://github.com/sgl-project/sglang/pull/5381) added the `merge_state_v2` CUDA kernel used in that family of paths.
+- [#5385](https://github.com/sgl-project/sglang/pull/5385) applied DeepSeek CUDA RoPE.
+- [#5578](https://github.com/sgl-project/sglang/pull/5578) removed an extra `forward_absorb` copy.
+- [#5619](https://github.com/sgl-project/sglang/pull/5619) fused `q_a_proj` and `kv_a_proj_with_mqa`.
+- [#5748](https://github.com/sgl-project/sglang/pull/5748) fused MLA KV-cache writes and removed K concat overhead.
+- [#5977](https://github.com/sgl-project/sglang/pull/5977) overlapped q/k norm on two streams.
+
+MTP interactions also belong to the H200 story. [#3582](https://github.com/sgl-project/sglang/pull/3582) introduced NextN/EAGLE for V3/R1, [#4218](https://github.com/sgl-project/sglang/pull/4218) connected NextN with FlashInfer MLA, [#5707](https://github.com/sgl-project/sglang/pull/5707) fixed MTP with shared-expert fusion for R1, [#5793](https://github.com/sgl-project/sglang/pull/5793) auto-set the draft path, [#5952](https://github.com/sgl-project/sglang/pull/5952) updated MTP API tests/docs, and [#6081](https://github.com/sgl-project/sglang/pull/6081) added MTP plus DP-attention support.
+
+Closed/exploratory note: [#6151](https://github.com/sgl-project/sglang/pull/6151) is a closed hybrid-attention experiment. It should be mentioned when auditing history, but not counted as current mainline V3/R1 support.
+
+### 3. MLA and weight loading
+
+Current main keeps most DeepSeek V3/R1 attention in `deepseek_common/attention_forward_methods/`. The important current split is:
+
+- `attention_backend_handler.py` decides MHA/MLA subtype and respects PCG/deterministic mode.
+- `forward_mla.py` handles MLA absorb and backend-specific q/k/v preparation.
+- `deepseek_weight_loader.py` post-processes `kv_b_proj` because MLA absorption needs `w_kc` and `w_vc`-style components and because FP8 block scales may need dequant or requant.
+
+[#16649](https://github.com/sgl-project/sglang/pull/16649) split the loader into `DeepseekV2WeightLoaderMixin`, which is why later V3, V3.1, V3.2, and NextN fixes all land in the shared mixin.
+
+[#17744](https://github.com/sgl-project/sglang/pull/17744) is a practical loader fix: it defers materializing `dict(weights)`, avoiding OOM on large DeepSeek checkpoints.
+
+[#23195](https://github.com/sgl-project/sglang/pull/23195) is still open and important for AWQ/compressed-tensors: code that assumes `.weight` exists on attention projection modules can break quantized layers.
+
+### 4. Shared experts and MoE routing
+
+Current `DeepseekV2MoE` computes `num_fused_shared_experts` from config and server args. When active, the loader remaps:
+
+```text
+mlp.shared_experts -> mlp.experts.256
+```
+
+The MoE layer then exposes a fused expert layout. Under ordinary fusion, the number of experts is `n_routed_experts + n_shared_experts`. Under DeepEP fusion, the layout becomes `256 + EP_size` local slots and TopK handles interleaving.
+
+Current main keeps fusion conservative:
+
+- disabled for TBO/SBO
+- disabled by default under DeepEP unless `--enforce-shared-experts-fusion`
+- disabled when architecture, expert counts, or capability do not match
+- disabled for W4AFP8 because routed and shared experts can use different quant methods
+
+[#15347](https://github.com/sgl-project/sglang/pull/15347) moved routing toward `fused_topk_deepseek`. [#17707](https://github.com/sgl-project/sglang/pull/17707) added a Blackwell router benchmark. [#22933](https://github.com/sgl-project/sglang/pull/22933) later expanded the CPU shared-expert interface when scaling factor is absent, which is CPU parity cleanup rather than H200 GPU throughput. [#21531](https://github.com/sgl-project/sglang/pull/21531) is the open JIT migration for `dsv3_router_gemm`.
+
+### 5. MTP and NextN
+
+DeepSeek V3/R1 MTP is implemented through EAGLE and `DeepseekV3ForCausalLMNextN`.
+
+Important current details:
+
+- only one NextN layer is supported
+- target model and draft layer can have different quant handling
+- shared head and embed weights are reused from the target model
+- AMD R1 MXFP4 has a naming workaround for `model.layers.61*`
+- `SGLANG_DEEPEP_BF16_DISPATCH` can be toggled around NextN execution when needed
+
+[#7376](https://github.com/sgl-project/sglang/pull/7376) fixed R1 FP4 MTP. [#13548](https://github.com/sgl-project/sglang/pull/13548) fixed V3 MTP on B200. [#18607](https://github.com/sgl-project/sglang/pull/18607) fixed AMD TP4 V3 MTP accuracy. [#19425](https://github.com/sgl-project/sglang/pull/19425) fixed R1 MXFP4 NextN loading shape.
+
+The newer spec line changes runtime assumptions even for the older V3/R1 model class. [#21599](https://github.com/sgl-project/sglang/pull/21599) adds adaptive `speculative_num_steps` for EAGLE top-k=1 by threading runtime speculative state and params through server args, EAGLE workers, and runner code. [#22128](https://github.com/sgl-project/sglang/pull/22128) lets piecewise CUDA graph coexist with speculative decoding by updating `model_runner.py`, `piecewise_cuda_graph_runner.py`, and the related server-argument gate. Open [#23336](https://github.com/sgl-project/sglang/pull/23336) carries the adaptive-spec idea into spec v2 through `scheduler_output_processor_mixin.py`, `managers/utils.py`, `eagle_worker_v2.py`, and `multi_layer_eagle_worker_v2.py`.
+
+### 6. R1 W4AFP8 and DeepEP
+
+[#7762](https://github.com/sgl-project/sglang/pull/7762) introduced the first large W4AFP8 stack:
+
+- `W4AFp8Config`
+- `W4AFp8MoEMethod`
+- Cutlass W4A8 grouped MoE kernels
+- packed int4 expert weights stored as int8
+- expert input-scale mapping
+- EP expert-map handling
+
+[#8118](https://github.com/sgl-project/sglang/pull/8118) added TP mode. [#8247](https://github.com/sgl-project/sglang/pull/8247) added normal DeepEP support, including `apply_deepep_normal`. [#8464](https://github.com/sgl-project/sglang/pull/8464) added low-latency DeepEP support.
+
+The low-latency FP8 communication line must be read with its revert history:
+
+- [#14162](https://github.com/sgl-project/sglang/pull/14162) introduced fused MoE sum/all-reduce and FP8 communication behavior.
+- [#21719](https://github.com/sgl-project/sglang/pull/21719) reverted it.
+- [#22316](https://github.com/sgl-project/sglang/pull/22316) relanded it.
+
+When investigating this area, inspect current main together with #14162.
+
+### 7. Quantized and backend-specific support
+
+The V3/R1 quantized landscape is broad:
+
+- W4AFP8 / W4A8: [#7762](https://github.com/sgl-project/sglang/pull/7762), [#8118](https://github.com/sgl-project/sglang/pull/8118), [#8247](https://github.com/sgl-project/sglang/pull/8247), [#8464](https://github.com/sgl-project/sglang/pull/8464), [#10027](https://github.com/sgl-project/sglang/pull/10027), [#12921](https://github.com/sgl-project/sglang/pull/12921)
+- FP4/NVFP4: [#11512](https://github.com/sgl-project/sglang/pull/11512), [#11708](https://github.com/sgl-project/sglang/pull/11708), [#12778](https://github.com/sgl-project/sglang/pull/12778)
+- MXFP4: [#15304](https://github.com/sgl-project/sglang/pull/15304), [#19425](https://github.com/sgl-project/sglang/pull/19425), [#21529](https://github.com/sgl-project/sglang/pull/21529) open
+- MXFP8: [#21280](https://github.com/sgl-project/sglang/pull/21280)
+- LoRA with DeepSeek MLA: [#22323](https://github.com/sgl-project/sglang/pull/22323), with [#22268](https://github.com/sgl-project/sglang/pull/22268) still open for adapter bypass in `prepare_qkv_latent`
+
+### 8. Reasoning radix-cache behavior
+
+DeepSeek V3/R1 thinking and reasoning-parser paths now have a cache-specific branch to audit. Closed [#22950](https://github.com/sgl-project/sglang/pull/22950) tried parser-gated two-phase stripping for reasoning radix caches by touching model config, scheduler, radix caches, and `reasoning_parser.py`; it is history, not current support. Merged [#23315](https://github.com/sgl-project/sglang/pull/23315) is the current path: it adds an opt-in server argument and teaches `schedule_batch.py` plus `mem_cache/common.py` to strip thinking tokens from radix-cache entries so they do not become reusable prefix tokens in later requests.
+
+When reproducing cache-hit or prefix-reuse issues, record the reasoning parser, the opt-in flag state, and whether the prompt contains `<think>` / `</think>` tokens. A model-side parser fix and a radix-cache stripping fix are different layers.
+
+### 9. Tests that define current main
+
+Current main has model-backed lanes for:
+
+- V3 basic and MTP on 8-GPU H200
+- AMD V3 basic, MTP, KV FP8, and R1 MXFP4
+- R1 FP8 TRTLLM backend
+- V3 FP4, W4A8, CuteDSL, Cutlass, MLA, INT8 MLA
+- deterministic inference
+- LoRA logprob regression
+- router/top-k kernel coverage
+
+Treat those tests as part of the support contract. A code path that is not represented by these lanes should be documented as a gap or an open PR to track.

--- a/skills/sglang-deepseek-v31-optimization/SKILL.md
+++ b/skills/sglang-deepseek-v31-optimization/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: sglang-deepseek-v31-optimization
+description: PR-backed and current-main optimization manual for DeepSeek V3.1 and DeepSeek-V3.1-Terminus in SGLang. Use when Codex needs to recover, extend, or audit DeepSeek V3.1 tool calling, thinking mode, chat templates, streaming parser behavior, loading fixes, MTP validation, fused MoE configs, or backend-specific tests.
+---
+
+# SGLang DeepSeek V3.1 Optimization
+
+## Overview
+
+This skill covers the DeepSeek V3.1 support and optimization ladder that is active in SGLang main. V3.1 shares the DeepSeek V3/R1 model backbone, but its tool-call format, chat template, thinking flag, streaming parser, and validation lanes are separate enough to require an independent skill.
+
+Current-main snapshot:
+
+- SGLang `origin/main`: `929e00eea` on `2026-04-21`
+- sgl-cookbook `origin/main`: `8ec4d03` on `2026-04-21`
+- core runtime entry: `python/sglang/srt/models/deepseek_v2.py`
+- V3.1 tool parser: `python/sglang/srt/function_call/deepseekv31_detector.py`
+- V3.1 tool template: `examples/chat_template/tool_chat_template_deepseekv31.jinja`
+
+The historical evidence lives in:
+
+- [references/pr-history.md](references/pr-history.md): chronological PR evidence and code-level notes
+- [references/playbook.md](references/playbook.md): investigation order, symptom mapping, validation commands
+
+## Before You Change Anything
+
+Record the exact serving shape first:
+
+- model: `deepseek-ai/DeepSeek-V3.1`, `DeepSeek-V3.1-Terminus`, or `DeepSeek-V3.1-Speciale`
+- whether thinking mode is enabled with `chat_template_kwargs.thinking`
+- whether tool calling is enabled with `--tool-call-parser deepseekv31`
+- whether the V3.1 tool template is used: `examples/chat_template/tool_chat_template_deepseekv31.jinja`
+- `--reasoning-parser deepseek-v3`
+- TP / DP / EP / PP topology
+- MTP enabled or not
+- backend and quantization inherited from the DeepSeek V3/R1 backbone
+- streaming or non-streaming OpenAI API path
+- exact test lane: manual, nightly, parser unit, chat-template unit, or model-backed accuracy/perf
+
+## Core Principle
+
+Do not debug V3.1 as ordinary V3.
+
+- The model class is shared with V3/R1, so MLA, MoE, quantization, DeepEP, and MTP bugs usually belong to `sglang-deepseek-v3-r1-optimization`.
+- The user-visible V3.1 delta is parser and template behavior: hybrid thinking, tool calling, streaming deltas, and structural-tag constrained decoding.
+- V3.1 tool calls do not use V3's literal `function` marker or fenced JSON block.
+- V3.1 uses `chat_template_kwargs: {"thinking": true}` with `--reasoning-parser deepseek-v3`, not R1's parser.
+- DeepSeek-V3.1-Speciale should not be treated as a tool-calling target.
+
+The optimization order matters:
+
+1. confirm the parser/template contract
+2. confirm streaming and non-streaming parity
+3. confirm thinking mode and `</think>` template behavior
+4. confirm model loading and MTP inherited from V3/R1
+5. only then tune MoE/backend performance
+6. add CPU parser tests for parser-only changes before running model-backed tests
+
+## Main Runtime Surfaces
+
+Start from these files before changing behavior:
+
+- `python/sglang/srt/function_call/deepseekv31_detector.py`
+- `python/sglang/srt/function_call/function_call_parser.py`
+- `examples/chat_template/tool_chat_template_deepseekv31.jinja`
+- `python/sglang/srt/entrypoints/openai/serving_chat.py`
+- `python/sglang/srt/parser/reasoning_parser.py`
+- `python/sglang/srt/managers/schedule_batch.py`
+- `python/sglang/srt/mem_cache/common.py`
+- `python/sglang/srt/models/deepseek_v2.py`
+- `python/sglang/srt/models/deepseek_common/deepseek_weight_loader.py`
+- `test/manual/test_deepseek_v31.py`
+- `test/manual/nightly/test_deepseek_v31_perf.py`
+- `test/manual/test_deepseek_chat_templates.py`
+
+## Open PRs to Track
+
+Check these before declaring a V3.1 gap:
+
+- [#17761](https://github.com/sgl-project/sglang/pull/17761): missing Assistant token after tool output in V3.1/V3.2 chat templates, open.
+- [#18236](https://github.com/sgl-project/sglang/pull/18236): function-call arguments missing in V3.1 streaming mode, open.
+- [#21739](https://github.com/sgl-project/sglang/pull/21739): NPU deployment docs for V3.1/V3.2, open.
+- [#22433](https://github.com/sgl-project/sglang/pull/22433): CPU unit tests for `DeepSeekV31Detector`, open.
+- [#22981](https://github.com/sgl-project/sglang/pull/22981): broader CPU tests for missing function-call detectors, open.
+- [#23336](https://github.com/sgl-project/sglang/pull/23336): adaptive speculative-num-steps support for spec v2 EAGLE workers, open and relevant when V3.1 MTP runs with spec v2.
+
+## Additional PR Coverage
+
+Additional all-state PR coverage includes parser/template PRs that are relevant to V3.1 even though they are not the core bring-up PRs:
+
+- [#9468](https://github.com/sgl-project/sglang/pull/9468), [#10875](https://github.com/sgl-project/sglang/pull/10875), and [#11189](https://github.com/sgl-project/sglang/pull/11189) refine reasoning/thinking docs, request handling, and eval flags.
+- [#9895](https://github.com/sgl-project/sglang/pull/9895) and [#14837](https://github.com/sgl-project/sglang/pull/14837) update `tool_chat_template_deepseekv31.jinja`.
+- [#10550](https://github.com/sgl-project/sglang/pull/10550), [#11223](https://github.com/sgl-project/sglang/pull/11223), [#11589](https://github.com/sgl-project/sglang/pull/11589), and [#21593](https://github.com/sgl-project/sglang/pull/21593) are general tool-choice / constrained-decoding / parser fixes that affect V3.1 serving behavior.
+- [#17141](https://github.com/sgl-project/sglang/pull/17141), [#17320](https://github.com/sgl-project/sglang/pull/17320), and [#17558](https://github.com/sgl-project/sglang/pull/17558) are closed attempts around the missing-Assistant-token-after-tool-output issue that remains tracked by open [#17761](https://github.com/sgl-project/sglang/pull/17761).
+- [#22950](https://github.com/sgl-project/sglang/pull/22950) closed the first parser-gated reasoning radix-cache stripping attempt, while merged [#23315](https://github.com/sgl-project/sglang/pull/23315) adds the current opt-in strip of thinking tokens from radix cache. For V3.1 thinking mode, this is cache-behavior work rather than a new tool parser.
+- [#21599](https://github.com/sgl-project/sglang/pull/21599) and [#22128](https://github.com/sgl-project/sglang/pull/22128) are inherited MTP/speculative-decoding infrastructure updates: adaptive EAGLE draft steps and piecewise CUDA graph with speculative decoding.
+
+## Evolution Path
+
+### Stage V31-0: Split V3.1 tool calling from V3
+
+DeepSeek V3.1 has a distinct tool-call wire format:
+
+```text
+<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>{name}<｜tool▁sep｜>{json_args}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+```
+
+It does not use V3's `function` literal or fenced `json` block.
+
+Key PR:
+
+- [#9446](https://github.com/sgl-project/sglang/pull/9446)
+
+Success check:
+
+- `--tool-call-parser deepseekv31` resolves to `DeepSeekV31Detector`
+- the template emits V3.1 markers, not V3 markers
+- multiple tool calls can be chained without separators
+
+### Stage V31-1: Enable hybrid thinking correctly
+
+V3.1 thinking mode is toggled through the chat template, not through the R1 parser.
+
+Key PR:
+
+- [#9464](https://github.com/sgl-project/sglang/pull/9464)
+
+Rules:
+
+- launch with `--reasoning-parser deepseek-v3`
+- send `extra_body: {"chat_template_kwargs": {"thinking": true}}`
+- the template emits `<think>` when thinking is enabled and `</think>` when non-thinking is desired
+
+### Stage V31-2: Keep chat template argument types stable
+
+V3.1 multi-turn tool calls can pass `tool["function"]["arguments"]` as either a dict or an already serialized JSON string. The template must not double-escape JSON strings.
+
+Key PR:
+
+- [#12123](https://github.com/sgl-project/sglang/pull/12123)
+
+Success check:
+
+- dict arguments are rendered through `tojson`
+- string arguments are used as-is
+- mixed multi-tool calls keep both forms intact
+
+### Stage V31-3: Harden structural tags and streaming deltas
+
+The structural trigger should be the generic per-call begin token, not the full name-specific begin string. Streaming must also preserve arguments that arrive in the first chunk and normal text before the tool marker.
+
+Key PRs:
+
+- [#13394](https://github.com/sgl-project/sglang/pull/13394)
+- [#18236](https://github.com/sgl-project/sglang/pull/18236), open
+- [#22433](https://github.com/sgl-project/sglang/pull/22433), open
+
+Success check:
+
+- `structure_info().trigger` is `<｜tool▁call▁begin｜>`
+- streaming emits the function name and the first argument diff when they appear together
+- normal text before the first tool marker is not dropped
+- CPU parser tests cover invalid JSON, unknown tools, unicode args, multiple calls, and streaming chunks
+
+### Stage V31-4: Keep inherited model loading and MTP healthy
+
+V3.1 still depends on DeepSeek V3/R1 loader, MLA, MoE, and MTP surfaces.
+
+Key PRs:
+
+- [#13954](https://github.com/sgl-project/sglang/pull/13954)
+- [#16660](https://github.com/sgl-project/sglang/pull/16660)
+- [#13190](https://github.com/sgl-project/sglang/pull/13190)
+
+Success check:
+
+- `test/manual/test_deepseek_v31.py` covers TP8 and TP8+MTP
+- nightly perf no longer carries stale `enable_dp_attention` flags
+- loading fixes are checked in the shared DeepSeek V2/V3 loader and in parser code
+
+### Stage V31-5: Tune MoE configs as a DeepSeek-family shape
+
+V3.1 shares the DeepSeek MoE shape with V3/V3.2-style fused MoE config work.
+
+Key PR:
+
+- [#17133](https://github.com/sgl-project/sglang/pull/17133)
+
+Success check:
+
+- H20 and H20-3E configs exist for `E=257,N=256,fp8_w8a8`
+- config selection is validated on the same hardware lane that motivated the tuning
+
+## Validation Surface
+
+Use the narrowest lane that matches the change:
+
+- parser-only: open [#22433](https://github.com/sgl-project/sglang/pull/22433) test pattern, or equivalent `DeepSeekV31Detector` CPU unit tests
+- template-only: `test/manual/test_deepseek_chat_templates.py`
+- V3.1 base/MTP: `test/manual/test_deepseek_v31.py`
+- nightly performance: `test/manual/nightly/test_deepseek_v31_perf.py`
+- inherited MLA/MoE/quant bug: switch to `sglang-deepseek-v3-r1-optimization`

--- a/skills/sglang-deepseek-v31-optimization/agents/openai.yaml
+++ b/skills/sglang-deepseek-v31-optimization/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SGLang DeepSeek V3.1 Optimization"
+  short_description: "Current-main DeepSeek V3.1 playbook for thinking mode, tool calling, chat templates, parser streaming, loading, MTP, and validation"
+  default_prompt: "Use $sglang-deepseek-v31-optimization to optimize or debug DeepSeek V3.1 or DeepSeek-V3.1-Terminus in SGLang, including deepseekv31 tool-call parsing, thinking mode with deepseek-v3 reasoning parser, chat template behavior, streaming deltas, loading fixes, MTP validation, and H20/H20-3E fused MoE config checks."

--- a/skills/sglang-deepseek-v31-optimization/references/playbook.md
+++ b/skills/sglang-deepseek-v31-optimization/references/playbook.md
@@ -1,0 +1,132 @@
+# DeepSeek V3.1 Playbook
+
+Use this playbook when a V3.1 optimization or regression report is ambiguous. The goal is to decide whether the bug belongs to V3.1 parser/template behavior or to the inherited DeepSeek V3/R1 runtime.
+
+## 1. Identify The Serving Contract
+
+Collect these first:
+
+- model path: V3.1, V3.1-Terminus, or V3.1-Speciale
+- `--tool-call-parser`
+- `--reasoning-parser`
+- chat template path
+- `extra_body.chat_template_kwargs.thinking`
+- streaming or non-streaming request
+- whether request includes tools
+- TP / DP / EP / PP
+- MTP and `SGLANG_ENABLE_SPEC_V2`
+- hardware and quantization
+
+If the issue is MLA, MoE, W4AFP8, DeepEP, LoRA, or backend selection, switch to `sglang-deepseek-v3-r1-optimization`.
+If the issue is DSA/NSA sparse attention, switch to `sglang-deepseek-v32-optimization`.
+
+## 2. Tool-Call Format
+
+V3.1 format:
+
+```text
+<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>{name}<｜tool▁sep｜>{json_args}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+```
+
+V3 format differs:
+
+- V3 has a literal `function` marker after `<｜tool▁call▁begin｜>`.
+- V3 wraps arguments in a fenced JSON block.
+- V3.1 does not.
+
+If `deepseekv3` and `deepseekv31` are accidentally swapped, non-streaming may fail to parse or streaming may emit malformed deltas.
+
+## 3. Thinking Mode
+
+Expected launch and request:
+
+```shell
+python -m sglang.launch_server \
+  --model deepseek-ai/DeepSeek-V3.1-Terminus \
+  --reasoning-parser deepseek-v3 \
+  --tool-call-parser deepseekv31 \
+  --chat-template examples/chat_template/tool_chat_template_deepseekv31.jinja
+```
+
+```json
+{"chat_template_kwargs": {"thinking": true}}
+```
+
+Common mistakes:
+
+- using `--reasoning-parser deepseek-r1`
+- sending `enable_thinking` instead of `thinking`
+- using DeepSeek-V3.1-Speciale as a tool-call target
+- forgetting the V3.1 tool template when tool calling is enabled
+
+## 4. Streaming Parser
+
+Read `DeepSeekV31Detector.parse_streaming_increment`.
+
+Check:
+
+- `_buffer` contains the outer or inner tool marker
+- `current_tool_id` starts at `0` only after the first tool call is detected
+- `current_tool_name_sent` is reset after each complete call
+- `_last_arguments` is cleared between calls
+- first-chunk arguments are not skipped when the function name and JSON arrive together
+- normal text before `<｜tool▁call▁begin｜>` is preserved
+
+Open [#18236](https://github.com/sgl-project/sglang/pull/18236) is the current reference for missing streaming arguments and dropped normal text.
+
+## 5. Structural Tag Constrained Decoding
+
+`structure_info()` should return:
+
+- `begin`: `<｜tool▁call▁begin｜>` + name + `<｜tool▁sep｜>`
+- `end`: `<｜tool▁call▁end｜>`
+- `trigger`: `<｜tool▁call▁begin｜>`
+
+The trigger must not include the function name. That was fixed in [#13394](https://github.com/sgl-project/sglang/pull/13394).
+
+## 6. Chat Template Regressions
+
+Read `examples/chat_template/tool_chat_template_deepseekv31.jinja`.
+
+Check:
+
+- dict arguments use `tojson`
+- string arguments are emitted as-is
+- tool output blocks are wrapped with `<｜tool▁output▁begin｜>` and `<｜tool▁output▁end｜>`
+- assistant generation after tool output has the right `<｜Assistant｜>` marker
+- `thinking=false` emits `</think>` after `<｜Assistant｜>`
+- `thinking=true` emits `<think>`
+
+Open [#17761](https://github.com/sgl-project/sglang/pull/17761) tracks missing Assistant token after tool output in V3.1/V3.2 templates.
+
+## 7. Loading And MTP
+
+For V3.1 model-backed failures:
+
+- inspect `deepseek_v2.py`
+- inspect `deepseek_common/deepseek_weight_loader.py`
+- inspect `deepseek_nextn.py` when MTP is enabled
+- compare against V3/R1 lanes before changing parser code
+
+Expected V3.1 manual variants:
+
+- TP8 base
+- TP8 + EAGLE MTP with `SGLANG_ENABLE_SPEC_V2=1`
+
+## 8. Validation Order
+
+Pick the smallest lane:
+
+1. parser-only: `DeepSeekV31Detector` unit tests following open [#22433](https://github.com/sgl-project/sglang/pull/22433)
+2. template-only: `test/manual/test_deepseek_chat_templates.py`
+3. model-backed V3.1: `test/manual/test_deepseek_v31.py`
+4. nightly performance: `test/manual/nightly/test_deepseek_v31_perf.py`
+5. inherited runtime regression: V3/R1 validation lanes
+
+## 9. Common False Conclusions
+
+- "V3.1 is only V3 with a new checkpoint." Not for tool calling or thinking.
+- "R1 parser should be used because V3.1 thinks." V3.1 uses `deepseek-v3`.
+- "Tool arguments are always dicts." Multi-turn paths may pass already serialized JSON strings.
+- "A streaming parser bug is fixed if non-streaming works." V3.1 has a custom streaming override and needs separate validation.
+- "Speciale supports tools." Current cookbook docs say DeepSeek-V3.1-Speciale does not support tool calling.

--- a/skills/sglang-deepseek-v31-optimization/references/pr-history.md
+++ b/skills/sglang-deepseek-v31-optimization/references/pr-history.md
@@ -1,0 +1,131 @@
+# DeepSeek V3.1 PR History
+
+Snapshot:
+
+- SGLang `origin/main`: `929e00eea`
+- sgl-cookbook `origin/main`: `8ec4d03`
+- Date: `2026-04-21`
+
+This history covers DeepSeek V3.1 only. DeepSeek V3/R1 runtime internals and DeepSeek V3.2 DSA/NSA are tracked by separate skills.
+
+## Chronological Timeline
+
+| Date | PR | State | Area | Main effect |
+| --- | ---: | --- | --- | --- |
+| 2025-08-21 | [#9446](https://github.com/sgl-project/sglang/pull/9446) | merged | tool calling | Added `tool_chat_template_deepseekv31.jinja`, `DeepSeekV31Detector`, and parser registration. |
+| 2025-08-21 | [#9464](https://github.com/sgl-project/sglang/pull/9464) | merged | thinking parser | Added V3.1 thinking-mode docs and `deepseek-v3` reasoning-parser support. |
+| 2025-08-23 | [#9544](https://github.com/sgl-project/sglang/pull/9544) | merged | docs | Added DeepSeek V3.1 support docs and examples. |
+| 2025-10-25 | [#12123](https://github.com/sgl-project/sglang/pull/12123) | merged | chat template | Fixed V3/V3.1/V3.2 templates so dict and string tool arguments do not double-escape. |
+| 2025-11-13 | [#13190](https://github.com/sgl-project/sglang/pull/13190) | merged | nightly tests | Removed stale `enable_dp_attention` from V3.1/V3.2 nightly tests. |
+| 2025-11-17 | [#13394](https://github.com/sgl-project/sglang/pull/13394) | merged | structural tags | Changed V3.1 structural trigger to generic `<｜tool▁call▁begin｜>`. |
+| 2025-11-26 | [#13954](https://github.com/sgl-project/sglang/pull/13954) | merged | loading | Fixed DeepSeek V3.1 loading issue in `deepseek_v2.py`. |
+| 2026-01-07 | [#16660](https://github.com/sgl-project/sglang/pull/16660) | merged | CI | Enabled DeepSeek V3.1 registered nightly H200 test. |
+| 2026-01-15 | [#17133](https://github.com/sgl-project/sglang/pull/17133) | merged | MoE tuning | Added H20/H20-3E fused MoE configs for V3.1/V3.2 shapes. |
+| 2026-01-26 | [#17761](https://github.com/sgl-project/sglang/pull/17761) | open | chat template | Tracks missing Assistant token after tool output in V3.1/V3.2 templates. |
+| 2026-02-04 | [#18236](https://github.com/sgl-project/sglang/pull/18236) | open | streaming parser | Fixes missing arguments and dropped normal text in V3.1 streaming function calls. |
+| 2026-03-28 | [#21599](https://github.com/sgl-project/sglang/pull/21599) | merged | MTP/spec | Added adaptive `speculative_num_steps` for EAGLE top-k=1, inherited by V3.1 MTP. |
+| 2026-03-31 | [#21739](https://github.com/sgl-project/sglang/pull/21739) | open | NPU docs | Updates V3.1/V3.2 Ascend NPU deployment instructions. |
+| 2026-04-05 | [#22128](https://github.com/sgl-project/sglang/pull/22128) | merged | PCG/spec | Allowed piecewise CUDA graph with speculative decoding. |
+| 2026-04-09 | [#22433](https://github.com/sgl-project/sglang/pull/22433) | open | parser tests | Adds CPU unit tests for `DeepSeekV31Detector`. |
+| 2026-04-16 | [#22981](https://github.com/sgl-project/sglang/pull/22981) | open | parser tests | Adds broader CPU tests for missing function-call detectors. |
+| 2026-04-16 | [#22950](https://github.com/sgl-project/sglang/pull/22950) | closed | reasoning cache | Explored parser-gated two-phase radix-cache stripping for reasoning tokens. |
+| 2026-04-21 | [#23315](https://github.com/sgl-project/sglang/pull/23315) | merged | reasoning cache | Added opt-in stripping of thinking tokens from radix cache. |
+| 2026-04-21 | [#23336](https://github.com/sgl-project/sglang/pull/23336) | open | spec v2 | Extends adaptive speculative decoding to spec v2 EAGLE workers. |
+
+## Additional PR Coverage
+
+Additional all-state PR coverage also includes V3.1-adjacent parser and template changes that should not be omitted from an audit:
+
+- 2025-08-21 [#9468](https://github.com/sgl-project/sglang/pull/9468): updated reasoning-parser docs after the V3.1 thinking parser landed.
+- 2025-09-02 [#9895](https://github.com/sgl-project/sglang/pull/9895): updated `tool_chat_template_deepseekv31.jinja`.
+- 2025-09-17 [#10550](https://github.com/sgl-project/sglang/pull/10550): used `jsonschema` for required or specific tool choice.
+- 2025-09-24 [#10875](https://github.com/sgl-project/sglang/pull/10875): improved request-level thinking enablement.
+- 2025-10-03 [#11189](https://github.com/sgl-project/sglang/pull/11189): added `--thinking-mode` to `run_eval`.
+- 2025-10-05 [#11223](https://github.com/sgl-project/sglang/pull/11223): updated tool parser and related docs.
+- 2025-10-14 [#11589](https://github.com/sgl-project/sglang/pull/11589): streamlined function arguments when `tool_choice="auto"` for `deepseekv31_detector`.
+- 2025-12-10 [#14837](https://github.com/sgl-project/sglang/pull/14837): auto-synced `tool_chat_template_deepseekv31.jinja`.
+- 2026-01-15 [#17141](https://github.com/sgl-project/sglang/pull/17141), 2026-01-19 [#17320](https://github.com/sgl-project/sglang/pull/17320), and 2026-01-22 [#17558](https://github.com/sgl-project/sglang/pull/17558): closed attempts around `finish_reason="stop"` after tool content; open [#17761](https://github.com/sgl-project/sglang/pull/17761) remains the current tracker.
+- 2026-01-16 [#17178](https://github.com/sgl-project/sglang/pull/17178): removed `deepseek-r1` from thinking-mode choices, clarifying V3.1 vs R1 parser semantics.
+- 2026-03-28 [#21593](https://github.com/sgl-project/sglang/pull/21593): fixed tool-call constrained decoding and parsing for native-format models.
+- 2026-04-16 [#22950](https://github.com/sgl-project/sglang/pull/22950) and 2026-04-21 [#23315](https://github.com/sgl-project/sglang/pull/23315): distinguish closed reasoning-cache exploration from the merged opt-in strip of thinking tokens from radix cache.
+- 2026-03-28 [#21599](https://github.com/sgl-project/sglang/pull/21599), 2026-04-05 [#22128](https://github.com/sgl-project/sglang/pull/22128), and open 2026-04-21 [#23336](https://github.com/sgl-project/sglang/pull/23336): inherited MTP/spec-v2 infrastructure to check when V3.1 uses EAGLE MTP.
+
+## Code-Level Narrative
+
+### 1. Tool-call parser and template
+
+[#9446](https://github.com/sgl-project/sglang/pull/9446) created the V3.1 tool-call surface. It added:
+
+- `examples/chat_template/tool_chat_template_deepseekv31.jinja`
+- `python/sglang/srt/function_call/deepseekv31_detector.py`
+- `deepseekv31` registration in `function_call_parser.py`
+
+The V3.1 format is:
+
+```text
+<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>{function_name}<｜tool▁sep｜>{json_arguments}<｜tool▁call▁end｜><｜tool▁calls▁end｜>
+```
+
+This differs from V3 because V3.1 does not insert a literal `function` token and does not fence arguments in a Markdown `json` block. The detector therefore searches for `<｜tool▁call▁begin｜>.*?<｜tool▁call▁end｜>` and extracts name/arguments with `<｜tool▁sep｜>`.
+
+### 2. Thinking parser
+
+[#9464](https://github.com/sgl-project/sglang/pull/9464) established that V3.1 thinking mode is controlled by `chat_template_kwargs.thinking` and parsed with `--reasoning-parser deepseek-v3`. It also updated serving logic so model-specific thinking flags can be read from chat-template kwargs.
+
+Current cookbook docs launch Terminus with:
+
+```shell
+python -m sglang.launch_server \
+  --model deepseek-ai/DeepSeek-V3.1-Terminus \
+  --reasoning-parser deepseek-v3 \
+  --tool-call-parser deepseekv31 \
+  --chat-template ./examples/chat_template/tool_chat_template_deepseekv31.jinja
+```
+
+The important distinction is that R1's parser is not used here. V3.1 is hybrid thinking/non-thinking and the template decides whether to emit `<think>` or `</think>`.
+
+Thinking mode also intersects with radix-cache reuse. [#22950](https://github.com/sgl-project/sglang/pull/22950) is a closed attempt at parser-gated two-phase reasoning cache stripping. The merged implementation is [#23315](https://github.com/sgl-project/sglang/pull/23315), which adds an opt-in path in `server_args.py`, `schedule_batch.py`, and `mem_cache/common.py` to strip thinking tokens from radix-cache entries. For V3.1 this does not change the `deepseekv31` tool parser; it changes whether thinking tokens can be reused as prefix-cache material.
+
+### 3. Template argument type checking
+
+[#12123](https://github.com/sgl-project/sglang/pull/12123) fixed issue `#11700` across DeepSeek V3/V3.1/V3.2 templates. Tool arguments can arrive as:
+
+- a dict from an OpenAI API object
+- an already serialized JSON string from a previous model/tool round
+
+The template now does:
+
+```jinja
+{% set formatted_args = tool['function']['arguments'] if tool['function']['arguments'] is string else tool['function']['arguments']|tojson %}
+```
+
+This prevents already serialized strings from becoming escaped JSON strings such as `"{\"symbol\":\"NVDA\"}"`.
+
+### 4. Structural trigger and streaming parser
+
+[#13394](https://github.com/sgl-project/sglang/pull/13394) changed:
+
+```python
+trigger="<｜tool▁call▁begin｜>"
+```
+
+instead of a trigger that included the concrete function name and separator. This matters for constrained decoding because the trigger has to activate before the function name is known.
+
+[#18236](https://github.com/sgl-project/sglang/pull/18236) is still open, but its patch explains the current streaming risk. The existing streaming parser can skip arguments when the function name and JSON arguments arrive in the first chunk because argument processing is inside the `else` branch after `current_tool_name_sent`. The PR changes this to process `func_args_raw` whenever it exists. It also adds `_normal_text_sent` so normal text before the first tool marker is emitted instead of dropped.
+
+[#22433](https://github.com/sgl-project/sglang/pull/22433) adds the missing CPU tests. The proposed tests cover `has_tool_call`, non-streaming parse, invalid JSON fallback, unknown tools, unicode arguments, multi-call ordering, streaming diffs, `structure_info`, and structural tag support.
+
+### 5. Loading, MTP, and MoE tuning
+
+[#13954](https://github.com/sgl-project/sglang/pull/13954) fixed a V3.1 loading issue in `deepseek_v2.py`. Because V3.1 reuses the V3/R1 model class, loading fixes usually belong to shared DeepSeek code rather than the V3.1 parser.
+
+[#16660](https://github.com/sgl-project/sglang/pull/16660) added a registered H200 V3.1 lane with two variants:
+
+- TP8 base
+- TP8 plus EAGLE MTP with `SGLANG_ENABLE_SPEC_V2=1`
+
+[#13190](https://github.com/sgl-project/sglang/pull/13190) removed stale `enable_dp_attention` from V3.1/V3.2 nightly perf tests, keeping the benchmark shape aligned with the current server defaults.
+
+[#21599](https://github.com/sgl-project/sglang/pull/21599) adds adaptive EAGLE top-k=1 draft steps; [#22128](https://github.com/sgl-project/sglang/pull/22128) allows piecewise CUDA graph with speculative decoding; open [#23336](https://github.com/sgl-project/sglang/pull/23336) applies adaptive spec to spec v2 workers. These PRs are not V3.1 parser work, but they matter for the TP8+MTP validation shape because V3.1 reuses the DeepSeek V3/R1 NextN stack.
+
+[#17133](https://github.com/sgl-project/sglang/pull/17133) added H20/H20-3E fused MoE configs for DeepSeek-family `E=257,N=256,fp8_w8a8` shapes. This is not parser work, but it affects V3.1 throughput on those devices.

--- a/skills/sglang-deepseek-v32-optimization/SKILL.md
+++ b/skills/sglang-deepseek-v32-optimization/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: sglang-deepseek-v32-optimization
+description: PR-backed and current-main optimization manual for DeepSeek V3.2, V3.2-Exp, V3.2-Speciale, NVFP4, and MXFP4 in SGLang. Use when Codex needs to recover, extend, or audit DSA/NSA sparse attention, NSA indexer, FP8/BF16/FP4 KV cache, context parallel, MTP, IndexCache, DSML tool calling, V3.2 docs/tests, AMD/NPU/Blackwell backends, or open NSA/DSA PRs.
+---
+
+# SGLang DeepSeek V3.2 Optimization
+
+## Overview
+
+This skill covers the DeepSeek V3.2 support and optimization ladder active in SGLang main. V3.2 shares the DeepSeek V3/R1 model backbone, but it is a separate optimization problem because it activates DeepSeek Sparse Attention, called DSA in docs and NSA in SGLang code.
+
+Current-main snapshot:
+
+- SGLang `origin/main`: `929e00eea` on `2026-04-21`
+- sgl-cookbook `origin/main`: `8ec4d03` on `2026-04-21`
+- V3.2 runtime entry: `DeepseekV32ForCausalLM` in `python/sglang/srt/models/deepseek_v2.py`
+- NSA backend: `python/sglang/srt/layers/attention/nsa_backend.py`
+- NSA indexer: `python/sglang/srt/layers/attention/nsa/nsa_indexer.py`
+- V3.2 tool parser: `python/sglang/srt/function_call/deepseekv32_detector.py`
+
+The historical evidence lives in:
+
+- [references/pr-history.md](references/pr-history.md): chronological PR evidence and code-level notes
+- [references/playbook.md](references/playbook.md): investigation order, symptom mapping, validation commands
+
+## Before You Change Anything
+
+Record the exact serving shape first:
+
+- model: V3.2-Exp, V3.2, V3.2-Speciale, V3.2-NVFP4, or V3.2-MXFP4
+- whether `is_deepseek_nsa(config)` is true
+- `--attention-backend`, `--nsa-prefill-backend`, `--nsa-decode-backend`
+- KV cache dtype: `auto`, `bfloat16`, `fp8_e4m3`, or experimental FP4 tracks
+- TP / DP / EP / PP / PD topology
+- `--enable-dp-attention`
+- `--enable-nsa-prefill-context-parallel`
+- `--nsa-prefill-cp-mode`: `round-robin-split` or `in-seq-split`
+- MTP enabled or not
+- IndexCache knobs: `index_topk_freq`, `index_topk_pattern`
+- tool parser: V3.2-Exp may use `deepseekv31` in the cookbook path, standard V3.2 uses `deepseekv32`
+- reasoning parser: `--reasoning-parser deepseek-v3`
+- hardware: H200, B200/GB200/GB300, AMD MI300/MI355, NPU, or another backend
+
+## Core Principle
+
+Do not treat V3.2 as ordinary DeepSeek V3.
+
+- V3.2 turns on DSA/NSA through `is_deepseek_nsa(config)`.
+- The attention hot path is split between the indexer, top-k transform, sparse MLA backend, and KV-cache quant/dequant.
+- Server defaults are model-specific: attention backend becomes `nsa`, KV cache dtype defaults differ by architecture, and NSA prefill/decode backends are auto-selected.
+- Context parallel is experimental and has strict mode-specific constraints.
+- MTP spans the NextN layer, NSA metadata, target_verify, draft_extend, CP positions, and speculative overlap.
+- V3.2 parser behavior is DSML for standard V3.2, while V3.2-Exp docs still point at the V3.1-style parser path.
+
+The optimization order matters:
+
+1. confirm DSA detection and server defaults
+2. confirm KV cache dtype and NSA backend pair
+3. validate indexer top-k generation and transform
+4. validate MTP, CP, PP, or DP attention only after base DSA is correct
+5. then tune backend-specific kernels for Blackwell, Hopper, AMD, or NPU
+6. add model-backed tests for any IndexCache, MTP, CP, or backend change
+
+## Main Runtime Surfaces
+
+Start from these files before changing behavior:
+
+- `python/sglang/srt/models/deepseek_v2.py`
+- `python/sglang/srt/models/deepseek_nextn.py`
+- `python/sglang/srt/configs/model_config.py`
+- `python/sglang/srt/server_args.py`
+- `python/sglang/srt/managers/schedule_batch.py`
+- `python/sglang/srt/managers/scheduler_output_processor_mixin.py`
+- `python/sglang/srt/mem_cache/common.py`
+- `python/sglang/srt/speculative/eagle_worker_v2.py`
+- `python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py`
+- `python/sglang/srt/layers/attention/nsa_backend.py`
+- `python/sglang/srt/layers/attention/nsa/nsa_indexer.py`
+- `python/sglang/srt/layers/attention/nsa/utils.py`
+- `python/sglang/srt/layers/attention/nsa/transform_index.py`
+- `python/sglang/srt/layers/attention/nsa/quant_k_cache.py`
+- `python/sglang/srt/layers/attention/nsa/dequant_k_cache.py`
+- `python/sglang/srt/layers/communicator_nsa_cp.py`
+- `python/sglang/srt/function_call/deepseekv32_detector.py`
+- `examples/chat_template/tool_chat_template_deepseekv32.jinja`
+
+## Open PRs to Track
+
+Check these before declaring a V3.2 gap:
+
+- [#11191](https://github.com/sgl-project/sglang/pull/11191): sparse attention and CPU/GPU KV scheduling for GQA/DSA, open.
+- [#12820](https://github.com/sgl-project/sglang/pull/12820): TP-SP for Qwen and DeepSeek V2/V3/V3.2, open.
+- [#16148](https://github.com/sgl-project/sglang/pull/16148): V3.2 W4AFP8 MTP with FP8 draft model, open.
+- [#17185](https://github.com/sgl-project/sglang/pull/17185): TP `o_proj` linear in context-parallel NSA, open.
+- [#17761](https://github.com/sgl-project/sglang/pull/17761): missing Assistant token after V3.1/V3.2 tool output, open.
+- [#18167](https://github.com/sgl-project/sglang/pull/18167): DCP support for V3.2, open.
+- [#18275](https://github.com/sgl-project/sglang/pull/18275): NPU all-gather after qlora for V3.2, open.
+- [#18733](https://github.com/sgl-project/sglang/pull/18733): V3.2 PD disaggregation test, open.
+- [#19211](https://github.com/sgl-project/sglang/pull/19211): extract V3.2/NSA logic into `DeepseekV32Mixin`, open.
+- [#19299](https://github.com/sgl-project/sglang/pull/19299): O(1) expert weight matching in DeepSeek weight loader, open.
+- [#19609](https://github.com/sgl-project/sglang/pull/19609): TP indexer weight in NSA attention, open.
+- [#19975](https://github.com/sgl-project/sglang/pull/19975): AMD context parallel for V3.2, open.
+- [#20360](https://github.com/sgl-project/sglang/pull/20360): AMD CP round-robin split garbage output, open.
+- [#20531](https://github.com/sgl-project/sglang/pull/20531): NSA indexer ragged gather mismatch in CP round-robin split, open.
+- [#20809](https://github.com/sgl-project/sglang/pull/20809): add `DeepseekV32ForCausalLM` to MTP draft mapping, open.
+- [#20880](https://github.com/sgl-project/sglang/pull/20880): reject HiCache L3 for NSA models, open.
+- [#21179](https://github.com/sgl-project/sglang/pull/21179): preserve V3.2 tool-call markers in reasoning parsing, open.
+- [#21194](https://github.com/sgl-project/sglang/pull/21194): AMD `PPMissingLayer` fix in DeepSeek AITER gfx95 path, open.
+- [#21506](https://github.com/sgl-project/sglang/pull/21506): V3.2 NPU torch compile, open.
+- [#21529](https://github.com/sgl-project/sglang/pull/21529): ROCm MXFP4 / Quark W4A4 support for DeepSeek architecture, open.
+- [#21530](https://github.com/sgl-project/sglang/pull/21530): ROCm fused MLA decode RoPE fix for DeepSeek-variant models, open.
+- [#21546](https://github.com/sgl-project/sglang/pull/21546): catch malformed JSON in V3.2 partial function-call parsing, open.
+- [#21889](https://github.com/sgl-project/sglang/pull/21889): AMD FP4 KV cache quantization for NSA TileLang, open.
+- [#22268](https://github.com/sgl-project/sglang/pull/22268): DeepSeek MLA LoRA adapter bypass in `prepare_qkv_latent`, open.
+- [#22473](https://github.com/sgl-project/sglang/pull/22473): dense MLA decode fallback for short sequences, open.
+- [#22774](https://github.com/sgl-project/sglang/pull/22774): MUSA backend support for DeepSeek V2/V3/R1-class layers, open.
+- [#22851](https://github.com/sgl-project/sglang/pull/22851): `--nsa-topk-backend` and FlashInfer/PyTorch top-k, open.
+- [#22865](https://github.com/sgl-project/sglang/pull/22865): sparsity framework extension for non-NSA sparse algorithms, open.
+- [#14332](https://github.com/sgl-project/sglang/pull/14332): V3.2 tool-call parsing without DSML tag, open.
+- [#14524](https://github.com/sgl-project/sglang/pull/14524): NSA backend test suite, open.
+- [#15322](https://github.com/sgl-project/sglang/pull/15322): V3.2 `o_proj` TP support, open.
+- [#18094](https://github.com/sgl-project/sglang/pull/18094): V3.2 piecewise CUDA graph, open and related to [#23351](https://github.com/sgl-project/sglang/pull/23351).
+- [#18542](https://github.com/sgl-project/sglang/pull/18542): EAGLE3 plus NSA CP aux-hidden-state index bug, open.
+- [#19987](https://github.com/sgl-project/sglang/pull/19987): AMD FP8 KV cache for TileLang NSA backend, open.
+- [#20534](https://github.com/sgl-project/sglang/pull/20534): transfer FP8 K/K-scale for CP indexer prefill gather, open.
+- [#21623](https://github.com/sgl-project/sglang/pull/21623): unit tests for `encoding_dsv32.py`, open.
+- [#22792](https://github.com/sgl-project/sglang/pull/22792): AITER `indexer_k_quant_and_cache`, open.
+- [#23268](https://github.com/sgl-project/sglang/pull/23268): NPU accuracy fix for NSA CP plus prefix cache, open.
+- [#22938](https://github.com/sgl-project/sglang/pull/22938): restore DeepSeek MLA MI300X paths after the MLA refactor, open.
+- [#23195](https://github.com/sgl-project/sglang/pull/23195): guard `.weight` access in DeepSeek MLA for AWQ/compressed-tensors, open.
+- [#23241](https://github.com/sgl-project/sglang/pull/23241): 3FS backend for DSA/mamba, open.
+- [#23257](https://github.com/sgl-project/sglang/pull/23257): CuteDSL EP plus DP-attention double-reduce fix in `DeepseekV2MoE`, open.
+- [#23336](https://github.com/sgl-project/sglang/pull/23336): adaptive speculative-num-steps support for spec v2 EAGLE workers, open.
+- [#23351](https://github.com/sgl-project/sglang/pull/23351): piecewise CUDA graph with NSA, open.
+
+## Additional PR Coverage
+
+Additional all-state PR coverage includes V3.2 bugfixes, closed experiments, tool-parser updates, and platform-specific backend work:
+
+- Early bring-up polish: [#11063](https://github.com/sgl-project/sglang/pull/11063), [#11194](https://github.com/sgl-project/sglang/pull/11194), [#11308](https://github.com/sgl-project/sglang/pull/11308), [#11309](https://github.com/sgl-project/sglang/pull/11309), [#11450](https://github.com/sgl-project/sglang/pull/11450), [#11557](https://github.com/sgl-project/sglang/pull/11557), [#11565](https://github.com/sgl-project/sglang/pull/11565), [#11682](https://github.com/sgl-project/sglang/pull/11682), [#11815](https://github.com/sgl-project/sglang/pull/11815), and [#11835](https://github.com/sgl-project/sglang/pull/11835).
+- Short-sequence MHA / Indexer fixes: [#11892](https://github.com/sgl-project/sglang/pull/11892), [#12094](https://github.com/sgl-project/sglang/pull/12094), [#12582](https://github.com/sgl-project/sglang/pull/12582), [#12583](https://github.com/sgl-project/sglang/pull/12583), [#12645](https://github.com/sgl-project/sglang/pull/12645), [#12788](https://github.com/sgl-project/sglang/pull/12788), [#12816](https://github.com/sgl-project/sglang/pull/12816), [#12964](https://github.com/sgl-project/sglang/pull/12964), [#13022](https://github.com/sgl-project/sglang/pull/13022), [#13459](https://github.com/sgl-project/sglang/pull/13459), and [#13544](https://github.com/sgl-project/sglang/pull/13544).
+- DSML/tool/parser path: [#14304](https://github.com/sgl-project/sglang/pull/14304), [#14307](https://github.com/sgl-project/sglang/pull/14307), [#14353](https://github.com/sgl-project/sglang/pull/14353), [#14573](https://github.com/sgl-project/sglang/pull/14573), [#14750](https://github.com/sgl-project/sglang/pull/14750), [#15064](https://github.com/sgl-project/sglang/pull/15064), [#15278](https://github.com/sgl-project/sglang/pull/15278), [#16091](https://github.com/sgl-project/sglang/pull/16091), [#18126](https://github.com/sgl-project/sglang/pull/18126), [#18174](https://github.com/sgl-project/sglang/pull/18174), and [#17951](https://github.com/sgl-project/sglang/pull/17951).
+- NSA backend / metadata / sparse-cache work: [#14781](https://github.com/sgl-project/sglang/pull/14781), [#14901](https://github.com/sgl-project/sglang/pull/14901), [#15040](https://github.com/sgl-project/sglang/pull/15040), [#15086](https://github.com/sgl-project/sglang/pull/15086), [#15242](https://github.com/sgl-project/sglang/pull/15242), [#15429](https://github.com/sgl-project/sglang/pull/15429), [#16520](https://github.com/sgl-project/sglang/pull/16520), [#16758](https://github.com/sgl-project/sglang/pull/16758), [#16841](https://github.com/sgl-project/sglang/pull/16841), [#17205](https://github.com/sgl-project/sglang/pull/17205), [#17554](https://github.com/sgl-project/sglang/pull/17554), and [#18319](https://github.com/sgl-project/sglang/pull/18319).
+- HiSparse/HiCache and platform fixes: [#14741](https://github.com/sgl-project/sglang/pull/14741), [#17409](https://github.com/sgl-project/sglang/pull/17409), [#17518](https://github.com/sgl-project/sglang/pull/17518), [#17523](https://github.com/sgl-project/sglang/pull/17523), [#17633](https://github.com/sgl-project/sglang/pull/17633), [#18297](https://github.com/sgl-project/sglang/pull/18297), [#18526](https://github.com/sgl-project/sglang/pull/18526), [#20343](https://github.com/sgl-project/sglang/pull/20343), [#21932](https://github.com/sgl-project/sglang/pull/21932), and [#22238](https://github.com/sgl-project/sglang/pull/22238).
+- Closed or superseded experiments to cite as history, not current support: [#11109](https://github.com/sgl-project/sglang/pull/11109), [#11596](https://github.com/sgl-project/sglang/pull/11596), [#11761](https://github.com/sgl-project/sglang/pull/11761), [#12017](https://github.com/sgl-project/sglang/pull/12017), [#12052](https://github.com/sgl-project/sglang/pull/12052), [#13531](https://github.com/sgl-project/sglang/pull/13531), [#13546](https://github.com/sgl-project/sglang/pull/13546), [#14619](https://github.com/sgl-project/sglang/pull/14619), [#14904](https://github.com/sgl-project/sglang/pull/14904), [#15051](https://github.com/sgl-project/sglang/pull/15051), [#15217](https://github.com/sgl-project/sglang/pull/15217), [#15310](https://github.com/sgl-project/sglang/pull/15310), [#15807](https://github.com/sgl-project/sglang/pull/15807), [#16079](https://github.com/sgl-project/sglang/pull/16079), [#16881](https://github.com/sgl-project/sglang/pull/16881), [#17024](https://github.com/sgl-project/sglang/pull/17024), [#17199](https://github.com/sgl-project/sglang/pull/17199), [#17310](https://github.com/sgl-project/sglang/pull/17310), and [#17647](https://github.com/sgl-project/sglang/pull/17647).
+- Round-2 runtime additions: [#21249](https://github.com/sgl-project/sglang/pull/21249) adds all-reduce fusion with context parallel, [#22003](https://github.com/sgl-project/sglang/pull/22003) relaxes `moe_dp_size == 1` with different `attention_cp_size` values, [#21599](https://github.com/sgl-project/sglang/pull/21599) adds adaptive EAGLE top-k=1 draft steps, [#22128](https://github.com/sgl-project/sglang/pull/22128) allows PCG with speculative decoding, [#23219](https://github.com/sgl-project/sglang/pull/23219) touches shared DSA/NextN infrastructure through `deepseek_nextn.py`, [#22950](https://github.com/sgl-project/sglang/pull/22950) is the closed predecessor for reasoning radix-cache stripping, [#23315](https://github.com/sgl-project/sglang/pull/23315) is the merged opt-in thinking-token strip from radix cache, and [#23336](https://github.com/sgl-project/sglang/pull/23336) is the open spec-v2 adaptive-spec follow-up.
+
+## Evolution Path
+
+### Stage V32-0: Bring up DSA/NSA as a separate DeepSeek class
+
+Key PR:
+
+- [#11061](https://github.com/sgl-project/sglang/pull/11061)
+
+Success check:
+
+- `DeepseekV32ForCausalLM` exists
+- `is_deepseek_nsa(config)` is true
+- `server_args.py` selects `attention_backend = "nsa"`
+- `NativeSparseAttnBackend` and `Indexer` are active
+
+### Stage V32-1: Server defaults, KV cache dtype, and backend pair
+
+V3.2 has model-specific defaults:
+
+- DSA KV cache defaults to `fp8_e4m3` on SM100 and `bfloat16` otherwise
+- only `bfloat16` and `fp8_e4m3` are mainline DSA KV cache dtypes
+- ROCm defaults to TileLang NSA backends
+- Blackwell defaults now prefer TRTLLM NSA kernels
+- Hopper often uses `flashmla_sparse`, `flashmla_kv`, or `fa3`
+
+Key PRs:
+
+- [#11936](https://github.com/sgl-project/sglang/pull/11936)
+- [#18389](https://github.com/sgl-project/sglang/pull/18389)
+- [#18931](https://github.com/sgl-project/sglang/pull/18931)
+- [#21783](https://github.com/sgl-project/sglang/pull/21783)
+- [#21914](https://github.com/sgl-project/sglang/pull/21914)
+
+### Stage V32-2: Indexer correctness and performance
+
+The NSA indexer computes sparse indices through q/k projection, weights projection, top-k, transforms, and optional KV-cache store.
+
+Key PRs:
+
+- [#12044](https://github.com/sgl-project/sglang/pull/12044)
+- [#13812](https://github.com/sgl-project/sglang/pull/13812)
+- [#16637](https://github.com/sgl-project/sglang/pull/16637)
+- [#17688](https://github.com/sgl-project/sglang/pull/17688)
+- [#19041](https://github.com/sgl-project/sglang/pull/19041)
+- [#19148](https://github.com/sgl-project/sglang/pull/19148)
+- [#19319](https://github.com/sgl-project/sglang/pull/19319)
+- [#22232](https://github.com/sgl-project/sglang/pull/22232)
+- [#22424](https://github.com/sgl-project/sglang/pull/22424)
+- [#22850](https://github.com/sgl-project/sglang/pull/22850)
+
+Success check:
+
+- `weights_proj` avoids FP32 precision loss
+- K/S buffers use fused kernels where available
+- FP8 KV cache store is fused or padded correctly for the selected backend
+- AMD and NPU have separate indexer paths where needed
+
+### Stage V32-3: Context parallel, PP, and DP attention
+
+Context parallel for NSA is powerful but constrained.
+
+Key PRs:
+
+- [#12065](https://github.com/sgl-project/sglang/pull/12065)
+- [#13959](https://github.com/sgl-project/sglang/pull/13959)
+- [#16119](https://github.com/sgl-project/sglang/pull/16119)
+- [#16156](https://github.com/sgl-project/sglang/pull/16156)
+- [#16305](https://github.com/sgl-project/sglang/pull/16305)
+- [#16380](https://github.com/sgl-project/sglang/pull/16380)
+- [#18613](https://github.com/sgl-project/sglang/pull/18613)
+- [#20438](https://github.com/sgl-project/sglang/pull/20438)
+- [#21192](https://github.com/sgl-project/sglang/pull/21192)
+- [#22914](https://github.com/sgl-project/sglang/pull/22914)
+
+Success check:
+
+- `round-robin-split` is the current default CP token split method
+- `in-seq-split` requires DeepEP and `ep_size == tp_size`
+- CP in PD decode mode is asserted away
+- CP positions match EAGLE NextN
+- key all-gather can overlap query computation
+
+### Stage V32-4: MTP and speculative decoding
+
+V3.2 MTP must cooperate with NSA metadata, target verify, draft extend, and context parallel.
+
+Key PRs:
+
+- [#11652](https://github.com/sgl-project/sglang/pull/11652)
+- [#15088](https://github.com/sgl-project/sglang/pull/15088)
+- [#15307](https://github.com/sgl-project/sglang/pull/15307)
+- [#16961](https://github.com/sgl-project/sglang/pull/16961)
+- [#17662](https://github.com/sgl-project/sglang/pull/17662)
+- [#19016](https://github.com/sgl-project/sglang/pull/19016)
+- [#19062](https://github.com/sgl-project/sglang/pull/19062)
+- [#19367](https://github.com/sgl-project/sglang/pull/19367)
+- [#19536](https://github.com/sgl-project/sglang/pull/19536)
+- [#20492](https://github.com/sgl-project/sglang/pull/20492)
+
+### Stage V32-5: Quantized checkpoints and platform lanes
+
+Separate the backend tracks:
+
+- NVFP4 Blackwell: [#17657](https://github.com/sgl-project/sglang/pull/17657), [#18389](https://github.com/sgl-project/sglang/pull/18389), [#20086](https://github.com/sgl-project/sglang/pull/20086)
+- AMD MXFP4/TileLang/FP8 KV: [#17783](https://github.com/sgl-project/sglang/pull/17783), [#19945](https://github.com/sgl-project/sglang/pull/19945), [#20840](https://github.com/sgl-project/sglang/pull/20840), [#21511](https://github.com/sgl-project/sglang/pull/21511), [#22258](https://github.com/sgl-project/sglang/pull/22258), [#22850](https://github.com/sgl-project/sglang/pull/22850)
+- NPU: [#14541](https://github.com/sgl-project/sglang/pull/14541), [#14572](https://github.com/sgl-project/sglang/pull/14572), [#15381](https://github.com/sgl-project/sglang/pull/15381), [#16990](https://github.com/sgl-project/sglang/pull/16990), [#17007](https://github.com/sgl-project/sglang/pull/17007), [#21468](https://github.com/sgl-project/sglang/pull/21468)
+- HiSparse/HiCache: [#21259](https://github.com/sgl-project/sglang/pull/21259), [#22065](https://github.com/sgl-project/sglang/pull/22065), [#22425](https://github.com/sgl-project/sglang/pull/22425)
+
+### Stage V32-6: IndexCache
+
+IndexCache reuses NSA top-k indices across layers.
+
+Key PR:
+
+- [#21405](https://github.com/sgl-project/sglang/pull/21405)
+
+Success check:
+
+- `skip_topk` and `next_skip_topk` are set per layer
+- `index_topk_freq` and `index_topk_pattern` override behavior correctly
+- `prev_topk_indices` is carried through layers
+- `test/registered/8-gpu-models/test_deepseek_v32_indexcache.py` remains accurate
+
+### Stage V32-7: DSML tool calling and reasoning interaction
+
+Standard V3.2 uses DSML:
+
+```text
+<｜DSML｜function_calls><｜DSML｜invoke name="tool">...</｜DSML｜invoke></｜DSML｜function_calls>
+```
+
+The detector supports XML parameter tags and direct JSON. Track open parser bugs:
+
+- [#21179](https://github.com/sgl-project/sglang/pull/21179): reasoning parser should preserve V3.2 tool-call markers.
+- [#21546](https://github.com/sgl-project/sglang/pull/21546): catch malformed JSON while parsing partial function calls.
+
+## Validation Surface
+
+Use the narrowest lane that matches the change:
+
+- V3.2 base/MTP/DP/TP/tool-calling: `test/registered/8-gpu-models/test_deepseek_v32.py`
+- NSA backend pair: `test_deepseek_v32_nsa_backends` inside that file
+- IndexCache: `test/registered/8-gpu-models/test_deepseek_v32_indexcache.py`
+- chat template argument types: `test/manual/test_deepseek_chat_templates.py`
+- CP and DeepEP-specific changes: use the dedicated CP/DeepEP suites referenced by the PR
+- AMD changes: MI300/MI355 registered lanes
+- NPU changes: Ascend/NPU model deployment and backend tests

--- a/skills/sglang-deepseek-v32-optimization/agents/openai.yaml
+++ b/skills/sglang-deepseek-v32-optimization/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "SGLang DeepSeek V3.2 Optimization"
+  short_description: "Current-main DeepSeek V3.2 playbook for DSA/NSA, indexer, CP, MTP, IndexCache, DSML parser, KV cache, and backend validation"
+  default_prompt: "Use $sglang-deepseek-v32-optimization to optimize or debug DeepSeek V3.2, V3.2-Exp, NVFP4, or MXFP4 in SGLang, including DSA/NSA sparse attention, NSA indexer, KV-cache dtype and backends, context parallel, MTP/spec decoding, IndexCache, DSML tool calling, AMD/NPU/Blackwell backends, and model-backed validation lanes."

--- a/skills/sglang-deepseek-v32-optimization/references/playbook.md
+++ b/skills/sglang-deepseek-v32-optimization/references/playbook.md
@@ -1,0 +1,177 @@
+# DeepSeek V3.2 Playbook
+
+Use this playbook when a V3.2 optimization or regression report is ambiguous. The goal is to determine whether the failure is DSA/NSA, inherited DeepSeek runtime, parser/template, MTP, CP, or backend-specific.
+
+## 1. Identify The Model Shape
+
+Collect these first:
+
+- `hf_config.architectures`
+- whether `is_deepseek_nsa(config)` is true
+- model variant: V3.2-Exp, V3.2, Speciale, NVFP4, MXFP4
+- quantization config
+- `--attention-backend`
+- `--nsa-prefill-backend`
+- `--nsa-decode-backend`
+- `--kv-cache-dtype`
+- TP / DP / EP / PP / PD
+- `--enable-dp-attention`
+- `--enable-nsa-prefill-context-parallel`
+- `--nsa-prefill-cp-mode`
+- MTP/speculative decoding args
+- parser pair and chat template
+- hardware
+
+If `is_deepseek_nsa(config)` is false, switch to `sglang-deepseek-v3-r1-optimization`.
+If the report is V3.1 parser behavior, switch to `sglang-deepseek-v31-optimization`.
+
+## 2. Server Defaults
+
+Read `server_args.py` first.
+
+Expected current behavior:
+
+- DSA models set `attention_backend = "nsa"` when not specified.
+- `SGLANG_NSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD` defaults to model `index_topk` if not user-set.
+- DSA KV cache dtype defaults to `fp8_e4m3` on SM100 and `bfloat16` otherwise.
+- DSA KV cache dtype is restricted to `bfloat16` or `fp8_e4m3` in the mainline path.
+- ROCm defaults to TileLang NSA prefill/decode.
+- Blackwell with FP8 KV defaults to TRTLLM NSA backends.
+- Hopper with FP8 KV can use FlashMLA KV.
+- BF16 KV can use `flashmla_sparse` plus `trtllm` or `fa3` depending on architecture.
+
+If a user manually sets NSA backend but leaves KV cache dtype as `auto`, ask for the explicit dtype before comparing performance.
+
+## 3. NSA Indexer
+
+Read `nsa_indexer.py`.
+
+Check:
+
+- q/k projection and `weights_proj`
+- mixed-type LayerNorm path
+- dual-stream decode threshold
+- activation quant
+- FP8 index/K-cache store
+- top-k transform backend
+- CP rerange and all-gather behavior
+- whether `skip_topk` is active through IndexCache
+
+Common clues:
+
+- 128K bugs often point to `get_k_and_s_triton`
+- FP8 KV bugs often point to scale buffer or fused-store handling
+- AMD kernel-count regressions often point to weights_proj and K-cache store fusion
+- quality regressions can come from FP32 precision loss in `weights_proj`
+
+## 4. NSA Backend
+
+Read `nsa_backend.py`.
+
+Check:
+
+- metadata fields: `nsa_cache_seqlens_int32`, `nsa_cu_seqlens_q`, `nsa_cu_seqlens_k`, `nsa_seqlens_expanded`
+- paged vs ragged top-k transform
+- prefill backend auto-selection
+- decode backend
+- FP8 K-cache quant/dequant
+- FlashMLA metadata and paged MQA schedule
+- MTP precompute mixin
+
+If top-k indices have the right shape but attention is wrong, look at transform, cache seqlens, and page-table offsets before changing the indexer.
+
+## 5. Context Parallel
+
+Context parallel is still guarded by constraints.
+
+Check:
+
+- `--enable-nsa-prefill-context-parallel`
+- `--nsa-prefill-cp-mode`
+- `round-robin-split` vs `in-seq-split`
+- DP size and EP size
+- DeepEP requirement for in-seq split
+- PD decode restrictions
+- CP positions in NextN/MTP
+
+Common open issues:
+
+- AMD round-robin output corruption: [#20360](https://github.com/sgl-project/sglang/pull/20360)
+- ragged gather mismatch in CP round-robin: [#20531](https://github.com/sgl-project/sglang/pull/20531)
+- TP indexer weight: [#19609](https://github.com/sgl-project/sglang/pull/19609)
+
+## 6. MTP / Spec Decoding
+
+If `SGLANG_ENABLE_SPEC_V2=1` or EAGLE args are present:
+
+- inspect `deepseek_nextn.py`
+- inspect NSA metadata precompute
+- inspect target_verify and draft_extend backend handling
+- verify CP positions
+- check page-table overflow fixes
+- verify draft-model mapping includes V3.2 when relevant
+
+MTP bugs often show up only under DP attention or CP.
+
+## 7. IndexCache
+
+IndexCache means some layers skip top-k computation and reuse previous top-k indices.
+
+Check in `deepseek_v2.py`:
+
+- `index_topk_freq`
+- `index_topk_pattern`
+- `skip_topk`
+- `next_skip_topk`
+- `prev_topk_indices`
+
+Validation:
+
+- `test/registered/8-gpu-models/test_deepseek_v32_indexcache.py`
+
+## 8. Parser And Tool Calling
+
+Standard V3.2 uses DSML:
+
+```text
+<｜DSML｜function_calls>
+<｜DSML｜invoke name="tool_name">
+...
+</｜DSML｜invoke>
+</｜DSML｜function_calls>
+```
+
+`DeepSeekV32Detector` supports:
+
+- XML parameter tags
+- direct JSON inside invoke
+- partial JSON during streaming
+- stable prefix diff streaming
+
+Open parser risks:
+
+- reasoning parser may strip tool markers: [#21179](https://github.com/sgl-project/sglang/pull/21179)
+- malformed partial JSON should not crash parsing: [#21546](https://github.com/sgl-project/sglang/pull/21546)
+
+V3.2-Exp cookbook docs may use `deepseekv31` with the V3.2 template, while standard V3.2 uses `deepseekv32` and no custom chat template. Check the exact model variant.
+
+## 9. Validation Order
+
+Pick the smallest lane:
+
+1. parser/template only: DSML parser or `test/manual/test_deepseek_chat_templates.py`
+2. DSA base: `test/registered/8-gpu-models/test_deepseek_v32.py`
+3. NSA backend pair: `test_deepseek_v32_nsa_backends`
+4. MTP: V3.2 TP8+MTP or DP8+MTP variants
+5. IndexCache: `test/registered/8-gpu-models/test_deepseek_v32_indexcache.py`
+6. CP: CP-specific registered or DeepEP suite tests
+7. AMD/NPU/Blackwell: the platform-specific lane that matches the backend
+
+## 10. Common False Conclusions
+
+- "V3.2 is only V3 with a new checkpoint." It activates DSA/NSA.
+- "NSA backend means one kernel." It is indexer, top-k transform, sparse MLA, KV quant/dequant, and metadata.
+- "FP8 KV is always faster." Backend, padding, scale buffer, and architecture decide.
+- "MTP bugs are only NextN bugs." For V3.2 they often involve NSA metadata or CP positions.
+- "IndexCache only changes speed." It changes when top-k is computed and must preserve accuracy.
+- "V3.2 parser is V3.1 parser." Standard V3.2 uses DSML and `deepseekv32`.

--- a/skills/sglang-deepseek-v32-optimization/references/pr-history.md
+++ b/skills/sglang-deepseek-v32-optimization/references/pr-history.md
@@ -1,0 +1,211 @@
+# DeepSeek V3.2 PR History
+
+Snapshot:
+
+- SGLang `origin/main`: `929e00eea`
+- sgl-cookbook `origin/main`: `8ec4d03`
+- Date: `2026-04-21`
+
+This history covers DeepSeek V3.2 only. DeepSeek V3/R1 runtime internals and V3.1 parser/template differences are tracked by separate skills.
+
+## Chronological Timeline
+
+| Date | PR | State | Area | Main effect |
+| --- | ---: | --- | --- | --- |
+| 2025-09-25 | [#10912](https://github.com/sgl-project/sglang/pull/10912) | merged | PD | Added PD support for hybrid models including DeepSeek V3.2 Exp. |
+| 2025-09-29 | [#11061](https://github.com/sgl-project/sglang/pull/11061) | merged | bring-up | Added DeepSeek V3.2 Exp, NSA backend, indexer, sparse attention plumbing, memory pool, model runner, and tests. |
+| 2025-10-03 | [#11191](https://github.com/sgl-project/sglang/pull/11191) | open | sparse KV scheduling | Tracks CPU/GPU KV cache scheduling for GQA/DSA sparse attention. |
+| 2025-10-12 | [#11510](https://github.com/sgl-project/sglang/pull/11510) | merged | bugfix | Fixed Qwen3/DSV3/DSV3.2 model support. |
+| 2025-10-15 | [#11652](https://github.com/sgl-project/sglang/pull/11652) | merged | MTP | Added MTP for DSV3.2. |
+| 2025-10-20 | [#11877](https://github.com/sgl-project/sglang/pull/11877) | merged | docs | Added DeepSeek V3.2 docs. |
+| 2025-10-21 | [#11936](https://github.com/sgl-project/sglang/pull/11936) | merged | NSA tests | Added V3.2 NSA backend testing. |
+| 2025-10-24 | [#12044](https://github.com/sgl-project/sglang/pull/12044) | merged | indexer | Enabled mixed-type LayerNorm kernel for NSA indexer. |
+| 2025-10-24 | [#12065](https://github.com/sgl-project/sglang/pull/12065) | merged | CP | Added initial context parallel support for DeepSeek V3.2 DSA. |
+| 2025-10-25 | [#12123](https://github.com/sgl-project/sglang/pull/12123) | merged | template | Fixed dict/string argument type handling in DeepSeek templates. |
+| 2025-10-28 | [#12296](https://github.com/sgl-project/sglang/pull/12296) | merged | docs | Updated `deepseek_v32.md`. |
+| 2025-11-08 | [#12868](https://github.com/sgl-project/sglang/pull/12868) | merged | docs | Documented MHA short-sequence prefill for V3.2. |
+| 2025-11-20 | [#13646](https://github.com/sgl-project/sglang/pull/13646) | merged | TP/DP attention | Enabled pure TP and partial DP attention for V3.2. |
+| 2025-11-23 | [#13812](https://github.com/sgl-project/sglang/pull/13812) | merged | indexer perf | Optimized NSA indexer K/S buffer access with fused Triton kernels. |
+| 2025-11-26 | [#13959](https://github.com/sgl-project/sglang/pull/13959) | merged | CP perf | Optimized context parallel with fused MoE, multi-batch, and FP8 KV cache. |
+| 2025-12-06 | [#14541](https://github.com/sgl-project/sglang/pull/14541) | merged | NPU CP | Added V3.2 CP support for NPU. |
+| 2025-12-07 | [#14572](https://github.com/sgl-project/sglang/pull/14572) | merged | NPU perf | Added V3.2 NPU optimizations. |
+| 2025-12-14 | [#15088](https://github.com/sgl-project/sglang/pull/15088) | merged | MTP tests | Added pure TP plus MTP test. |
+| 2025-12-17 | [#15307](https://github.com/sgl-project/sglang/pull/15307) | merged | spec overlap | Supported overlap speculative decoding plus NSA. |
+| 2025-12-18 | [#15381](https://github.com/sgl-project/sglang/pull/15381) | merged | NPU | Added NPU MLA prolog support for V3.2. |
+| 2025-12-27 | [#15938](https://github.com/sgl-project/sglang/pull/15938) | merged | env cleanup | Cleaned V3.2 environment variables. |
+| 2025-12-30 | [#16119](https://github.com/sgl-project/sglang/pull/16119) | merged | CP bugfix | Fixed V3.2 CP issues. |
+| 2025-12-30 | [#16156](https://github.com/sgl-project/sglang/pull/16156) | merged | CP guard | Asserted V3.2 CP in PD decode mode. |
+| 2026-01-02 | [#16305](https://github.com/sgl-project/sglang/pull/16305) | merged | V32/CP updates | Added multiple V3.2 and context-parallel updates. |
+| 2026-01-02 | [#16306](https://github.com/sgl-project/sglang/pull/16306) | merged | refactor | Refactored DeepSeek attention backend handlers and forward definitions. |
+| 2026-01-04 | [#16380](https://github.com/sgl-project/sglang/pull/16380) | merged | PP/CP | Supported and optimized pipeline parallelism when context pipeline is enabled. |
+| 2026-01-07 | [#16637](https://github.com/sgl-project/sglang/pull/16637) | merged | indexer overlap | Overlapped indexer `weights_proj` during dual-stream decode. |
+| 2026-01-11 | [#16907](https://github.com/sgl-project/sglang/pull/16907) | merged | AWQ loading | Fixed DeepSeek-V3.2-AWQ model loading. |
+| 2026-01-12 | [#16916](https://github.com/sgl-project/sglang/pull/16916) | merged | docs | Added V3.2 CP+PP documentation. |
+| 2026-01-12 | [#16961](https://github.com/sgl-project/sglang/pull/16961) | merged | MTP perf | Optimized MTP decode CUDA batch sizes and NSA implementation. |
+| 2026-01-13 | [#16990](https://github.com/sgl-project/sglang/pull/16990) | merged | NPU bugfix | Fixed V3.2 weight-cast bug on Ascend. |
+| 2026-01-13 | [#17007](https://github.com/sgl-project/sglang/pull/17007) | merged | NPU bugfix | Fixed V3.2 and DSVL2 NPU issues. |
+| 2026-01-14 | [#17076](https://github.com/sgl-project/sglang/pull/17076) | merged | indexer/FA3 bugfix | Fixed sliced indexer and FA3 padding when CUDA graph cannot run. |
+| 2026-01-15 | [#17133](https://github.com/sgl-project/sglang/pull/17133) | merged | MoE tuning | Added H20/H20-3E fused MoE configs for V3.1/V3.2. |
+| 2026-01-23 | [#17657](https://github.com/sgl-project/sglang/pull/17657) | merged | NVFP4 | Updated tests and docs for V3.2 NVFP4 checkpoint. |
+| 2026-01-23 | [#17662](https://github.com/sgl-project/sglang/pull/17662) | merged | TRTLLM NSA | Fixed TRT-LLM NSA in target_verify and draft_extend. |
+| 2026-01-25 | [#17688](https://github.com/sgl-project/sglang/pull/17688) | merged | indexer overlap | Overlapped indexer q/k projection and activation quantization. |
+| 2026-01-26 | [#17783](https://github.com/sgl-project/sglang/pull/17783) | merged | AMD docs | Updated V3.2 AMD GPU docs and unified ROCm TileLang build. |
+| 2026-02-05 | [#18280](https://github.com/sgl-project/sglang/pull/18280) | merged | CP scale buffer | Added CP support for `get_index_k_scale_buffer`. |
+| 2026-02-07 | [#18389](https://github.com/sgl-project/sglang/pull/18389) | merged | NVFP4/TRTLLM | Added NSA TRTLLM sparse MLA FP8 support for V3.2 NVFP4. |
+| 2026-02-10 | [#18553](https://github.com/sgl-project/sglang/pull/18553) | merged | bugfix | Fixed V3.2 bug. |
+| 2026-02-11 | [#18613](https://github.com/sgl-project/sglang/pull/18613) | merged | CP default | Changed default CP token split method to `round-robin-split`. |
+| 2026-02-16 | [#18876](https://github.com/sgl-project/sglang/pull/18876) | merged | MoE tune | Added DeepSeek3.2 and GLM-MoE-DSA into MoE tuning. |
+| 2026-02-17 | [#18931](https://github.com/sgl-project/sglang/pull/18931) | merged | FP8 KV | Fixed NSA FP8 KV cache path for both-TRTLLM MHA one-shot. |
+| 2026-02-18 | [#18978](https://github.com/sgl-project/sglang/pull/18978) | merged | AMD MTP | Fixed MI35x V3.2 MTP nightly. |
+| 2026-02-19 | [#19016](https://github.com/sgl-project/sglang/pull/19016) | merged | spec bugfix | Fixed NSA backend page-table overflow in target_verify. |
+| 2026-02-20 | [#19041](https://github.com/sgl-project/sglang/pull/19041) | merged | quality | Avoided FP32 precision loss in `weights_proj`. |
+| 2026-02-20 | [#19062](https://github.com/sgl-project/sglang/pull/19062) | merged | MTP/CP | Fixed MTP and CP compatibility. |
+| 2026-02-21 | [#19122](https://github.com/sgl-project/sglang/pull/19122) | merged | MLA refactor | Migrated MLA forward method out of `deepseek_v2.py`. |
+| 2026-02-22 | [#19148](https://github.com/sgl-project/sglang/pull/19148) | merged | JIT kernel | Added JIT NSA fused store for indexer K cache. |
+| 2026-02-25 | [#19319](https://github.com/sgl-project/sglang/pull/19319) | merged | 128K bugfix | Fixed `get_k_and_s_triton` for 128K sequence case. |
+| 2026-02-25 | [#19367](https://github.com/sgl-project/sglang/pull/19367) | merged | MTP/CP | Fixed NSA CP position mismatch in EAGLE NextN. |
+| 2026-02-26 | [#19428](https://github.com/sgl-project/sglang/pull/19428) | merged | qlora/ag | Added `mla_ag_after_qlora` feature for V3.2. |
+| 2026-02-28 | [#19536](https://github.com/sgl-project/sglang/pull/19536) | merged | MTP metadata | Optimized NSA backend metadata under MTP. |
+| 2026-03-05 | [#19945](https://github.com/sgl-project/sglang/pull/19945) | merged | AMD TileLang | Added TileLang sparse forward for V3.2 MI355/MI300. |
+| 2026-03-07 | [#20086](https://github.com/sgl-project/sglang/pull/20086) | merged | NVFP4 default | Changed V3.2 NVFP4 default setting on TP4. |
+| 2026-03-11 | [#20326](https://github.com/sgl-project/sglang/pull/20326) | merged | docs | Added DSA/NSA attention backend to support matrix. |
+| 2026-03-12 | [#20438](https://github.com/sgl-project/sglang/pull/20438) | merged | CP perf | Overlapped NSA-CP key all-gather with query computation. |
+| 2026-03-13 | [#20492](https://github.com/sgl-project/sglang/pull/20492) | merged | EAGLE3/DP | Fixed DeepSeek EAGLE3 in attention-DP mode. |
+| 2026-03-15 | [#20606](https://github.com/sgl-project/sglang/pull/20606) | merged | FP8 KV offset | Computed `topk_indices_offset` for flashmla_sparse with FP8 KV cache. |
+| 2026-03-18 | [#20840](https://github.com/sgl-project/sglang/pull/20840) | merged | AMD accuracy | Fixed V3.2 accuracy on MI355. |
+| 2026-03-20 | [#20984](https://github.com/sgl-project/sglang/pull/20984) | merged | FP4 test | Fixed V3.2 FP4 test. |
+| 2026-03-20 | [#21003](https://github.com/sgl-project/sglang/pull/21003) | merged | revert | Reverted the V3.2 FP4 test fix. |
+| 2026-03-23 | [#21192](https://github.com/sgl-project/sglang/pull/21192) | merged | CP tests | Fixed CP in-seq-split and updated tests. |
+| 2026-03-24 | [#21249](https://github.com/sgl-project/sglang/pull/21249) | merged | CP/all-reduce | Supported all-reduce fusion with context parallel. |
+| 2026-03-24 | [#21259](https://github.com/sgl-project/sglang/pull/21259) | merged | HiCache | Added mooncake backend support for DSA and mamba hybrid models. |
+| 2026-03-24 | [#21337](https://github.com/sgl-project/sglang/pull/21337) | merged | B200+DP perf | Added workaround for DSA performance drop on B200 + DP. |
+| 2026-03-25 | [#21405](https://github.com/sgl-project/sglang/pull/21405) | merged | IndexCache | Enabled IndexCache for DeepSeek V3.2. |
+| 2026-03-26 | [#21468](https://github.com/sgl-project/sglang/pull/21468) | merged | NPU docs | Updated V3.2 NPU deployment docs. |
+| 2026-03-27 | [#21511](https://github.com/sgl-project/sglang/pull/21511) | merged | AMD FP8 KV | Enabled FP8 KV cache and FP8 attention kernel for NSA TileLang. |
+| 2026-03-28 | [#21585](https://github.com/sgl-project/sglang/pull/21585) | merged | CI | Moved V3.2 CP test to DeepEP suite. |
+| 2026-03-28 | [#21599](https://github.com/sgl-project/sglang/pull/21599) | merged | MTP/spec | Added adaptive `speculative_num_steps` for EAGLE top-k=1. |
+| 2026-03-31 | [#21783](https://github.com/sgl-project/sglang/pull/21783) | merged | TRTLLM prefill | Supported TRTLLM sparse MLA kernel for DSA prefill batches. |
+| 2026-04-02 | [#21914](https://github.com/sgl-project/sglang/pull/21914) | merged | Blackwell default | Set TRTLLM kernels as default for Blackwell DSA. |
+| 2026-04-03 | [#22003](https://github.com/sgl-project/sglang/pull/22003) | merged | CP topology | Supported `moe_dp_size = 1` across different `attention_cp_size` values. |
+| 2026-04-03 | [#22065](https://github.com/sgl-project/sglang/pull/22065) | merged | HiSparse guard | Restricted HiSparse checks to DSA models. |
+| 2026-04-05 | [#22128](https://github.com/sgl-project/sglang/pull/22128) | merged | PCG/spec | Allowed piecewise CUDA graph with speculative decoding. |
+| 2026-04-06 | [#22179](https://github.com/sgl-project/sglang/pull/22179) | merged | docs | Improved DeepSeek V3.2 and GLM-5 docs. |
+| 2026-04-07 | [#22232](https://github.com/sgl-project/sglang/pull/22232) | merged | indexer perf | Reduced unnecessary kernels and copies in NSA indexer. |
+| 2026-04-07 | [#22258](https://github.com/sgl-project/sglang/pull/22258) | merged | AMD perf | Added BF16 passthrough from RMSNorm to avoid FP8 dequantization. |
+| 2026-04-08 | [#22372](https://github.com/sgl-project/sglang/pull/22372) | merged | Hopper FP8 KV | Added Hopper FP8 FlashMLA KV padding. |
+| 2026-04-08 | [#22390](https://github.com/sgl-project/sglang/pull/22390) | merged | all-reduce fusion | Enabled all-reduce fusion for DSA models. |
+| 2026-04-09 | [#22424](https://github.com/sgl-project/sglang/pull/22424) | merged | AMD layernorm | Used AITER CK LayerNorm2D for NSA indexer. |
+| 2026-04-09 | [#22425](https://github.com/sgl-project/sglang/pull/22425) | merged | HiSparse CI | Added HiSparse-DSA nightly CI. |
+| 2026-04-09 | [#22430](https://github.com/sgl-project/sglang/pull/22430) | merged | DSA bugfix | Fixed several DSA model bugs. |
+| 2026-04-15 | [#22850](https://github.com/sgl-project/sglang/pull/22850) | merged | AMD indexer perf | Fused weights projection and K-cache store to reduce NSA indexer kernels. |
+| 2026-04-16 | [#22914](https://github.com/sgl-project/sglang/pull/22914) | merged | CP refactor | Deduplicated NSA utils into CP utils. |
+| 2026-04-16 | [#22950](https://github.com/sgl-project/sglang/pull/22950) | closed | reasoning cache | Explored parser-gated two-phase radix-cache stripping for reasoning tokens. |
+| 2026-04-20 | [#23219](https://github.com/sgl-project/sglang/pull/23219) | merged | shared NextN | Enabled MTP for GLM-5 MXFP4 by touching shared `deepseek_nextn.py` infrastructure. |
+| 2026-04-21 | [#23315](https://github.com/sgl-project/sglang/pull/23315) | merged | reasoning cache | Added opt-in stripping of thinking tokens from radix cache. |
+| 2026-04-21 | [#23336](https://github.com/sgl-project/sglang/pull/23336) | open | spec v2 | Extends adaptive speculative decoding to spec v2 EAGLE workers. |
+| 2026-04-21 | [#23351](https://github.com/sgl-project/sglang/pull/23351) | open | PCG | Adds piecewise CUDA graph support with NSA. |
+
+## Additional PR Coverage
+
+Additional all-state PR coverage includes V3.2-relevant work that the first timeline did not enumerate one by one:
+
+- Early bring-up polish: [#11063](https://github.com/sgl-project/sglang/pull/11063), [#11194](https://github.com/sgl-project/sglang/pull/11194), [#11308](https://github.com/sgl-project/sglang/pull/11308), [#11309](https://github.com/sgl-project/sglang/pull/11309), [#11450](https://github.com/sgl-project/sglang/pull/11450), [#11557](https://github.com/sgl-project/sglang/pull/11557), [#11565](https://github.com/sgl-project/sglang/pull/11565), [#11682](https://github.com/sgl-project/sglang/pull/11682), [#11815](https://github.com/sgl-project/sglang/pull/11815), and [#11835](https://github.com/sgl-project/sglang/pull/11835).
+- Short-sequence MHA / Indexer fixes: [#11892](https://github.com/sgl-project/sglang/pull/11892), [#12094](https://github.com/sgl-project/sglang/pull/12094), [#12582](https://github.com/sgl-project/sglang/pull/12582), [#12583](https://github.com/sgl-project/sglang/pull/12583), [#12645](https://github.com/sgl-project/sglang/pull/12645), [#12788](https://github.com/sgl-project/sglang/pull/12788), [#12816](https://github.com/sgl-project/sglang/pull/12816), [#12964](https://github.com/sgl-project/sglang/pull/12964), [#13022](https://github.com/sgl-project/sglang/pull/13022), [#13459](https://github.com/sgl-project/sglang/pull/13459), and [#13544](https://github.com/sgl-project/sglang/pull/13544).
+- DSML/tool/parser path: [#14304](https://github.com/sgl-project/sglang/pull/14304), [#14307](https://github.com/sgl-project/sglang/pull/14307), [#14353](https://github.com/sgl-project/sglang/pull/14353), [#14573](https://github.com/sgl-project/sglang/pull/14573), [#14750](https://github.com/sgl-project/sglang/pull/14750), [#15064](https://github.com/sgl-project/sglang/pull/15064), [#15278](https://github.com/sgl-project/sglang/pull/15278), [#16091](https://github.com/sgl-project/sglang/pull/16091), [#17951](https://github.com/sgl-project/sglang/pull/17951), [#18126](https://github.com/sgl-project/sglang/pull/18126), and [#18174](https://github.com/sgl-project/sglang/pull/18174).
+- NSA backend / metadata / sparse-cache work: [#14781](https://github.com/sgl-project/sglang/pull/14781), [#14901](https://github.com/sgl-project/sglang/pull/14901), [#15040](https://github.com/sgl-project/sglang/pull/15040), [#15086](https://github.com/sgl-project/sglang/pull/15086), [#15242](https://github.com/sgl-project/sglang/pull/15242), [#15429](https://github.com/sgl-project/sglang/pull/15429), [#16520](https://github.com/sgl-project/sglang/pull/16520), [#16758](https://github.com/sgl-project/sglang/pull/16758), [#16841](https://github.com/sgl-project/sglang/pull/16841), [#17205](https://github.com/sgl-project/sglang/pull/17205), [#17554](https://github.com/sgl-project/sglang/pull/17554), and [#18319](https://github.com/sgl-project/sglang/pull/18319).
+- HiSparse/HiCache and platform fixes: [#14741](https://github.com/sgl-project/sglang/pull/14741), [#17409](https://github.com/sgl-project/sglang/pull/17409), [#17518](https://github.com/sgl-project/sglang/pull/17518), [#17523](https://github.com/sgl-project/sglang/pull/17523), [#17633](https://github.com/sgl-project/sglang/pull/17633), [#18297](https://github.com/sgl-project/sglang/pull/18297), [#18526](https://github.com/sgl-project/sglang/pull/18526), [#20343](https://github.com/sgl-project/sglang/pull/20343), [#21932](https://github.com/sgl-project/sglang/pull/21932), and [#22238](https://github.com/sgl-project/sglang/pull/22238).
+- Additional open PRs: [#14332](https://github.com/sgl-project/sglang/pull/14332), [#14524](https://github.com/sgl-project/sglang/pull/14524), [#15322](https://github.com/sgl-project/sglang/pull/15322), [#18094](https://github.com/sgl-project/sglang/pull/18094), [#18542](https://github.com/sgl-project/sglang/pull/18542), [#19987](https://github.com/sgl-project/sglang/pull/19987), [#20534](https://github.com/sgl-project/sglang/pull/20534), [#21623](https://github.com/sgl-project/sglang/pull/21623), [#22792](https://github.com/sgl-project/sglang/pull/22792), and [#23268](https://github.com/sgl-project/sglang/pull/23268).
+- Closed or superseded experiments to cite as history, not current support: [#11109](https://github.com/sgl-project/sglang/pull/11109), [#11596](https://github.com/sgl-project/sglang/pull/11596), [#11761](https://github.com/sgl-project/sglang/pull/11761), [#12017](https://github.com/sgl-project/sglang/pull/12017), [#12052](https://github.com/sgl-project/sglang/pull/12052), [#13531](https://github.com/sgl-project/sglang/pull/13531), [#13546](https://github.com/sgl-project/sglang/pull/13546), [#14619](https://github.com/sgl-project/sglang/pull/14619), [#14904](https://github.com/sgl-project/sglang/pull/14904), [#15051](https://github.com/sgl-project/sglang/pull/15051), [#15217](https://github.com/sgl-project/sglang/pull/15217), [#15310](https://github.com/sgl-project/sglang/pull/15310), [#15807](https://github.com/sgl-project/sglang/pull/15807), [#16079](https://github.com/sgl-project/sglang/pull/16079), [#16881](https://github.com/sgl-project/sglang/pull/16881), [#17024](https://github.com/sgl-project/sglang/pull/17024), [#17199](https://github.com/sgl-project/sglang/pull/17199), [#17310](https://github.com/sgl-project/sglang/pull/17310), and [#17647](https://github.com/sgl-project/sglang/pull/17647).
+- Round-2 runtime additions: [#21249](https://github.com/sgl-project/sglang/pull/21249) and [#22003](https://github.com/sgl-project/sglang/pull/22003) are CP/all-reduce topology updates; [#21599](https://github.com/sgl-project/sglang/pull/21599), [#22128](https://github.com/sgl-project/sglang/pull/22128), and open [#23336](https://github.com/sgl-project/sglang/pull/23336) are speculative-decoding updates; [#23219](https://github.com/sgl-project/sglang/pull/23219) is GLM-5-specific but touches shared `deepseek_nextn.py`; [#22950](https://github.com/sgl-project/sglang/pull/22950) and [#23315](https://github.com/sgl-project/sglang/pull/23315) define the closed/current reasoning radix-cache split.
+
+## Code-Level Narrative
+
+### 1. Bring-up and server defaults
+
+[#11061](https://github.com/sgl-project/sglang/pull/11061) is the foundational V3.2 Exp bring-up. It added the model-config detection, NSA backend, indexer, top-k transform, K-cache quant/dequant, memory-pool changes, model runner and CUDA-graph plumbing, `deepseek_v2.py` integration, `server_args.py` defaults, and tests.
+
+Current `server_args.py` treats DSA specially. If `is_deepseek_nsa(hf_config)` is true, it sets the attention backend to `nsa`, sets the dense-attention threshold env var to the model `index_topk` when not user-set, chooses DSA KV cache dtype, and selects NSA prefill/decode backends by hardware and dtype.
+
+### 2. NSA indexer and sparse attention backend
+
+`nsa_indexer.py` is the core of DSA. It computes q/k projections, applies the indexer weights projection, produces top-k indices, handles CP all-gather and rerange, and can quantize/store K cache. Performance work repeatedly targeted this file:
+
+- `#12044` enabled mixed-type LayerNorm.
+- `#13812` fused K/S buffer access.
+- `#16637` overlapped `weights_proj` in dual-stream decode.
+- `#17688` overlapped q/k projection and activation quantization.
+- `#19041` avoided FP32 precision loss in `weights_proj`.
+- `#19148` added JIT fused K-cache store.
+- `#22232` reduced extra kernels and copies.
+- `#22424` used AITER CK LayerNorm2D on AMD.
+- `#22850` fused AMD weights projection and K-cache store.
+
+`nsa_backend.py` then consumes those indices and metadata. It owns `NativeSparseAttnBackend`, computes `nsa_cache_seqlens_int32`, `nsa_cu_seqlens_q/k`, picks paged or ragged top-k transforms, prepares FlashMLA metadata, handles FP8 K-cache dequantization, and dispatches to `trtllm`, `flashmla_sparse`, `flashmla_kv`, `fa3`, `tilelang`, or `aiter`.
+
+### 3. Context parallel, PP, and DP attention
+
+V3.2 context parallel started in `#12065`. It touched server args, pynccl, parallel state, NSA utils/backend, communicator, DP attention, schedule policy, cuda graph, forward-batch metadata, `deepseek_v2.py`, `deepseek_nextn.py`, docs, and tests.
+
+The CP line then evolved through `#13959`, `#16119`, `#16156`, `#16305`, `#16380`, `#18613`, `#20438`, `#21192`, `#21249`, `#22003`, and `#22914`. Current important rules are:
+
+- `round-robin-split` is the default CP token split method.
+- `in-seq-split` requires DeepEP and `ep_size == tp_size`.
+- CP is restricted in PD decode mode.
+- CP positions must match EAGLE NextN.
+- key all-gather can overlap query computation.
+- all-reduce fusion can now be used with CP, so inspect `flashinfer_comm_fusion.py`, communicator setup, and `model_runner.py` before treating CP and all-reduce fusion as mutually exclusive.
+- `moe_dp_size = 1` with nontrivial `attention_cp_size` is no longer automatically out of scope; check `parallel_state.py`, `dp_attention.py`, and CP utilities for the active topology constraints.
+- utilities have been moved toward shared CP utils.
+
+### 4. MTP and speculative decoding
+
+`#11652` added MTP for V3.2, but several later PRs were needed because NSA changes the speculative decoding surface:
+
+- `#15088` added pure TP + MTP testing.
+- `#15307` supported overlap speculative decoding plus NSA.
+- `#16961` optimized MTP decode batch sizes and NSA implementation.
+- `#17662` fixed TRTLLM NSA in `target_verify` and `draft_extend`.
+- `#19016` fixed page-table overflow in speculative target_verify.
+- `#19062` fixed MTP and CP compatibility.
+- `#19367` fixed NSA CP position mismatch in EAGLE NextN.
+- `#19536` optimized NSA metadata under MTP.
+- `#20492` fixed DeepSeek EAGLE3 in attention-DP mode.
+- `#21599` added adaptive EAGLE top-k=1 draft steps, changing the assumption that speculative steps are static.
+- `#22128` allowed piecewise CUDA graph with speculative decoding.
+- `#23219` is GLM-5 MXFP4-specific, but it edits shared `deepseek_nextn.py`, so read it as DSA/NextN-adjacent history rather than V3.2 checkpoint support.
+- Open `#23336` extends adaptive speculative decoding to spec v2 workers.
+
+For V3.2, an MTP bug can also come from NSA metadata, CP positions, page-table offsets, or backend selection.
+
+### 5. Quantized and platform tracks
+
+V3.2 has several platform-specific tracks:
+
+- NVFP4 Blackwell: `#17657`, `#18389`, and `#20086` added docs/tests, TRTLLM sparse MLA FP8 support, and TP4 defaults.
+- AMD: `#17783`, `#19945`, `#20840`, `#21511`, `#22258`, and `#22850` cover ROCm docs, TileLang sparse forward, MI355 accuracy, FP8 KV cache, BF16 passthrough, and indexer kernel fusion.
+- NPU: `#14541`, `#14572`, `#15381`, `#16990`, `#17007`, and `#21468` cover CP, NPU optimizations, MLA prolog, cast bugs, and deployment docs.
+- HiSparse/HiCache: `#21259`, `#22065`, and `#22425` add DSA hybrid support, guard checks, and nightly CI.
+
+### 6. IndexCache
+
+[#21405](https://github.com/sgl-project/sglang/pull/21405) enabled IndexCache for V3.2. Current `deepseek_v2.py` sets `skip_topk` and `next_skip_topk` per layer. Without a pattern, it uses `index_topk_freq`; with `index_topk_pattern`, layers marked `S` skip top-k and reuse previous top-k indices. `test_deepseek_v32_indexcache.py` covers both `index_topk_freq=4` and a long explicit pattern.
+
+### 7. DSML parser
+
+Standard V3.2 uses `DeepSeekV32Detector`, which parses DSML:
+
+```text
+<｜DSML｜function_calls>
+<｜DSML｜invoke name="tool">
+<｜DSML｜parameter name="city" string="true">Beijing</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜function_calls>
+```
+
+It also accepts direct JSON inside an invoke block. Streaming parsing emits the tool name once, keeps previous argument strings, and sends stable-prefix diffs. Open `#21179` and `#21546` show the remaining parser edge cases around reasoning-parser marker preservation and malformed partial JSON.
+
+### 8. Reasoning radix-cache behavior
+
+V3.2 thinking and DSML parsing can interact with prefix-cache reuse. Closed [#22950](https://github.com/sgl-project/sglang/pull/22950) tried parser-gated two-phase reasoning cache stripping across model config, scheduler, radix cache, and reasoning parser code. Merged [#23315](https://github.com/sgl-project/sglang/pull/23315) is the current path: it adds an opt-in server argument and changes `schedule_batch.py` plus `mem_cache/common.py` so thinking tokens can be stripped from radix-cache entries.
+
+This is separate from DSML parsing. A tool-call marker preservation bug belongs to `deepseekv32_detector.py` / `reasoning_parser.py`; a thinking-prefix cache reuse bug belongs to the radix-cache stripping path.


### PR DESCRIPTION
## Summary

- Add PR-backed SGLang skills for DeepSeek V3/R1, DeepSeek V3.1, and DeepSeek V3.2.
- Add bilingual model optimization history documents for the same three model families.
- Document runtime coverage for adaptive EAGLE, PCG plus speculative decoding, thinking-token radix-cache stripping, CP all-reduce fusion, `moe_dp_size=1` with `attention_cp_size`, and spec-v2 adaptive-spec open PRs.

## Notes

The documents are based on SGLang `origin/main` snapshot `929e00eea` and sgl-cookbook `origin/main` snapshot `8ec4d03`. The SGLang source history contains runtime PRs that are not represented by cookbook-only changes; the cookbook snapshot changed, but DeepSeek cookbook docs/model entries did not change in that interval.

## Validation

- `SKIP=no-commit-to-branch pre-commit run --files ...`
- `codespell --config .codespellrc ...`
- YAML parse check for the added `agents/openai.yaml` files
- stale cookbook snapshot hash check
- terminology cleanup check on the PR-added files