### PR TITLE
[codex] Add cross-framework serving benchmark skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Agent skills for SGLang/vLLM/TensorRT-LLM development, profiling, and production
 
 ```
 skills/
+├── llm-serving-auto-benchmark/
+│   ├── SKILL.md
+│   ├── references/
+│   │   ├── example-plan.yaml
+│   │   ├── framework-matrix.md
+│   │   └── result-schema.md
+│   └── scripts/
+│       └── compare_benchmark_results.py
 ├── h100/
 │   └── SKILL.md
 ├── h100-sglang-diffusion/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ skills/
 │   ├── references/
 │   │   ├── example-plan.yaml
 │   │   ├── framework-matrix.md
-│   │   └── result-schema.md
+│   │   ├── result-schema.md
+│   │   └── version-notes.md
 │   └── scripts/
 │       └── compare_benchmark_results.py
 ├── h100/

--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -27,6 +27,11 @@ Prefer native tooling when it gives better coverage:
 Do not declare a winner until each requested framework has had a reasonable
 chance to tune its important knobs.
 
+Important: the parameter lists in this skill are not a permanent compatibility
+contract. They are version-sensitive candidate knob families. Before every real
+run, record the exact framework version or git commit and verify the concrete
+CLI flag names with `--help` in the target environment.
+
 ## Required Inputs
 
 Collect these before starting a long run:
@@ -42,6 +47,13 @@ Collect these before starting a long run:
 - SLA target: TTFT, TPOT/ITL, end-to-end latency, success rate, or goodput
 - search budget: quick smoke, default search, or exhaustive search
 - output directory for logs and result artifacts
+
+Also collect a version manifest:
+
+- framework package version and git commit when available
+- container image or Python environment identifier
+- `--help` snapshots for the server command and benchmark command
+- whether each parameter in the search plan was accepted by that exact CLI
 
 If real production traffic is the goal, use the real request distribution. A
 synthetic workload is acceptable for bring-up and broad comparison, but it is not
@@ -78,6 +90,10 @@ trtllm-serve --help
 Use the framework-specific `--help` output in the target environment as the
 source of truth. Do not keep a stale launch flag just because it appears in an
 old note.
+
+Save these `--help` outputs into the run artifact directory. If a listed search
+knob is missing from the current CLI, remove or translate that knob before
+running the benchmark. Do not silently pass unknown flags.
 
 For each framework:
 
@@ -153,7 +169,7 @@ python -m sglang.bench_serving \
   --request-rate 8
 ```
 
-High-impact SGLang knobs:
+Version-sensitive SGLang knob families to verify:
 
 - `tp_size`, `pp_size`, `dp_size`, `ep_size`
 - `attention_backend`, `prefill_attention_backend`, `decode_attention_backend`
@@ -180,7 +196,7 @@ vllm bench sweep serve \
 If sweep support is unavailable, run `vllm serve` for each candidate and measure
 with `vllm bench serve`.
 
-High-impact vLLM knobs:
+Version-sensitive vLLM knob families to verify:
 
 - tensor and pipeline parallelism
 - `gpu_memory_utilization`
@@ -196,18 +212,22 @@ High-impact vLLM knobs:
 
 ### 6. Tune TensorRT-LLM
 
-Use `trtllm-serve` as the server entrypoint when the target environment supports
-it:
+Use `trtllm-serve serve` as the server entrypoint when the target environment
+supports it:
 
 ```bash
-trtllm-serve <model> --tp_size <tp> --pp_size <pp> --host 0.0.0.0 --port 8000
+trtllm-serve serve <model> --tp_size <tp> --pp_size <pp> --host 0.0.0.0 --port 8000
 ```
 
 Then benchmark the OpenAI-compatible endpoint with the TensorRT-LLM serving
 benchmark client or with the same OpenAI-compatible client used for the other
 frameworks.
 
-High-impact TensorRT-LLM knobs:
+For TensorRT-LLM 1.0.0, `benchmark_serving --dataset-name random` samples from
+ShareGPT unless you pass either `--download-path` or `--random-ids`. For a fast
+synthetic smoke test, pass `--random-ids`.
+
+Version-sensitive TensorRT-LLM knob families to verify:
 
 - `tp_size`, `pp_size`, and `ep_size`
 - PyTorch backend versus TensorRT engine path when both are available
@@ -258,4 +278,6 @@ Return a compact report with:
 Use [references/framework-matrix.md](references/framework-matrix.md) when you
 need command templates or source links for each framework. Use
 [references/example-plan.yaml](references/example-plan.yaml) as the starting
-point for a full cross-framework run plan.
+point for a full cross-framework run plan. Use
+[references/version-notes.md](references/version-notes.md) to understand which
+source snapshots informed this skill and what has or has not been smoke-tested.

--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: llm-serving-auto-benchmark
+description: Cross-framework LLM serving benchmark skill for SGLang, vLLM, and TensorRT-LLM. Use when a user wants to find the best deployment command for one model across multiple serving frameworks under the same workload, GPU budget, and latency SLA.
+---
+
+# LLM Serving Auto Benchmark
+
+## Overview
+
+Use this skill to compare SGLang, vLLM, and TensorRT-LLM fairly for the same
+model and workload.
+
+The goal is not to run one benchmark command per framework. The goal is to run a
+small, controlled search for each framework, normalize the results, and report
+the best configuration under the same latency and throughput constraints.
+
+Prefer native tooling when it gives better coverage:
+
+- SGLang: `python -m sglang.auto_benchmark` when available, otherwise
+  `python -m sglang.bench_serving`
+- vLLM: `vllm bench sweep serve` for server-parameter sweeps, otherwise
+  `vllm serve` plus `vllm bench serve`
+- TensorRT-LLM: `trtllm-serve` for the OpenAI-compatible server plus the
+  TensorRT-LLM serving benchmark client or a common OpenAI-compatible benchmark
+  client
+
+Do not declare a winner until each requested framework has had a reasonable
+chance to tune its important knobs.
+
+## Required Inputs
+
+Collect these before starting a long run:
+
+- model path or Hugging Face repo id
+- tokenizer path if it differs from the model
+- target frameworks: any subset of `sglang`, `vllm`, `tensorrt-llm`
+- GPU model, GPU count, and whether multi-node is allowed
+- precision and quantization constraints
+- endpoint shape: completions, chat completions, responses, or custom
+- workload source: real traffic JSONL, ShareGPT, random synthetic, or generated
+  shared-prefix synthetic
+- SLA target: TTFT, TPOT/ITL, end-to-end latency, success rate, or goodput
+- search budget: quick smoke, default search, or exhaustive search
+- output directory for logs and result artifacts
+
+If real production traffic is the goal, use the real request distribution. A
+synthetic workload is acceptable for bring-up and broad comparison, but it is not
+enough to choose a production winner.
+
+## Fairness Rules
+
+Use these rules throughout the benchmark:
+
+- Run every framework on the same GPU type, GPU count, model weights, tokenizer,
+  precision, quantization policy, prompt distribution, output length target, and
+  sampling settings.
+- Record framework version, git commit, container image, CUDA/NCCL versions, GPU
+  driver, visible GPU ids, launch command, and benchmark command.
+- Warm the server before measuring. Restart or clear state between candidate
+  configurations when cache effects would bias the comparison.
+- Compare steady-state fixed-QPS runs separately from burst throughput runs.
+- Keep failed candidates in the final results with their failure reason.
+- Report both raw throughput and SLA-passing throughput. The fastest failing
+  candidate is not the best deployment command.
+
+## Workflow
+
+### 1. Preflight
+
+Verify all requested frameworks before starting a search:
+
+```bash
+python -m sglang.bench_serving --help
+vllm bench serve --help
+trtllm-serve --help
+```
+
+Use the framework-specific `--help` output in the target environment as the
+source of truth. Do not keep a stale launch flag just because it appears in an
+old note.
+
+For each framework:
+
+1. Launch a minimal server.
+2. Confirm `/v1/models` or the framework-native model-info endpoint works.
+3. Send one streaming request and verify TTFT can be measured.
+4. Run one tiny benchmark with at least 5 requests.
+5. Save the launch command, benchmark command, server log, and benchmark output.
+
+### 2. Normalize The Workload
+
+Use one canonical workload for all frameworks. Recommended JSONL row shape:
+
+```json
+{"prompt": [{"role": "user", "content": "Summarize this text."}], "output_len": 256}
+{"prompt": "Write a short explanation of CUDA graphs.", "output_len": 128}
+```
+
+Optional fields:
+
+```json
+{
+  "prompt": [{"role": "user", "content": "Use low temperature."}],
+  "output_len": 256,
+  "extra_request_body": {"temperature": 0.0, "top_p": 0.95},
+  "metadata": {"source": "prod-sample"}
+}
+```
+
+When converting user data:
+
+- inspect at least 3 rows before conversion
+- preserve request-level sampling options in `extra_request_body`
+- do not include the final assistant answer in the prompt when that answer is
+  the target completion
+- keep multimodal or tool-call payloads only if all requested frameworks support
+  the chosen endpoint shape
+
+### 3. Pick A Search Tier
+
+Use the smallest tier that can answer the user's question:
+
+- Tier 1: smoke and sanity. One baseline plus a few high-impact knobs.
+- Tier 2: default. A bounded sweep over the most likely server settings.
+- Tier 3: exhaustive. Only when the search space is already tight and the user
+  accepts a long run.
+
+Default budget:
+
+- `num_prompts: 80` for quick comparison
+- `search.max_candidates: 8` per framework for the first useful pass
+- at most 5 QPS search rounds unless the user asks for more
+- stop early when every candidate in one framework is clearly OOM or fails the
+  basic health check
+
+### 4. Tune SGLang
+
+Prefer the SGLang auto-benchmark runner when the target checkout supports it:
+
+```bash
+python -m sglang.auto_benchmark run --config /path/to/sglang.yaml
+```
+
+Otherwise launch the server manually and benchmark with:
+
+```bash
+python -m sglang.bench_serving \
+  --backend sglang \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 256 \
+  --num-prompts 80 \
+  --request-rate 8
+```
+
+High-impact SGLang knobs:
+
+- `tp_size`, `pp_size`, `dp_size`, `ep_size`
+- `attention_backend`, `prefill_attention_backend`, `decode_attention_backend`
+- `sampling_backend`
+- `max_running_requests`, `max_queued_requests`
+- `chunked_prefill_size`, `prefill_max_requests`, `max_prefill_tokens`
+- `max_total_tokens`, `page_size`, `mem_fraction_static`
+- CUDA graph and piecewise CUDA graph settings
+- speculative or EAGLE settings only after the non-speculative baseline is tuned
+
+### 5. Tune vLLM
+
+Use vLLM's sweep runner when available:
+
+```bash
+vllm bench sweep serve \
+  --serve-cmd 'vllm serve <model> --port 8000' \
+  --bench-cmd 'vllm bench serve --backend vllm --model <model> --port 8000 --dataset-name random --num-prompts 80' \
+  --serve-params /path/to/vllm_serve_params.json \
+  --bench-params /path/to/vllm_bench_params.json \
+  --output-dir /path/to/vllm_results
+```
+
+If sweep support is unavailable, run `vllm serve` for each candidate and measure
+with `vllm bench serve`.
+
+High-impact vLLM knobs:
+
+- tensor and pipeline parallelism
+- `gpu_memory_utilization`
+- `max_num_seqs`
+- `max_num_batched_tokens`
+- `max_model_len`
+- chunked prefill settings
+- KV cache dtype and block size
+- dtype and quantization settings
+- CUDA graph capture sizes or eager-mode toggles when relevant
+- prefix cache and speculative decoding settings only when the workload needs
+  those features
+
+### 6. Tune TensorRT-LLM
+
+Use `trtllm-serve` as the server entrypoint when the target environment supports
+it:
+
+```bash
+trtllm-serve <model> --tp_size <tp> --pp_size <pp> --host 0.0.0.0 --port 8000
+```
+
+Then benchmark the OpenAI-compatible endpoint with the TensorRT-LLM serving
+benchmark client or with the same OpenAI-compatible client used for the other
+frameworks.
+
+High-impact TensorRT-LLM knobs:
+
+- `tp_size`, `pp_size`, and `ep_size`
+- PyTorch backend versus TensorRT engine path when both are available
+- engine build options, quantization, and plugin selections
+- max batch size, max sequence length, max number of tokens, and KV-cache budget
+- inflight batching and scheduler options
+- extra LLM API options YAML used by `trtllm-serve`
+
+Because TensorRT-LLM can involve engine build time, keep build artifacts and
+server artifacts separate from benchmark outputs. Report build time separately
+from serving performance.
+
+### 7. Normalize Results
+
+Write one JSONL row per candidate using the schema in
+[references/result-schema.md](references/result-schema.md). Then run:
+
+```bash
+python skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py \
+  --input /path/to/candidates.jsonl \
+  --output /path/to/summary.md
+```
+
+Rank candidates in this order:
+
+1. SLA passed
+2. highest request throughput or goodput
+3. highest output token throughput
+4. lower p99 TTFT
+5. lower p99 TPOT/ITL
+6. lower GPU count or simpler deployment if performance is close
+
+## Output Contract
+
+Return a compact report with:
+
+- workload and SLA used
+- hardware and framework versions
+- best candidate per framework
+- overall winner under the SLA
+- failed or excluded candidates with reasons
+- exact launch command and benchmark command for each winner
+- artifact paths: canonical workload, raw results JSONL, normalized JSONL, CSV or
+  markdown summary, and key server logs
+- a caveat if the workload was synthetic or if any framework did not complete a
+  fair search
+
+Use [references/framework-matrix.md](references/framework-matrix.md) when you
+need command templates or source links for each framework. Use
+[references/example-plan.yaml](references/example-plan.yaml) as the starting
+point for a full cross-framework run plan.

--- a/skills/llm-serving-auto-benchmark/agents/openai.yaml
+++ b/skills/llm-serving-auto-benchmark/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "LLM Serving Auto Benchmark"
+  short_description: "Compare SGLang, vLLM, and TensorRT-LLM serving performance"
+  default_prompt: "Use $llm-serving-auto-benchmark to compare SGLang, vLLM, and TensorRT-LLM for one model under the same workload and SLA. Return the best deployment command per framework, the overall SLA-passing winner, and the benchmark artifact paths."

--- a/skills/llm-serving-auto-benchmark/references/example-plan.yaml
+++ b/skills/llm-serving-auto-benchmark/references/example-plan.yaml
@@ -9,6 +9,23 @@ model:
   precision: bf16
   quantization: none
 
+version_manifest:
+  sglang:
+    package_version: null
+    git_commit: null
+    server_help: artifacts/help/sglang_launch_server.txt
+    benchmark_help: artifacts/help/sglang_bench_serving.txt
+  vllm:
+    package_version: null
+    git_commit: null
+    server_help: artifacts/help/vllm_serve.txt
+    benchmark_help: artifacts/help/vllm_bench_serve.txt
+  tensorrt_llm:
+    package_version: null
+    git_commit: null
+    server_help: artifacts/help/trtllm_serve.txt
+    benchmark_help: artifacts/help/trtllm_benchmark_serving.txt
+
 hardware:
   gpu_model: NVIDIA H100 80GB HBM3
   gpu_count: 8
@@ -44,6 +61,7 @@ frameworks:
       tp_size: 8
       trust_remote_code: true
     search_space:
+      # Verify these names against `python -m sglang.launch_server --help`.
       attention_backend: [flashinfer, fa3]
       chunked_prefill_size: [8192, 16384]
       max_running_requests: [64, 128]
@@ -54,6 +72,7 @@ frameworks:
       tensor_parallel_size: 8
       trust_remote_code: true
     search_space:
+      # Verify these names against `vllm serve --help`.
       gpu_memory_utilization: [0.9, 0.95]
       max_num_seqs: [64, 128]
       max_num_batched_tokens: [8192, 16384]
@@ -64,6 +83,7 @@ frameworks:
       tp_size: 8
       pp_size: 1
     search_space:
-      backend: [pytorch, tensorrt]
+      # Verify these names against `trtllm-serve --help` and the selected backend.
+      backend: [pytorch, trt]
       max_batch_size: [64, 128]
       max_num_tokens: [8192, 16384]

--- a/skills/llm-serving-auto-benchmark/references/example-plan.yaml
+++ b/skills/llm-serving-auto-benchmark/references/example-plan.yaml
@@ -1,0 +1,69 @@
+# Example run plan for the llm-serving-auto-benchmark skill.
+#
+# This file is intentionally a control-plane template. The skill can translate
+# it into native SGLang, vLLM, and TensorRT-LLM commands in the target runtime.
+
+model:
+  name: meta-llama/Llama-3.1-70B-Instruct
+  tokenizer: meta-llama/Llama-3.1-70B-Instruct
+  precision: bf16
+  quantization: none
+
+hardware:
+  gpu_model: NVIDIA H100 80GB HBM3
+  gpu_count: 8
+  multi_node: false
+
+workload:
+  kind: custom
+  canonical_jsonl: /bench/workloads/prod_sample.autobench.jsonl
+  endpoint: /v1/chat/completions
+  num_prompts: 1000
+  request_rates: [4, 8, 12, 16]
+  max_concurrency: 256
+  synthetic_fallback:
+    dataset_name: random
+    input_len: 1024
+    output_len: 256
+
+sla:
+  max_p99_ttft_ms: 2000
+  max_p99_tpot_ms: 80
+  min_success_rate: 0.99
+
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  max_qps_rounds: 5
+  output_dir: /bench/results/llm-serving-auto-benchmark
+
+frameworks:
+  sglang:
+    enabled: true
+    base_server_flags:
+      tp_size: 8
+      trust_remote_code: true
+    search_space:
+      attention_backend: [flashinfer, fa3]
+      chunked_prefill_size: [8192, 16384]
+      max_running_requests: [64, 128]
+
+  vllm:
+    enabled: true
+    base_server_flags:
+      tensor_parallel_size: 8
+      trust_remote_code: true
+    search_space:
+      gpu_memory_utilization: [0.9, 0.95]
+      max_num_seqs: [64, 128]
+      max_num_batched_tokens: [8192, 16384]
+
+  tensorrt_llm:
+    enabled: true
+    base_server_flags:
+      tp_size: 8
+      pp_size: 1
+    search_space:
+      backend: [pytorch, tensorrt]
+      max_batch_size: [64, 128]
+      max_num_tokens: [8192, 16384]

--- a/skills/llm-serving-auto-benchmark/references/framework-matrix.md
+++ b/skills/llm-serving-auto-benchmark/references/framework-matrix.md
@@ -1,0 +1,65 @@
+# Framework Matrix
+
+Use this table to choose the native runner for each framework. Always verify the
+actual CLI in the target container with `--help` before a long run.
+
+| Framework | Server | Benchmark | Notes |
+| --- | --- | --- | --- |
+| SGLang | `python -m sglang.launch_server` | `python -m sglang.auto_benchmark` or `python -m sglang.bench_serving` | Use `auto_benchmark` when available for tiered server-flag search. `bench_serving` supports native and OpenAI-compatible endpoints. |
+| vLLM | `vllm serve` | `vllm bench sweep serve` or `vllm bench serve` | `vllm bench sweep serve` can launch `vllm serve` repeatedly and sweep serve/bench parameter JSON files. |
+| TensorRT-LLM | `trtllm-serve` | TensorRT-LLM serving benchmark client or a common OpenAI-compatible benchmark client | `trtllm-serve` exposes OpenAI-compatible endpoints. Separate engine build time from serving performance. |
+
+## Source Links
+
+- SGLang Bench Serving Guide: <https://docs.sglang.ai/developer_guide/bench_serving.html>
+- vLLM benchmark sweeps: <https://docs.vllm.ai/en/latest/benchmarking/sweeps/>
+- vLLM `bench sweep serve` CLI: <https://docs.vllm.ai/en/latest/cli/bench/sweep/serve.html>
+- TensorRT-LLM `trtllm-serve`: <https://nvidia.github.io/TensorRT-LLM/commands/trtllm-serve/trtllm-serve.html>
+- TensorRT-LLM serving benchmark tutorial: <https://nvidia.github.io/TensorRT-LLM/1.2.0rc6/commands/trtllm-serve/run-benchmark-with-trtllm-serve.html>
+
+## Command Templates
+
+### SGLang
+
+```bash
+python -m sglang.launch_server \
+  --model-path <model> \
+  --tp-size <tp> \
+  --port 30000
+
+python -m sglang.bench_serving \
+  --backend sglang \
+  --host 127.0.0.1 \
+  --port 30000 \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 256 \
+  --num-prompts 80 \
+  --request-rate 8
+```
+
+### vLLM
+
+```bash
+vllm bench sweep serve \
+  --serve-cmd 'vllm serve <model> --port 8000' \
+  --bench-cmd 'vllm bench serve --backend vllm --model <model> --port 8000 --dataset-name random --num-prompts 80' \
+  --serve-params vllm_serve_params.json \
+  --bench-params vllm_bench_params.json \
+  --output-dir vllm_results
+```
+
+### TensorRT-LLM
+
+```bash
+trtllm-serve <model> \
+  --tp_size <tp> \
+  --pp_size <pp> \
+  --host 0.0.0.0 \
+  --port 8000
+```
+
+Then benchmark `http://127.0.0.1:8000/v1/completions` or
+`http://127.0.0.1:8000/v1/chat/completions` with the TensorRT-LLM serving
+benchmark client or the same OpenAI-compatible client used for the other
+frameworks.

--- a/skills/llm-serving-auto-benchmark/references/framework-matrix.md
+++ b/skills/llm-serving-auto-benchmark/references/framework-matrix.md
@@ -7,7 +7,7 @@ actual CLI in the target container with `--help` before a long run.
 | --- | --- | --- | --- |
 | SGLang | `python -m sglang.launch_server` | `python -m sglang.auto_benchmark` or `python -m sglang.bench_serving` | Use `auto_benchmark` when available for tiered server-flag search. `bench_serving` supports native and OpenAI-compatible endpoints. |
 | vLLM | `vllm serve` | `vllm bench sweep serve` or `vllm bench serve` | `vllm bench sweep serve` can launch `vllm serve` repeatedly and sweep serve/bench parameter JSON files. |
-| TensorRT-LLM | `trtllm-serve` | TensorRT-LLM serving benchmark client or a common OpenAI-compatible benchmark client | `trtllm-serve` exposes OpenAI-compatible endpoints. Separate engine build time from serving performance. |
+| TensorRT-LLM | `trtllm-serve serve` | TensorRT-LLM serving benchmark client or a common OpenAI-compatible benchmark client | `trtllm-serve serve` exposes OpenAI-compatible endpoints. Separate engine build time from serving performance. |
 
 ## Source Links
 
@@ -52,7 +52,7 @@ vllm bench sweep serve \
 ### TensorRT-LLM
 
 ```bash
-trtllm-serve <model> \
+trtllm-serve serve <model> \
   --tp_size <tp> \
   --pp_size <pp> \
   --host 0.0.0.0 \
@@ -62,4 +62,5 @@ trtllm-serve <model> \
 Then benchmark `http://127.0.0.1:8000/v1/completions` or
 `http://127.0.0.1:8000/v1/chat/completions` with the TensorRT-LLM serving
 benchmark client or the same OpenAI-compatible client used for the other
-frameworks.
+frameworks. For TensorRT-LLM 1.0.0 synthetic random data, pass `--random-ids`
+unless you also provide a ShareGPT `--download-path`.

--- a/skills/llm-serving-auto-benchmark/references/result-schema.md
+++ b/skills/llm-serving-auto-benchmark/references/result-schema.md
@@ -1,0 +1,77 @@
+# Result Schema
+
+Write one JSON object per candidate. Keep failed candidates in the same file so
+the final summary explains what was tried.
+
+## JSONL Row
+
+```json
+{
+  "framework": "sglang",
+  "framework_version": "0.5.0",
+  "candidate_id": "sglang-tp8-flashinfer",
+  "model": "meta-llama/Llama-3.1-70B-Instruct",
+  "status": "ok",
+  "failure_reason": "",
+  "hardware": {
+    "gpu_model": "NVIDIA H100 80GB HBM3",
+    "gpu_count": 8,
+    "visible_devices": "0,1,2,3,4,5,6,7"
+  },
+  "workload": {
+    "kind": "custom",
+    "dataset_path": "/bench/workload.autobench.jsonl",
+    "num_prompts": 1000,
+    "request_rate": 16,
+    "max_concurrency": 256,
+    "endpoint": "/v1/chat/completions"
+  },
+  "sla": {
+    "max_p99_ttft_ms": 2000,
+    "max_p99_tpot_ms": 80,
+    "min_success_rate": 0.99,
+    "passed": true
+  },
+  "metrics": {
+    "request_throughput": 15.8,
+    "output_token_throughput": 12500.0,
+    "total_token_throughput": 42000.0,
+    "mean_ttft_ms": 430.0,
+    "p99_ttft_ms": 1550.0,
+    "mean_tpot_ms": 26.0,
+    "p99_tpot_ms": 72.0,
+    "mean_e2e_ms": 8200.0,
+    "p99_e2e_ms": 19000.0,
+    "success_rate": 0.995
+  },
+  "server_command": "python -m sglang.launch_server ...",
+  "benchmark_command": "python -m sglang.bench_serving ...",
+  "artifacts": {
+    "server_log": "/bench/sglang/server.log",
+    "raw_result": "/bench/sglang/results.jsonl"
+  }
+}
+```
+
+## Status Values
+
+- `ok`: benchmark finished and metrics are trustworthy
+- `failed`: command failed for a known non-OOM reason
+- `oom`: model or candidate exhausted GPU/host memory
+- `timeout`: server or benchmark timed out
+- `skipped`: intentionally not run, with a reason in `failure_reason`
+
+## Ranking Rule
+
+The default ranking is:
+
+1. `status == "ok"`
+2. `sla.passed == true`
+3. higher `metrics.request_throughput`
+4. higher `metrics.output_token_throughput`
+5. lower `metrics.p99_ttft_ms`
+6. lower `metrics.p99_tpot_ms`
+7. lower `hardware.gpu_count`
+
+If the user cares more about token throughput than request throughput, swap
+steps 3 and 4 and state that in the final report.

--- a/skills/llm-serving-auto-benchmark/references/result-schema.md
+++ b/skills/llm-serving-auto-benchmark/references/result-schema.md
@@ -9,6 +9,7 @@ the final summary explains what was tried.
 {
   "framework": "sglang",
   "framework_version": "0.5.0",
+  "framework_commit": "abcdef0",
   "candidate_id": "sglang-tp8-flashinfer",
   "model": "meta-llama/Llama-3.1-70B-Instruct",
   "status": "ok",
@@ -46,9 +47,15 @@ the final summary explains what was tried.
   },
   "server_command": "python -m sglang.launch_server ...",
   "benchmark_command": "python -m sglang.bench_serving ...",
+  "validated_cli_flags": {
+    "server": ["tp_size", "attention_backend"],
+    "benchmark": ["dataset_name", "request_rate", "max_concurrency"]
+  },
   "artifacts": {
     "server_log": "/bench/sglang/server.log",
-    "raw_result": "/bench/sglang/results.jsonl"
+    "raw_result": "/bench/sglang/results.jsonl",
+    "server_help": "/bench/sglang/help_launch_server.txt",
+    "benchmark_help": "/bench/sglang/help_bench_serving.txt"
   }
 }
 ```

--- a/skills/llm-serving-auto-benchmark/references/version-notes.md
+++ b/skills/llm-serving-auto-benchmark/references/version-notes.md
@@ -1,0 +1,62 @@
+# Version Notes
+
+This skill intentionally treats framework knobs as version-sensitive. Serving
+CLIs move quickly, so a future run must capture a fresh version manifest instead
+of trusting the examples blindly.
+
+## Authored Snapshot
+
+Last updated: 2026-04-22.
+
+The initial skill text was informed by these local/source snapshots:
+
+| Framework | Snapshot | Notes |
+| --- | --- | --- |
+| SGLang | local checkout `7044d5fe7`; H100 container package `sglang 0.5.10rc0` at repo commit `30cd2cf32` | SGLang `bench_serving` help was checked in the H100 validation container. |
+| vLLM | local checkout `ed2f282bc`; H100 image `vllm/vllm-openai:latest` with `vllm 0.19.1`; official docs for `vllm bench sweep serve` and benchmark sweeps | `vllm serve` and `vllm bench serve` were smoke-tested in the H100 validation image. |
+| TensorRT-LLM | H100 image `nvcr.io/nvidia/tensorrt-llm/release:latest` with `tensorrt_llm 1.0.0`; official `trtllm-serve` and serving benchmark docs current on 2026-04-22 | `trtllm-serve serve` and `tensorrt_llm.serve.scripts.benchmark_serving` were smoke-tested in the H100 validation image. |
+
+## Update Rule
+
+When updating this skill:
+
+1. Refresh this table with the exact source commit, package version, or docs
+   version used.
+2. Re-run `--help` for each server and benchmark CLI in the target environment.
+3. Move renamed or removed flags out of the example run plan.
+4. Record which frameworks were actually smoke-tested and which were only
+   preflighted.
+
+## H100 Validation Notes
+
+On 2026-04-22, the `h100_sglang` environment had:
+
+- GPUs 6 and 7 idle before validation: 0% utilization and 4 MiB allocated.
+- `sglang_bbuf` container: `sglang 0.5.10rc0`.
+- `vllm/vllm-openai:latest` image: `vllm 0.19.1`.
+- `nvcr.io/nvidia/tensorrt-llm/release:latest` image: `tensorrt_llm 1.0.0`.
+
+Smoke-tested on GPU 6 and 7 with tensor parallel size 2:
+
+| Model | SGLang | vLLM | TensorRT-LLM |
+| --- | --- | --- | --- |
+| `Qwen/Qwen2.5-0.5B-Instruct` | pass: `python -m sglang.auto_benchmark run` with one tiny candidate | pass: `vllm serve` plus `vllm bench serve` | pass: `trtllm-serve serve --backend pytorch` plus TensorRT-LLM `benchmark_serving --random-ids` |
+| `Qwen/Qwen2.5-1.5B-Instruct` | pass: `python -m sglang.auto_benchmark run` with one tiny candidate | pass: `vllm serve` plus `vllm bench serve` | pass: `trtllm-serve serve --backend pytorch` plus TensorRT-LLM `benchmark_serving --random-ids` |
+
+Cleanup behavior used in validation:
+
+- SGLang: kill the test port with `fuser`, then kill matching
+  `sglang.launch_server` command lines for the same port.
+- vLLM and TensorRT-LLM: run each server in a uniquely named Docker container
+  and stop it with `docker rm -f`.
+- Re-check GPUs 6 and 7 after every framework. They returned to 0% utilization
+  and 4 MiB allocated after the final cleanup.
+
+TensorRT-LLM notes from validation:
+
+- The Docker image worked when running `trtllm-serve serve` through `bash -lc`.
+  Overriding the Docker entrypoint directly to `trtllm-serve` missed library
+  setup in this environment and failed to load `libnvinfer.so.10`.
+- For `benchmark_serving --dataset-name random`, use `--random-ids` for fast
+  synthetic smoke tests. Without it, TensorRT-LLM 1.0.0 asks for a ShareGPT
+  `--download-path`.

--- a/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
+++ b/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Summarize normalized cross-framework benchmark JSONL results."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _get(row: dict[str, Any], path: str, default: Any = None) -> Any:
+    current: Any = row
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return default
+        current = current[part]
+    return current
+
+
+def _float(row: dict[str, Any], path: str, default: float = 0.0) -> float:
+    value = _get(row, path, default)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _bool(row: dict[str, Any], path: str, default: bool = False) -> bool:
+    value = _get(row, path, default)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.lower() in {"1", "true", "yes", "y"}
+    return bool(value)
+
+
+def _rank_key(row: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        _get(row, "status") == "ok",
+        _bool(row, "sla.passed"),
+        _float(row, "metrics.request_throughput"),
+        _float(row, "metrics.output_token_throughput"),
+        -_float(row, "metrics.p99_ttft_ms", 1e30),
+        -_float(row, "metrics.p99_tpot_ms", 1e30),
+        -_float(row, "hardware.gpu_count", 1e30),
+    )
+
+
+def _fmt(value: Any, digits: int = 2) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float):
+        return f"{value:.{digits}f}"
+    return str(value)
+
+
+def load_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as f:
+        for line_no, line in enumerate(f, 1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                row = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise SystemExit(f"{path}:{line_no}: invalid JSON: {exc}") from exc
+            if not isinstance(row, dict):
+                raise SystemExit(f"{path}:{line_no}: expected a JSON object")
+            rows.append(row)
+    return rows
+
+
+def best_by_framework(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    best: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        framework = str(_get(row, "framework", "unknown"))
+        if framework not in best or _rank_key(row) > _rank_key(best[framework]):
+            best[framework] = row
+    return sorted(best.values(), key=_rank_key, reverse=True)
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    fields = [
+        "framework",
+        "candidate_id",
+        "status",
+        "sla_passed",
+        "request_throughput",
+        "output_token_throughput",
+        "p99_ttft_ms",
+        "p99_tpot_ms",
+        "gpu_count",
+        "failure_reason",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    "framework": _get(row, "framework", ""),
+                    "candidate_id": _get(row, "candidate_id", ""),
+                    "status": _get(row, "status", ""),
+                    "sla_passed": _bool(row, "sla.passed"),
+                    "request_throughput": _get(row, "metrics.request_throughput", ""),
+                    "output_token_throughput": _get(
+                        row, "metrics.output_token_throughput", ""
+                    ),
+                    "p99_ttft_ms": _get(row, "metrics.p99_ttft_ms", ""),
+                    "p99_tpot_ms": _get(row, "metrics.p99_tpot_ms", ""),
+                    "gpu_count": _get(row, "hardware.gpu_count", ""),
+                    "failure_reason": _get(row, "failure_reason", ""),
+                }
+            )
+
+
+def render_markdown(rows: list[dict[str, Any]]) -> str:
+    ranked = sorted(rows, key=_rank_key, reverse=True)
+    winners = best_by_framework(rows)
+    overall = ranked[0] if ranked else None
+
+    lines = ["# Benchmark Summary", ""]
+    if overall is None:
+        lines.append("No rows found.")
+        return "\n".join(lines) + "\n"
+
+    lines.extend(
+        [
+            "## Overall Winner",
+            "",
+            f"- Framework: `{_get(overall, 'framework', 'unknown')}`",
+            f"- Candidate: `{_get(overall, 'candidate_id', 'unknown')}`",
+            f"- SLA passed: `{_bool(overall, 'sla.passed')}`",
+            f"- Request throughput: `{_fmt(_get(overall, 'metrics.request_throughput'))}`",
+            f"- Output token throughput: `{_fmt(_get(overall, 'metrics.output_token_throughput'))}`",
+            "",
+            "## Best Per Framework",
+            "",
+            "| Framework | Candidate | Status | SLA | Req/s | Output tok/s | P99 TTFT ms | P99 TPOT ms | GPUs |",
+            "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for row in winners:
+        lines.append(
+            "| {framework} | {candidate} | {status} | {sla} | {rps} | {otps} | {ttft} | {tpot} | {gpus} |".format(
+                framework=_get(row, "framework", ""),
+                candidate=_get(row, "candidate_id", ""),
+                status=_get(row, "status", ""),
+                sla=_bool(row, "sla.passed"),
+                rps=_fmt(_get(row, "metrics.request_throughput")),
+                otps=_fmt(_get(row, "metrics.output_token_throughput")),
+                ttft=_fmt(_get(row, "metrics.p99_ttft_ms")),
+                tpot=_fmt(_get(row, "metrics.p99_tpot_ms")),
+                gpus=_fmt(_get(row, "hardware.gpu_count")),
+            )
+        )
+
+    failed = [
+        row
+        for row in rows
+        if _get(row, "status") != "ok" or not _bool(row, "sla.passed")
+    ]
+    if failed:
+        lines.extend(
+            [
+                "",
+                "## Failed Or SLA-Failing Candidates",
+                "",
+                "| Framework | Candidate | Status | SLA | Reason |",
+                "| --- | --- | --- | --- | --- |",
+            ]
+        )
+        for row in failed:
+            lines.append(
+                "| {framework} | {candidate} | {status} | {sla} | {reason} |".format(
+                    framework=_get(row, "framework", ""),
+                    candidate=_get(row, "candidate_id", ""),
+                    status=_get(row, "status", ""),
+                    sla=_bool(row, "sla.passed"),
+                    reason=str(_get(row, "failure_reason", "")).replace("|", "\\|"),
+                )
+            )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, type=Path, help="Normalized JSONL")
+    parser.add_argument("--output", required=True, type=Path, help="Markdown summary")
+    parser.add_argument("--csv", type=Path, help="Optional CSV table")
+    args = parser.parse_args()
+
+    rows = load_rows(args.input)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(render_markdown(rows), encoding="utf-8")
+    if args.csv:
+        args.csv.parent.mkdir(parents=True, exist_ok=True)
+        write_csv(args.csv, sorted(rows, key=_rank_key, reverse=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `llm-serving-auto-benchmark`, a cross-framework benchmark skill for SGLang, vLLM, and TensorRT-LLM.
- Document fairness rules, workload normalization, SLA-driven ranking, and framework-specific tuning surfaces.
- Add command/source references, an example run-plan YAML, and a small JSONL result summarizer that produces markdown and optional CSV output.
- Update the README skill tree.

## Validation

- `python3 -m py_compile skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py`
- `python3 skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py --help`
- Ran the summarizer against a temporary sample JSONL and verified markdown/CSV output.
- `SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`
- `git diff --cached --check`

## Notes

- Manual `lychee` could not run locally because this machine has Cargo 1.72.0, which cannot install the current `lychee` crate using Rust 2024 edition metadata. The CI workflow uses the lychee GitHub Action instead.