### PR TITLE
[codex] Update LLM serving benchmark validation notes

### DIFF
--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -398,7 +398,10 @@ Return a compact report with:
 - one cross-framework comparison table for the selected best command per
   framework and scenario, including the command, so the deployment choice is
   obvious for each dataset
-- failed or excluded candidates with reasons
+- failed or excluded candidates with reasons. Explain that this table is an
+  audit trail, not a recommendation list: it records candidates that failed,
+  were skipped by policy, or completed but missed the SLA, so the reader can see
+  what was tried and why it was not selected.
 - exact launch command and benchmark command for each winner
 - artifact paths: canonical workload, raw results JSONL, normalized JSONL, CSV or
   markdown summary, and key server logs

--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -20,6 +20,21 @@ Use a config-driven workflow:
 - keep failed candidates in the result file
 - pick the best SLA-passing candidate after normalizing the results
 
+For model-specific starting points, prefer the shipped configs in
+`configs/cookbook-llm/`. They reuse the SGLang auto-benchmark cookbook model set
+and translate it into framework-native SGLang, vLLM, and TensorRT-LLM server
+flags. Validate those configs before a real run:
+
+```bash
+python skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py \
+  skills/llm-serving-auto-benchmark/configs/cookbook-llm
+```
+
+If you have captured target-environment `--help` files, add
+`--help-dir <artifact-help-dir>`. That check only loads configs, verifies the
+server flag names, and renders candidate commands; it does not launch model
+servers.
+
 Prefer native tooling when it gives better coverage:
 
 - SGLang: `python -m sglang.auto_benchmark` when available, otherwise

--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -7,12 +7,18 @@ description: Cross-framework LLM serving benchmark skill for SGLang, vLLM, and T
 
 ## Overview
 
-Use this skill to compare SGLang, vLLM, and TensorRT-LLM fairly for the same
-model and workload.
+Use this skill to compare SGLang, vLLM, and TensorRT-LLM for the same model and
+workload.
 
-The goal is not to run one benchmark command per framework. The goal is to run a
-small, controlled search for each framework, normalize the results, and report
-the best configuration under the same latency and throughput constraints.
+Use a config-driven workflow:
+
+- keep launch-only capacity choices in each framework's `base_server_flags`
+- put the search knobs in `search_space`
+- run the same dataset scenarios for every framework
+- generate a bounded candidate list from `search_space`, with the baseline
+  candidate included first
+- keep failed candidates in the result file
+- pick the best SLA-passing candidate after normalizing the results
 
 Prefer native tooling when it gives better coverage:
 
@@ -24,13 +30,18 @@ Prefer native tooling when it gives better coverage:
   TensorRT-LLM serving benchmark client or a common OpenAI-compatible benchmark
   client
 
-Do not declare a winner until each requested framework has had its own main
-serving knobs tuned.
+Only pick a winner after each requested framework has had its main serving knobs
+tuned.
 
 The parameter lists in this skill are not a compatibility contract. They are
 version-sensitive candidate knob families. Before every real run, record the
 exact framework version or git commit and verify the concrete CLI flag names
 with `--help` in the target environment.
+
+The default search style should stay close to SGLang auto benchmark: start from
+a mostly pure-TP baseline, sweep a small set of high-impact runtime knobs, and
+cap the first pass around 10 candidates per framework. Do not search memory
+fractions by default.
 
 ## Required Inputs
 
@@ -44,6 +55,8 @@ Collect these before starting a long run:
 - endpoint shape: completions, chat completions, responses, or custom
 - workload source: real traffic JSONL, ShareGPT, random synthetic, or generated
   shared-prefix synthetic
+- dataset scenarios when synthetic traffic is used, for example `chat` and
+  `summarization`
 - SLA target: TTFT, TPOT/ITL, end-to-end latency, success rate, or goodput
 - search budget: quick smoke, default search, or exhaustive search
 - output directory for logs and result artifacts
@@ -56,8 +69,8 @@ Also collect a version manifest:
 - whether each parameter in the search plan was accepted by that exact CLI
 
 If real production traffic is the goal, use the real request distribution. A
-synthetic workload is acceptable for bring-up and broad comparison, but it is not
-enough to choose a production winner.
+synthetic workload is fine for bring-up and first-pass comparison, but it is not
+enough for a production choice.
 
 ## Fairness Rules
 
@@ -152,6 +165,26 @@ When converting user data:
 - keep multimodal or tool-call payloads only if all requested frameworks support
   the chosen endpoint shape
 
+For synthetic bring-up, follow the two-scenario shape used by the SGLang auto
+benchmark references:
+
+```yaml
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names: [chat, summarization]
+  input_len: [1000, 8000]
+  output_len: [1000, 1000]
+```
+
+Each aligned `input_len` / `output_len` pair is one scenario. Do not take the
+cartesian product unless the user asks for that.
+
+Before searching any sequence-length limit, compute the largest
+`input_len + output_len` in the dataset. SGLang `context_length`, vLLM
+`max_model_len`, and TensorRT-LLM `max_seq_len` must be at least that value for
+every candidate that is expected to run all scenarios.
+
 ### 3. Pick A Search Tier
 
 Use the smallest tier that can answer the user's question:
@@ -164,10 +197,23 @@ Use the smallest tier that can answer the user's question:
 Default budget:
 
 - `num_prompts: 80` for quick comparison
-- `search.max_candidates: 8` per framework for the first useful pass
+- `search.max_candidates_per_framework: 10` for the first useful pass
+- candidate generation: baseline first, then a bounded product or ordered
+  candidate list from `search_space`
 - at most 5 QPS search rounds unless the user asks for more
 - stop early when every candidate in one framework is clearly OOM or fails the
   basic health check
+
+Keep these in `base_server_flags` unless the user specifically wants a capacity
+or memory study:
+
+- SGLang `mem_fraction_static`
+- SGLang `schedule_policy`
+- vLLM `gpu_memory_utilization`
+- TensorRT-LLM `kv_cache_free_gpu_memory_fraction`
+
+These are real knobs, but they widen the search quickly and often turn a serving
+comparison into a memory-limit study.
 
 ### 4. Tune SGLang
 
@@ -186,7 +232,9 @@ python -m sglang.bench_serving \
   --random-input-len 1024 \
   --random-output-len 256 \
   --num-prompts 80 \
-  --request-rate 8
+  --request-rate 8 \
+  --output-file /path/to/sglang/results.json \
+  --output-details
 ```
 
 Version-sensitive SGLang knob families to verify:
@@ -196,9 +244,12 @@ Version-sensitive SGLang knob families to verify:
 - `sampling_backend`
 - `max_running_requests`, `max_queued_requests`
 - `chunked_prefill_size`, `prefill_max_requests`, `max_prefill_tokens`
-- `max_total_tokens`, `page_size`, `mem_fraction_static`
+- `max_total_tokens`, `page_size`
 - CUDA graph and piecewise CUDA graph settings
 - speculative or EAGLE settings only after the non-speculative baseline is tuned
+
+Keep `mem_fraction_static` and `schedule_policy` pinned in the default pass,
+matching the SGLang auto benchmark cookbook style.
 
 For quick smoke tests, it is reasonable to disable CUDA graph and piecewise CUDA
 graph startup work if the goal is only to prove the framework flow. Record those
@@ -235,10 +286,20 @@ Version-sensitive vLLM knob families to verify:
 - prefix cache and speculative decoding settings only when the workload needs
   those features
 
-vLLM has enough server knobs for a real search. Treat it as a peer to SGLang,
-not as a single baseline command. See
+vLLM should get a normal sweep, not one baseline command. See
 [references/parameter-coverage.md](references/parameter-coverage.md) for the
 H100-verified flag families.
+
+Keep `gpu_memory_utilization` in the baseline for the default pass. Search it
+only when the question is explicitly about fitting the model or trading capacity
+against throughput.
+
+Keep DBO and all2all backend settings out of the default pass unless the target
+vLLM environment is already set up for them. They are real tuning knobs, but a
+candidate can fail at startup if the required all2all backend is not available.
+Also preflight concurrent partial prefill before raising
+`max_num_partial_prefills` above 1; some model/runtime combinations reject it at
+startup.
 
 ### 6. Tune TensorRT-LLM
 
@@ -281,10 +342,14 @@ Because TensorRT-LLM can involve engine build time, keep build artifacts and
 server artifacts separate from benchmark outputs. Report build time separately
 from serving performance.
 
-The `trtllm-serve serve` CLI exposes fewer direct runtime knobs than SGLang and
-vLLM. Do not invent one-to-one parity. Use direct flags when they exist, then use
-`--extra_llm_api_options` or an engine-build step for backend-specific options,
-and record that split in the final report.
+The `trtllm-serve serve` CLI exposes fewer direct runtime knobs than SGLang or
+vLLM. Use direct flags when they exist, then use `--extra_llm_api_options` or an
+engine-build step for backend-specific options. Record that split in the final
+report.
+
+Keep `kv_cache_free_gpu_memory_fraction` in the baseline for the default pass.
+Search `max_batch_size`, `max_num_tokens`, `max_seq_len`, backend choice, and
+engine/config options first.
 
 ### 7. Normalize Results
 

--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -397,14 +397,13 @@ Return a compact report with:
   dataset scenario and all relevant performance metrics
 - one cross-framework comparison table for the selected best command per
   framework and scenario, including the command, so the deployment choice is
-  obvious for each dataset
+  clear for each dataset
 - failed or excluded candidates with reasons. Explain that this table is an
-  audit trail, not a recommendation list: it records candidates that failed,
-  were skipped by policy, or completed but missed the SLA, so the reader can see
-  what was tried and why it was not selected.
+  record of tried configs that were not selected: candidates that failed, were
+  skipped by policy, or completed but missed the SLA.
 - exact launch command and benchmark command for each winner
 - artifact paths: canonical workload, raw results JSONL, normalized JSONL, CSV or
-  markdown summary, and key server logs
+  markdown summary, and server logs needed to debug winners or failures
 - a caveat if the workload was synthetic, if any framework did not complete a
   fair search, or if any framework needed framework-specific parameter
   substitutions

--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -85,7 +85,10 @@ Verify all requested frameworks before starting a search:
 python -m sglang.launch_server --help
 python -m sglang.bench_serving --help
 vllm serve --help
+vllm serve --help=all
 vllm bench serve --help
+vllm bench serve --help=all
+vllm bench sweep serve --help=all
 trtllm-serve serve --help
 python -m tensorrt_llm.serve.scripts.benchmark_serving --help
 ```
@@ -93,6 +96,9 @@ python -m tensorrt_llm.serve.scripts.benchmark_serving --help
 Use the framework-specific `--help` output in the target environment as the
 source of truth. Do not keep a stale launch flag just because it appears in an
 old note.
+
+vLLM 0.19 and newer use grouped help. Plain `vllm serve --help` only shows the
+groups, so capture `--help=all` before deciding whether a search knob exists.
 
 Save these `--help` outputs into the run artifact directory. If a listed search
 knob is missing from the current CLI, remove or translate that knob before
@@ -111,6 +117,11 @@ Before any GPU-backed smoke run, check the requested GPU ids directly with
 Do not silently borrow a different GPU count for a performance comparison. It is
 fine to run a smaller one-GPU smoke only when the result is clearly labeled as a
 flow check rather than a fair throughput comparison.
+
+If the target environment runs through containers, follow
+[references/container-runbook.md](references/container-runbook.md). Save the
+image tags, pull commands, launch commands, server logs, benchmark logs, and
+cleanup commands in the artifact directory.
 
 ### 2. Normalize The Workload
 
@@ -212,17 +223,22 @@ with `vllm bench serve`.
 
 Version-sensitive vLLM knob families to verify:
 
-- tensor and pipeline parallelism
+- tensor, pipeline, data, decode-context, and expert parallelism
 - `gpu_memory_utilization`
 - `max_num_seqs`
 - `max_num_batched_tokens`
 - `max_model_len`
-- chunked prefill settings
+- `enable_chunked_prefill`, partial prefill limits, and DBO thresholds
 - KV cache dtype and block size
 - dtype and quantization settings
 - CUDA graph capture sizes or eager-mode toggles when relevant
 - prefix cache and speculative decoding settings only when the workload needs
   those features
+
+vLLM has enough server knobs for a real search. Treat it as a peer to SGLang,
+not as a single baseline command. See
+[references/parameter-coverage.md](references/parameter-coverage.md) for the
+H100-verified flag families.
 
 ### 6. Tune TensorRT-LLM
 
@@ -264,6 +280,11 @@ Version-sensitive TensorRT-LLM knob families to verify:
 Because TensorRT-LLM can involve engine build time, keep build artifacts and
 server artifacts separate from benchmark outputs. Report build time separately
 from serving performance.
+
+The `trtllm-serve serve` CLI exposes fewer direct runtime knobs than SGLang and
+vLLM. Do not invent one-to-one parity. Use direct flags when they exist, then use
+`--extra_llm_api_options` or an engine-build step for backend-specific options,
+and record that split in the final report.
 
 ### 7. Normalize Results
 

--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -67,6 +67,8 @@ Collect these before starting a long run:
   `summarization`
 - SLA target: TTFT, TPOT/ITL, end-to-end latency, success rate, or goodput
 - search budget: quick smoke, default search, or exhaustive search
+- accuracy evaluation mode for final winners: OpenAI-compatible chat or
+  completions API, plus any model-specific chat-template or thinking settings
 - output directory for logs and result artifacts
 
 Also collect a version manifest:
@@ -95,6 +97,9 @@ Use these rules throughout the benchmark:
 - Keep failed candidates in the final results with their failure reason.
 - Report both raw throughput and SLA-passing throughput. The fastest failing
   candidate is not the best deployment command.
+- Run accuracy with deterministic sampling on the selected deployment commands,
+  not on every searched candidate. Use the same prompt template and evaluator
+  settings for every framework.
 
 ## Workflow
 
@@ -367,7 +372,59 @@ Search `max_batch_size`, `max_num_tokens`, `max_seq_len`, and validated
 PyTorch-backend config options first. The server backend remains fixed to
 `pytorch`.
 
-### 7. Normalize Results
+### 7. Run Accuracy For Selected Commands
+
+After the performance search chooses each framework's best deployment command,
+relaunch those selected commands and run full MMLU and GSM8K accuracy.
+
+Use a common OpenAI-compatible evaluator whenever possible. This works across
+SGLang, vLLM, and TensorRT-LLM because all three final serving paths expose
+OpenAI-compatible endpoints:
+
+- SGLang: use the native endpoint or `/v1/chat/completions` /
+  `/v1/completions`.
+- vLLM: use its OpenAI-compatible server endpoint. vLLM's serving benchmark
+  does not measure accuracy; use the common evaluator.
+- TensorRT-LLM: use the PyTorch-backend `trtllm-serve` OpenAI-compatible
+  endpoint. TensorRT-LLM's serving benchmark does not measure accuracy; use the
+  common evaluator.
+
+Preferred evaluator when an SGLang checkout is available:
+
+```bash
+python -m sglang.test.run_eval \
+  --base-url http://127.0.0.1:<port> \
+  --model <served-model-name> \
+  --eval-name mmlu \
+  --num-threads 128 \
+  --temperature 0.0
+
+python -m sglang.test.run_eval \
+  --base-url http://127.0.0.1:<port> \
+  --model <served-model-name> \
+  --eval-name gsm8k \
+  --api completion \
+  --num-threads 128 \
+  --temperature 0.0 \
+  --max-tokens 512
+```
+
+Do not pass `--num-examples` in the final report run. The final accuracy table
+must use the full evaluator dataset. For GSM8K, record the number of evaluated
+rows after the evaluator removes few-shot examples to avoid leakage.
+
+MMLU must include subgroup accuracy when the evaluator provides it. The SGLang
+simple-evals path reports `stem`, `humanities`, `social_sciences`, and `other`.
+If the selected evaluator or endpoint cannot produce subgroup metrics, report
+the final MMLU score only and mark the subgroup columns as unavailable in the
+artifact notes. Do not invent subgroup scores from the final score.
+
+Store accuracy under the selected candidate row in the normalized result file,
+using the `accuracy.mmlu` and `accuracy.gsm8k` fields from
+[references/result-schema.md](references/result-schema.md). Keep the MMLU and
+GSM8K raw result JSON or HTML report paths in the artifacts.
+
+### 8. Normalize Results
 
 Write one JSONL row per candidate using the schema in
 [references/result-schema.md](references/result-schema.md). Then run:
@@ -393,14 +450,20 @@ Return a compact report with:
 
 - workload and SLA used
 - hardware and framework versions
-- best candidate per framework
-- overall winner under the SLA
+- for each framework, one table listing the best deployment command for each
+  dataset scenario and all relevant performance metrics
+- one cross-framework comparison table for the selected best command per
+  framework and scenario, including the command, so the deployment choice is
+  obvious for each dataset
+- one accuracy table for the selected deployment command per framework, covering
+  full-dataset MMLU and GSM8K; include MMLU subgroup accuracy when available
 - failed or excluded candidates with reasons
 - exact launch command and benchmark command for each winner
+- exact accuracy evaluation command and artifact path for each accuracy row
 - artifact paths: canonical workload, raw results JSONL, normalized JSONL, CSV or
   markdown summary, and key server logs
-- a caveat if the workload was synthetic or if any framework did not complete a
-  fair search
+- a caveat if the workload was synthetic, if any framework did not complete a
+  fair search, or if any accuracy subgroup could not be produced
 
 Use [references/framework-matrix.md](references/framework-matrix.md) when you
 need command templates or source links for each framework. Use

--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -67,8 +67,6 @@ Collect these before starting a long run:
   `summarization`
 - SLA target: TTFT, TPOT/ITL, end-to-end latency, success rate, or goodput
 - search budget: quick smoke, default search, or exhaustive search
-- accuracy evaluation mode for final winners: OpenAI-compatible chat or
-  completions API, plus any model-specific chat-template or thinking settings
 - output directory for logs and result artifacts
 
 Also collect a version manifest:
@@ -97,9 +95,6 @@ Use these rules throughout the benchmark:
 - Keep failed candidates in the final results with their failure reason.
 - Report both raw throughput and SLA-passing throughput. The fastest failing
   candidate is not the best deployment command.
-- Run accuracy with deterministic sampling on the selected deployment commands,
-  not on every searched candidate. Use the same prompt template and evaluator
-  settings for every framework.
 
 ## Workflow
 
@@ -372,59 +367,7 @@ Search `max_batch_size`, `max_num_tokens`, `max_seq_len`, and validated
 PyTorch-backend config options first. The server backend remains fixed to
 `pytorch`.
 
-### 7. Run Accuracy For Selected Commands
-
-After the performance search chooses each framework's best deployment command,
-relaunch those selected commands and run full MMLU and GSM8K accuracy.
-
-Use a common OpenAI-compatible evaluator whenever possible. This works across
-SGLang, vLLM, and TensorRT-LLM because all three final serving paths expose
-OpenAI-compatible endpoints:
-
-- SGLang: use the native endpoint or `/v1/chat/completions` /
-  `/v1/completions`.
-- vLLM: use its OpenAI-compatible server endpoint. vLLM's serving benchmark
-  does not measure accuracy; use the common evaluator.
-- TensorRT-LLM: use the PyTorch-backend `trtllm-serve` OpenAI-compatible
-  endpoint. TensorRT-LLM's serving benchmark does not measure accuracy; use the
-  common evaluator.
-
-Preferred evaluator when an SGLang checkout is available:
-
-```bash
-python -m sglang.test.run_eval \
-  --base-url http://127.0.0.1:<port> \
-  --model <served-model-name> \
-  --eval-name mmlu \
-  --num-threads 128 \
-  --temperature 0.0
-
-python -m sglang.test.run_eval \
-  --base-url http://127.0.0.1:<port> \
-  --model <served-model-name> \
-  --eval-name gsm8k \
-  --api completion \
-  --num-threads 128 \
-  --temperature 0.0 \
-  --max-tokens 512
-```
-
-Do not pass `--num-examples` in the final report run. The final accuracy table
-must use the full evaluator dataset. For GSM8K, record the number of evaluated
-rows after the evaluator removes few-shot examples to avoid leakage.
-
-MMLU must include subgroup accuracy when the evaluator provides it. The SGLang
-simple-evals path reports `stem`, `humanities`, `social_sciences`, and `other`.
-If the selected evaluator or endpoint cannot produce subgroup metrics, report
-the final MMLU score only and mark the subgroup columns as unavailable in the
-artifact notes. Do not invent subgroup scores from the final score.
-
-Store accuracy under the selected candidate row in the normalized result file,
-using the `accuracy.mmlu` and `accuracy.gsm8k` fields from
-[references/result-schema.md](references/result-schema.md). Keep the MMLU and
-GSM8K raw result JSON or HTML report paths in the artifacts.
-
-### 8. Normalize Results
+### 7. Normalize Results
 
 Write one JSONL row per candidate using the schema in
 [references/result-schema.md](references/result-schema.md). Then run:
@@ -455,15 +398,13 @@ Return a compact report with:
 - one cross-framework comparison table for the selected best command per
   framework and scenario, including the command, so the deployment choice is
   obvious for each dataset
-- one accuracy table for the selected deployment command per framework, covering
-  full-dataset MMLU and GSM8K; include MMLU subgroup accuracy when available
 - failed or excluded candidates with reasons
 - exact launch command and benchmark command for each winner
-- exact accuracy evaluation command and artifact path for each accuracy row
 - artifact paths: canonical workload, raw results JSONL, normalized JSONL, CSV or
   markdown summary, and key server logs
 - a caveat if the workload was synthetic, if any framework did not complete a
-  fair search, or if any accuracy subgroup could not be produced
+  fair search, or if any framework needed framework-specific parameter
+  substitutions
 
 Use [references/framework-matrix.md](references/framework-matrix.md) when you
 need command templates or source links for each framework. Use

--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -30,6 +30,14 @@ Prefer native tooling when it gives better coverage:
   TensorRT-LLM serving benchmark client or a common OpenAI-compatible benchmark
   client
 
+TensorRT-LLM has one hard scope rule in this skill: the server backend is fixed
+to `trtllm-serve serve --backend pytorch`. Do not search TensorRT-LLM backend
+choice. If a request, config, or candidate asks for `trt`, an engine backend, or
+any other non-PyTorch TensorRT-LLM server backend, reject that candidate as
+unsupported for this skill and record the reason. This does not change the
+benchmark client backend; the TensorRT-LLM benchmark client still uses
+OpenAI-compatible modes such as `--backend openai` or `--backend openai-chat`.
+
 Only pick a winner after each requested framework has had its main serving knobs
 tuned.
 
@@ -116,6 +124,10 @@ groups, so capture `--help=all` before deciding whether a search knob exists.
 Save these `--help` outputs into the run artifact directory. If a listed search
 knob is missing from the current CLI, remove or translate that knob before
 running the benchmark. Do not silently pass unknown flags.
+
+For TensorRT-LLM, also confirm that `trtllm-serve serve --help` accepts
+`--backend pytorch`. If it does not, mark TensorRT-LLM unsupported in that
+environment rather than falling back to a different server backend.
 
 For each framework:
 
@@ -308,6 +320,7 @@ supports it:
 
 ```bash
 trtllm-serve serve <model> \
+  --backend pytorch \
   --tp_size <tp> \
   --pp_size <pp> \
   --kv_cache_free_gpu_memory_fraction 0.75 \
@@ -329,27 +342,30 @@ TensorRT-LLM 1.0.0 image, the KV-cache memory flag accepted by
 `--free_gpu_memory_fraction`. Verify this with `trtllm-serve serve --help`
 before running a search.
 
+TensorRT-LLM backend policy for this skill:
+
+- launch the server with `--backend pytorch`
+- keep `backend: pytorch` in `base_server_flags`
+- do not add `backend` to `search_space`
+- reject `trt`, engine-backed serving, or any other non-PyTorch TensorRT-LLM
+  server backend as unsupported for this skill
+
 Version-sensitive TensorRT-LLM knob families to verify:
 
 - `tp_size`, `pp_size`, and `ep_size`
-- PyTorch backend versus TensorRT engine path when both are available
-- engine build options, quantization, and plugin selections
 - max batch size, max sequence length, max number of tokens, and KV-cache budget
 - inflight batching and scheduler options
-- extra LLM API options YAML used by `trtllm-serve`
-
-Because TensorRT-LLM can involve engine build time, keep build artifacts and
-server artifacts separate from benchmark outputs. Report build time separately
-from serving performance.
+- extra LLM API options YAML used by `trtllm-serve` with the PyTorch backend
 
 The `trtllm-serve serve` CLI exposes fewer direct runtime knobs than SGLang or
-vLLM. Use direct flags when they exist, then use `--extra_llm_api_options` or an
-engine-build step for backend-specific options. Record that split in the final
-report.
+vLLM. Use direct flags when they exist, then use `--extra_llm_api_options` for
+PyTorch-backend settings that are not top-level CLI flags. Keep unsupported
+backend or engine requests in the failure table instead of translating them.
 
 Keep `kv_cache_free_gpu_memory_fraction` in the baseline for the default pass.
-Search `max_batch_size`, `max_num_tokens`, `max_seq_len`, backend choice, and
-engine/config options first.
+Search `max_batch_size`, `max_num_tokens`, `max_seq_len`, and validated
+PyTorch-backend config options first. The server backend remains fixed to
+`pytorch`.
 
 ### 7. Normalize Results
 

--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -24,13 +24,13 @@ Prefer native tooling when it gives better coverage:
   TensorRT-LLM serving benchmark client or a common OpenAI-compatible benchmark
   client
 
-Do not declare a winner until each requested framework has had a reasonable
-chance to tune its important knobs.
+Do not declare a winner until each requested framework has had its own main
+serving knobs tuned.
 
-Important: the parameter lists in this skill are not a permanent compatibility
-contract. They are version-sensitive candidate knob families. Before every real
-run, record the exact framework version or git commit and verify the concrete
-CLI flag names with `--help` in the target environment.
+The parameter lists in this skill are not a compatibility contract. They are
+version-sensitive candidate knob families. Before every real run, record the
+exact framework version or git commit and verify the concrete CLI flag names
+with `--help` in the target environment.
 
 ## Required Inputs
 
@@ -82,9 +82,12 @@ Use these rules throughout the benchmark:
 Verify all requested frameworks before starting a search:
 
 ```bash
+python -m sglang.launch_server --help
 python -m sglang.bench_serving --help
+vllm serve --help
 vllm bench serve --help
-trtllm-serve --help
+trtllm-serve serve --help
+python -m tensorrt_llm.serve.scripts.benchmark_serving --help
 ```
 
 Use the framework-specific `--help` output in the target environment as the
@@ -102,6 +105,12 @@ For each framework:
 3. Send one streaming request and verify TTFT can be measured.
 4. Run one tiny benchmark with at least 5 requests.
 5. Save the launch command, benchmark command, server log, and benchmark output.
+
+Before any GPU-backed smoke run, check the requested GPU ids directly with
+`nvidia-smi`. If a requested GPU is already in use, stop and record that fact.
+Do not silently borrow a different GPU count for a performance comparison. It is
+fine to run a smaller one-GPU smoke only when the result is clearly labeled as a
+flow check rather than a fair throughput comparison.
 
 ### 2. Normalize The Workload
 
@@ -180,6 +189,11 @@ Version-sensitive SGLang knob families to verify:
 - CUDA graph and piecewise CUDA graph settings
 - speculative or EAGLE settings only after the non-speculative baseline is tuned
 
+For quick smoke tests, it is reasonable to disable CUDA graph and piecewise CUDA
+graph startup work if the goal is only to prove the framework flow. Record those
+flags in the artifact. Do not carry that smoke setting into a performance winner
+unless the user asked to tune eager-mode serving.
+
 ### 5. Tune vLLM
 
 Use vLLM's sweep runner when available:
@@ -216,7 +230,12 @@ Use `trtllm-serve serve` as the server entrypoint when the target environment
 supports it:
 
 ```bash
-trtllm-serve serve <model> --tp_size <tp> --pp_size <pp> --host 0.0.0.0 --port 8000
+trtllm-serve serve <model> \
+  --tp_size <tp> \
+  --pp_size <pp> \
+  --kv_cache_free_gpu_memory_fraction 0.75 \
+  --host 0.0.0.0 \
+  --port 8000
 ```
 
 Then benchmark the OpenAI-compatible endpoint with the TensorRT-LLM serving
@@ -226,6 +245,12 @@ frameworks.
 For TensorRT-LLM 1.0.0, `benchmark_serving --dataset-name random` samples from
 ShareGPT unless you pass either `--download-path` or `--random-ids`. For a fast
 synthetic smoke test, pass `--random-ids`.
+
+TensorRT-LLM flag names are especially version-sensitive. In the H100
+TensorRT-LLM 1.0.0 image, the KV-cache memory flag accepted by
+`trtllm-serve serve` is `--kv_cache_free_gpu_memory_fraction`, not
+`--free_gpu_memory_fraction`. Verify this with `trtllm-serve serve --help`
+before running a search.
 
 Version-sensitive TensorRT-LLM knob families to verify:
 

--- a/skills/llm-serving-auto-benchmark/agents/openai.yaml
+++ b/skills/llm-serving-auto-benchmark/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "LLM Serving Auto Benchmark"
-  short_description: "Compare SGLang, vLLM, and TensorRT-LLM serving performance and accuracy"
-  default_prompt: "Use $llm-serving-auto-benchmark to compare SGLang, vLLM, and TensorRT-LLM for one model under the same workload and SLA. Return per-framework best command tables, a cross-framework performance comparison table, full MMLU/GSM8K accuracy for selected commands, and artifact paths."
+  short_description: "Compare SGLang, vLLM, and TensorRT-LLM serving performance"
+  default_prompt: "Use $llm-serving-auto-benchmark to compare SGLang, vLLM, and TensorRT-LLM for one model under the same workload and SLA. Return per-framework best command tables, a cross-framework performance comparison table, failed candidate notes, and artifact paths."

--- a/skills/llm-serving-auto-benchmark/agents/openai.yaml
+++ b/skills/llm-serving-auto-benchmark/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "LLM Serving Auto Benchmark"
-  short_description: "Compare SGLang, vLLM, and TensorRT-LLM serving performance"
-  default_prompt: "Use $llm-serving-auto-benchmark to compare SGLang, vLLM, and TensorRT-LLM for one model under the same workload and SLA. Return the best deployment command per framework, the overall SLA-passing winner, and the benchmark artifact paths."
+  short_description: "Compare SGLang, vLLM, and TensorRT-LLM serving performance and accuracy"
+  default_prompt: "Use $llm-serving-auto-benchmark to compare SGLang, vLLM, and TensorRT-LLM for one model under the same workload and SLA. Return per-framework best command tables, a cross-framework performance comparison table, full MMLU/GSM8K accuracy for selected commands, and artifact paths."

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/README.md
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/README.md
@@ -1,0 +1,17 @@
+# Cookbook LLM Configs
+
+These configs reuse the SGLang auto-benchmark cookbook model set and translate each model into a three-framework run plan for SGLang, vLLM, and TensorRT-LLM.
+
+Scope:
+- SGLang keeps the cookbook `base_flags` and `search_space`; if a cookbook sequence limit is smaller than the default synthetic scenario, the config raises that limit so the shipped workload can run.
+- vLLM uses framework-native `vllm serve` flags. The translation keeps the same model, tokenizer, dataset shape, GPU count, and high-impact batching/prefix-cache knobs; it does not copy SGLang-only parser or scheduler flags.
+- TensorRT-LLM uses `trtllm-serve serve` with `backend: pytorch` fixed in `base_server_flags`. Backend choice is never searched.
+- The two default random scenarios remain aligned pairs: `chat` uses `1000 -> 1000`, and `summarization` uses `8000 -> 1000`.
+
+Before a real run, capture the target framework `--help` output and validate the configs:
+
+```bash
+python skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py   skills/llm-serving-auto-benchmark/configs/cookbook-llm
+```
+
+With captured help files, add `--help-dir <artifact-help-dir>` to check the concrete flag names against that environment. This check only loads configs and renders candidate commands; it does not launch model servers.

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-math-v2.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-math-v2.yaml
@@ -1,0 +1,131 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: deepseek-math-v2.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: deepseek-ai/DeepSeek-Math-V2
+  tokenizer: deepseek-ai/DeepSeek-Math-V2
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: deepseek-ai/DeepSeek-Math-V2
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/deepseek-math-v2
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      model_path: deepseek-ai/DeepSeek-Math-V2
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - flashinfer
+      decode_attention_backend:
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+      ep_size:
+      - 1
+      - 4
+      - 8
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 4
+      - 8

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-r1-0528.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-r1-0528.yaml
@@ -1,0 +1,134 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: deepseek-r1-0528.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: deepseek-ai/DeepSeek-R1-0528
+  tokenizer: deepseek-ai/DeepSeek-R1-0528
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: deepseek-ai/DeepSeek-R1-0528
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/deepseek-r1-0528
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      enable_symm_mem: true
+      model_path: deepseek-ai/DeepSeek-R1-0528
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+      ep_size:
+      - 1
+      - 4
+      - 8
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 4
+      - 8

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.1.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.1.yaml
@@ -1,0 +1,133 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: deepseek-v3.1.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: deepseek-ai/DeepSeek-V3.1
+  tokenizer: deepseek-ai/DeepSeek-V3.1
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: deepseek-ai/DeepSeek-V3.1
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/deepseek-v3.1
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      model_path: deepseek-ai/DeepSeek-V3.1
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+      ep_size:
+      - 1
+      - 4
+      - 8
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 4
+      - 8

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.2.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.2.yaml
@@ -1,0 +1,133 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: deepseek-v3.2.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: deepseek-ai/DeepSeek-V3.2
+  tokenizer: deepseek-ai/DeepSeek-V3.2
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: deepseek-ai/DeepSeek-V3.2
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/deepseek-v3.2
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      model_path: deepseek-ai/DeepSeek-V3.2
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+      ep_size:
+      - 1
+      - 4
+      - 8
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 4
+      - 8

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.yaml
@@ -1,0 +1,134 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: deepseek-v3.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: deepseek-ai/DeepSeek-V3
+  tokenizer: deepseek-ai/DeepSeek-V3
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: deepseek-ai/DeepSeek-V3
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/deepseek-v3
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      enable_symm_mem: true
+      model_path: deepseek-ai/DeepSeek-V3
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+      ep_size:
+      - 1
+      - 4
+      - 8
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 4
+      - 8

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/devstral-small-2-24b-instruct-2512.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/devstral-small-2-24b-instruct-2512.yaml
@@ -1,0 +1,124 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: devstral-small-2-24b-instruct-2512.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: mistralai/Devstral-Small-2-24B-Instruct-2512
+  tokenizer: mistralai/Devstral-Small-2-24B-Instruct-2512
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 1
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: mistralai/Devstral-Small-2-24B-Instruct-2512
+  max_concurrency:
+  - null
+  - 16
+  - 32
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 16.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/devstral-small-2-24b-instruct-2512
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      model_path: mistralai/Devstral-Small-2-24B-Instruct-2512
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 1
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ernie-4.5-21b-a3b-pt.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ernie-4.5-21b-a3b-pt.yaml
@@ -1,0 +1,118 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: ernie-4.5-21b-a3b-pt.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: baidu/ERNIE-4.5-21B-A3B-PT
+  tokenizer: baidu/ERNIE-4.5-21B-A3B-PT
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 1
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: baidu/ERNIE-4.5-21B-A3B-PT
+  max_concurrency:
+  - null
+  - 16
+  - 32
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 16.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/ernie-4.5-21b-a3b-pt
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      model_path: baidu/ERNIE-4.5-21B-A3B-PT
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 1
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.5.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.5.yaml
@@ -1,0 +1,120 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: glm-4.5.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: zai-org/GLM-4.5
+  tokenizer: zai-org/GLM-4.5
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 4
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: zai-org/GLM-4.5
+  max_concurrency:
+  - null
+  - 8
+  - 16
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 8.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/glm-4.5
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 4
+      context_length: 9000
+      model_path: zai-org/GLM-4.5
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 9000
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 4
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 9000
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 9000
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.6.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.6.yaml
@@ -1,0 +1,133 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: glm-4.6.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: zai-org/GLM-4.6
+  tokenizer: zai-org/GLM-4.6
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: zai-org/GLM-4.6
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/glm-4.6
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      model_path: zai-org/GLM-4.6
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+      ep_size:
+      - 1
+      - 4
+      - 8
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 4
+      - 8

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7-flash.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7-flash.yaml
@@ -1,0 +1,124 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: glm-4.7-flash.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: zai-org/GLM-4.7-Flash
+  tokenizer: zai-org/GLM-4.7-Flash
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 1
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: zai-org/GLM-4.7-Flash
+  max_concurrency:
+  - null
+  - 16
+  - 32
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 16.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/glm-4.7-flash
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      model_path: zai-org/GLM-4.7-Flash
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 1
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7.yaml
@@ -1,0 +1,128 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: glm-4.7.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: zai-org/GLM-4.7
+  tokenizer: zai-org/GLM-4.7
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 4
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: zai-org/GLM-4.7
+  max_concurrency:
+  - null
+  - 8
+  - 16
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 8.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/glm-4.7
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 4
+      context_length: 9000
+      model_path: zai-org/GLM-4.7
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+      ep_size:
+      - 1
+      - 2
+      - 4
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 9000
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 4
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 9000
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 9000
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 2
+      - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-5-fp8.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-5-fp8.yaml
@@ -1,0 +1,133 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: glm-5-fp8.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: zai-org/GLM-5-FP8
+  tokenizer: zai-org/GLM-5-FP8
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: zai-org/GLM-5-FP8
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/glm-5-fp8
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      model_path: zai-org/GLM-5-FP8
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+      ep_size:
+      - 1
+      - 4
+      - 8
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 4
+      - 8

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glyph.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glyph.yaml
@@ -1,0 +1,127 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: glyph.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: zai-org/Glyph
+  tokenizer: zai-org/Glyph
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 4
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: zai-org/Glyph
+  max_concurrency:
+  - null
+  - 8
+  - 16
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 8.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/glyph
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 4
+      reasoning_parser: glm45
+      tool_call_parser: glm45
+      model_path: zai-org/Glyph
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 4
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/gpt-oss-120b.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/gpt-oss-120b.yaml
@@ -1,0 +1,133 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: gpt-oss-120b.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: openai/gpt-oss-120b
+  tokenizer: openai/gpt-oss-120b
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: openai/gpt-oss-120b
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/gpt-oss-120b
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      model_path: openai/gpt-oss-120b
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+      ep_size:
+      - 1
+      - 4
+      - 8
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 4
+      - 8

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/intern-s1.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/intern-s1.yaml
@@ -1,0 +1,136 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: intern-s1.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: internlm/Intern-S1
+  tokenizer: internlm/Intern-S1
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: internlm/Intern-S1
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/intern-s1
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      trust_remote_code: true
+      model_path: internlm/Intern-S1
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+      ep_size:
+      - 1
+      - 4
+      - 8
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 4
+      - 8

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-k2-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-k2-instruct.yaml
@@ -1,0 +1,134 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: kimi-k2-instruct.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: moonshotai/Kimi-K2-Instruct
+  tokenizer: moonshotai/Kimi-K2-Instruct
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: moonshotai/Kimi-K2-Instruct
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/kimi-k2-instruct
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      trust_remote_code: true
+      model_path: moonshotai/Kimi-K2-Instruct
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+      ep_size:
+      - 1
+      - 4
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-k2.5.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-k2.5.yaml
@@ -1,0 +1,128 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: kimi-k2.5.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: moonshotai/Kimi-K2.5
+  tokenizer: moonshotai/Kimi-K2.5
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: moonshotai/Kimi-K2.5
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/kimi-k2.5
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      trust_remote_code: true
+      model_path: moonshotai/Kimi-K2.5
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-linear-48b-a3b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-linear-48b-a3b-instruct.yaml
@@ -1,0 +1,122 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: kimi-linear-48b-a3b-instruct.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: moonshotai/Kimi-Linear-48B-A3B-Instruct
+  tokenizer: moonshotai/Kimi-Linear-48B-A3B-Instruct
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 4
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: moonshotai/Kimi-Linear-48B-A3B-Instruct
+  max_concurrency:
+  - null
+  - 8
+  - 16
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 8.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/kimi-linear-48b-a3b-instruct
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 4
+      trust_remote_code: true
+      model_path: moonshotai/Kimi-Linear-48B-A3B-Instruct
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 4
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ling-2.5-1t.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ling-2.5-1t.yaml
@@ -1,0 +1,135 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: ling-2.5-1t.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: inclusionAI/Ling-2.5-1T
+  tokenizer: inclusionAI/Ling-2.5-1T
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: true
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: inclusionAI/Ling-2.5-1T
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 2.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/ling-2.5-1t
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      pp_size: 2
+      nnodes: 2
+      trust_remote_code: true
+      tool_call_parser: qwen
+      model_path: inclusionAI/Ling-2.5-1T
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+      pp_size:
+      - 1
+      - 2
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+      pipeline_parallel_size: 2
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 2
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llada2-1-mini.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llada2-1-mini.yaml
@@ -1,0 +1,131 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: llada2-1-mini.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: inclusionAI/LLaDA2.1-mini
+  tokenizer: inclusionAI/LLaDA2.1-mini
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 1
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: inclusionAI/LLaDA2.1-mini
+  max_concurrency:
+  - 1
+  - 2
+  - 4
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/llada2-1-mini
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 1
+      dllm_algorithm: JointThreshold
+      trust_remote_code: true
+      max_running_requests: 1
+      attention_backend: flashinfer
+      model_path: inclusionAI/LLaDA2.1-mini
+      mem_fraction_static: 0.77
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 1
+      - 2
+      - 4
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 1
+      - 2
+      - 4
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 1
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 1
+      - 2
+      - 4
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-3.1-70b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-3.1-70b-instruct.yaml
@@ -1,0 +1,125 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: llama-3.1-70b-instruct.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: meta-llama/Llama-3.1-70B-Instruct
+  tokenizer: meta-llama/Llama-3.1-70B-Instruct
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 4
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: meta-llama/Llama-3.1-70B-Instruct
+  max_concurrency:
+  - null
+  - 8
+  - 16
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 12.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/llama-3.1-70b-instruct
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 4
+      model_path: meta-llama/Llama-3.1-70B-Instruct
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 4
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-3.3-70b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-3.3-70b-instruct.yaml
@@ -1,0 +1,119 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: llama-3.3-70b-instruct.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: meta-llama/Llama-3.3-70B-Instruct
+  tokenizer: meta-llama/Llama-3.3-70B-Instruct
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 1
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: meta-llama/Llama-3.3-70B-Instruct
+  max_concurrency:
+  - null
+  - 16
+  - 32
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 16.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/llama-3.3-70b-instruct
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tool_call_parser: llama3
+      model_path: meta-llama/Llama-3.3-70B-Instruct
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 1
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-4-maverick-17b-128e-instruct-fp8.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-4-maverick-17b-128e-instruct-fp8.yaml
@@ -1,0 +1,123 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: llama-4-maverick-17b-128e-instruct-fp8.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
+  tokenizer: meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
+  max_concurrency:
+  - null
+  - 2
+  - 4
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 2.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/llama-4-maverick-17b-128e-instruct-fp8
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      context_length: 1000000
+      trust_remote_code: true
+      enable_multimodal: true
+      model_path: meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 4
+      - 8
+      - 12
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 1000000
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 4
+      - 8
+      - 12
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 1000000
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 4
+      - 8
+      - 12
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 1000000
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-4-scout-17b-16e-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-4-scout-17b-16e-instruct.yaml
@@ -1,0 +1,130 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: llama-4-scout-17b-16e-instruct.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: meta-llama/Llama-4-Scout-17B-16E-Instruct
+  tokenizer: meta-llama/Llama-4-Scout-17B-16E-Instruct
+  precision: bfloat16
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: meta-llama/Llama-4-Scout-17B-16E-Instruct
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/llama-4-scout-17b-16e-instruct
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      enable_multimodal: true
+      context_length: 65536
+      dtype: bfloat16
+      trust_remote_code: true
+      model_path: meta-llama/Llama-4-Scout-17B-16E-Instruct
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 8
+      - 16
+      - 24
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 65536
+      dtype: bfloat16
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 8
+      - 16
+      - 24
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 65536
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 8
+      - 16
+      - 24
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 65536
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/mimo-v2-flash.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/mimo-v2-flash.yaml
@@ -1,0 +1,134 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: mimo-v2-flash.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: XiaomiMiMo/MiMo-V2-Flash
+  tokenizer: XiaomiMiMo/MiMo-V2-Flash
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: XiaomiMiMo/MiMo-V2-Flash
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/mimo-v2-flash
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      trust_remote_code: true
+      max_running_requests: 128
+      chunked_prefill_size: 16384
+      model_loader_extra_config: '{"enable_multithread_load": "true","num_threads": 64}'
+      attention_backend: fa3
+      reasoning_parser: qwen3
+      tool_call_parser: mimo
+      model_path: XiaomiMiMo/MiMo-V2-Flash
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/minimax-m2.1.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/minimax-m2.1.yaml
@@ -1,0 +1,122 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: minimax-m2.1.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: MiniMaxAI/MiniMax-M2.1
+  tokenizer: MiniMaxAI/MiniMax-M2.1
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 4
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: MiniMaxAI/MiniMax-M2.1
+  max_concurrency:
+  - null
+  - 8
+  - 16
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 8.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/minimax-m2.1
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 4
+      trust_remote_code: true
+      model_path: MiniMaxAI/MiniMax-M2.1
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 4
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/minimax-m2.5.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/minimax-m2.5.yaml
@@ -1,0 +1,134 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: minimax-m2.5.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: MiniMaxAI/MiniMax-M2.5
+  tokenizer: MiniMaxAI/MiniMax-M2.5
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 4
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: MiniMaxAI/MiniMax-M2.5
+  max_concurrency:
+  - null
+  - 8
+  - 16
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/minimax-m2.5
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 4
+      trust_remote_code: true
+      model_path: MiniMaxAI/MiniMax-M2.5
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+      ep_size:
+      - 1
+      - 4
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 4
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ministral-3-8b-instruct-2512.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ministral-3-8b-instruct-2512.yaml
@@ -1,0 +1,122 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: ministral-3-8b-instruct-2512.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: mistralai/Ministral-3-8B-Instruct-2512
+  tokenizer: mistralai/Ministral-3-8B-Instruct-2512
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 1
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: mistralai/Ministral-3-8B-Instruct-2512
+  max_concurrency:
+  - null
+  - 16
+  - 32
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 16.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/ministral-3-8b-instruct-2512
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      trust_remote_code: true
+      tool_call_parser: mistral
+      model_path: mistralai/Ministral-3-8B-Instruct-2512
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 1
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/mistral-small-4-119b-2603.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/mistral-small-4-119b-2603.yaml
@@ -1,0 +1,125 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: mistral-small-4-119b-2603.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: mistralai/Mistral-Small-4-119B-2603
+  tokenizer: mistralai/Mistral-Small-4-119B-2603
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 2
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: mistralai/Mistral-Small-4-119B-2603
+  max_concurrency:
+  - null
+  - 8
+  - 16
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 6.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/mistral-small-4-119b-2603
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 2
+      model_path: mistralai/Mistral-Small-4-119B-2603
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 2
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 2
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/nemotron-3-nano-30b-a3b-bf16.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/nemotron-3-nano-30b-a3b-bf16.yaml
@@ -1,0 +1,129 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: nemotron-3-nano-30b-a3b-bf16.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+  tokenizer: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 1
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+  max_concurrency:
+  - null
+  - 16
+  - 32
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 16.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/nemotron-3-nano-30b-a3b-bf16
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 1
+      trust_remote_code: true
+      kv_cache_dtype: fp8_e4m3
+      model_path: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: fp8_e4m3
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 1
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/nemotron-3-super-120b-a12b-bf16.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/nemotron-3-super-120b-a12b-bf16.yaml
@@ -1,0 +1,129 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: nemotron-3-super-120b-a12b-bf16.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+  tokenizer: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 4
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+  max_concurrency:
+  - null
+  - 8
+  - 16
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 6.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/nemotron-3-super-120b-a12b-bf16
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 4
+      trust_remote_code: true
+      kv_cache_dtype: fp8_e4m3
+      model_path: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: fp8_e4m3
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 4
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-235b-a22b.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-235b-a22b.yaml
@@ -1,0 +1,133 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: qwen3-235b-a22b.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: Qwen/Qwen3-235B-A22B
+  tokenizer: Qwen/Qwen3-235B-A22B
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: Qwen/Qwen3-235B-A22B
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/qwen3-235b-a22b
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      model_path: Qwen/Qwen3-235B-A22B
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+      ep_size:
+      - 1
+      - 4
+      - 8
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 4
+      - 8

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-coder-480b-a35b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-coder-480b-a35b-instruct.yaml
@@ -1,0 +1,132 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: qwen3-coder-480b-a35b-instruct.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: Qwen/Qwen3-Coder-480B-A35B-Instruct
+  tokenizer: Qwen/Qwen3-Coder-480B-A35B-Instruct
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: Qwen/Qwen3-Coder-480B-A35B-Instruct
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/qwen3-coder-480b-a35b-instruct
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      ep_size: 2
+      moe_runner_backend: triton
+      model_path: Qwen/Qwen3-Coder-480B-A35B-Instruct
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - flashinfer
+      decode_attention_backend:
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+      ep_size:
+      - 1
+      - 2
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+      ep_size: 2
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 2

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-coder-next.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-coder-next.yaml
@@ -1,0 +1,125 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: qwen3-coder-next.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: Qwen/Qwen3-Coder-Next
+  tokenizer: Qwen/Qwen3-Coder-Next
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 2
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: Qwen/Qwen3-Coder-Next
+  max_concurrency:
+  - null
+  - 8
+  - 16
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 12.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/qwen3-coder-next
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 2
+      model_path: Qwen/Qwen3-Coder-Next
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 2
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 2
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-next-80b-a3b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-next-80b-a3b-instruct.yaml
@@ -1,0 +1,131 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: qwen3-next-80b-a3b-instruct.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: Qwen/Qwen3-Next-80B-A3B-Instruct
+  tokenizer: Qwen/Qwen3-Next-80B-A3B-Instruct
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 2
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: Qwen/Qwen3-Next-80B-A3B-Instruct
+  max_concurrency:
+  - null
+  - 8
+  - 16
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 12.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/qwen3-next-80b-a3b-instruct
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 2
+      model_path: Qwen/Qwen3-Next-80B-A3B-Instruct
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+      ep_size:
+      - 1
+      - 2
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 2
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 2
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 2

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen35-397b-a17b-fp8.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen35-397b-a17b-fp8.yaml
@@ -1,0 +1,133 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: qwen35-397b-a17b-fp8.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: Qwen/Qwen3.5-397B-A17B-FP8
+  tokenizer: Qwen/Qwen3.5-397B-A17B-FP8
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 4
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: Qwen/Qwen3.5-397B-A17B-FP8
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 4.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/qwen35-397b-a17b-fp8
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 4
+      model_path: Qwen/Qwen3.5-397B-A17B-FP8
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+      ep_size:
+      - 1
+      - 4
+      - 8
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 4
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 4
+      - 8

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ring-2.5-1t.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ring-2.5-1t.yaml
@@ -1,0 +1,125 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: ring-2.5-1t.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: inclusionAI/Ring-2.5-1T
+  tokenizer: inclusionAI/Ring-2.5-1T
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 8
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: inclusionAI/Ring-2.5-1T
+  max_concurrency:
+  - null
+  - 4
+  - 8
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 2.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/ring-2.5-1t
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 8
+      model_path: inclusionAI/Ring-2.5-1T
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 32
+      - 48
+      - 64
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 8
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+    search_space:
+      max_batch_size:
+      - 32
+      - 48
+      - 64
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/step-3.5-flash.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/step-3.5-flash.yaml
@@ -1,0 +1,134 @@
+schema_version: 1
+source:
+  kind: sglang_auto_benchmark_cookbook
+  sglang_cookbook_file: step-3.5-flash.yaml
+  translation: SGLang flags follow the cookbook config, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+model:
+  name: stepfun-ai/Step-3.5-Flash
+  tokenizer: stepfun-ai/Step-3.5-Flash
+  precision: auto
+  quantization: model default
+hardware:
+  gpu_count: 4
+  multi_node: false
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names:
+  - chat
+  - summarization
+  input_len:
+  - 1000
+  - 8000
+  output_len:
+  - 1000
+  - 1000
+benchmark:
+  endpoint: /v1/completions
+  backend: openai-compatible
+  tokenizer: stepfun-ai/Step-3.5-Flash
+  max_concurrency:
+  - null
+  - 8
+  - 16
+  extra_request_body:
+    temperature: 0.0
+  qps:
+    lower: 0.25
+    upper: 8.0
+    tolerance: 0.1
+  sla:
+    max_ttft_ms: 1500
+    max_tpot_ms: 30
+  output_dir: ./auto_benchmark_results/cookbook-llm/step-3.5-flash
+search:
+  tier: 2
+  max_candidates_per_framework: 8
+  candidate_generation: baseline_first_bounded_product
+  resume: true
+frameworks:
+  sglang:
+    enabled: true
+    server_command: python -m sglang.launch_server
+    base_server_flags:
+      tp_size: 4
+      trust_remote_code: true
+      model_path: stepfun-ai/Step-3.5-Flash
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+    search_space:
+      prefill_attention_backend:
+      - fa3
+      - flashinfer
+      decode_attention_backend:
+      - fa3
+      - flashinfer
+      chunked_prefill_size:
+      - 4096
+      - 8192
+      max_running_requests:
+      - 64
+      - 96
+      - 128
+      ep_size:
+      - 1
+      - 4
+  vllm:
+    enabled: true
+    server_command: vllm serve
+    config_source: framework_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      enable_chunked_prefill: true
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      max_num_batched_tokens:
+      - 8192
+      - 16384
+      max_num_partial_prefills:
+      - 1
+      max_long_partial_prefills:
+      - 1
+      long_prefill_token_threshold:
+      - 0
+      - 4096
+      enable_prefix_caching:
+      - true
+      block_size:
+      - 16
+  tensorrt_llm:
+    enabled: true
+    server_command: trtllm-serve serve
+    backend_policy: fixed_pytorch
+    config_source: framework_generic_translation
+    base_server_flags:
+      backend: pytorch
+      tp_size: 4
+      pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
+      max_seq_len: 12288
+      trust_remote_code: true
+    search_space:
+      max_batch_size:
+      - 64
+      - 96
+      - 128
+      max_num_tokens:
+      - 8192
+      - 16384
+      max_seq_len:
+      - 12288
+      - 16384
+      extra_llm_api_options:
+      - null
+      ep_size:
+      - 1
+      - 4

--- a/skills/llm-serving-auto-benchmark/references/container-runbook.md
+++ b/skills/llm-serving-auto-benchmark/references/container-runbook.md
@@ -213,11 +213,20 @@ This skill only supports the TensorRT-LLM PyTorch server backend. Keep
 server to `--backend trt`, an engine path, or any other backend; mark that
 candidate unsupported instead.
 
+For single-node multi-GPU TensorRT-LLM containers, keep the IPC, ulimit, shared
+memory, and NCCL settings below. In H100 validation, a 4-GPU PyTorch-backend
+server entered `PyTorchConfig` but failed NCCL allreduce without these container
+options; the same model and candidate list passed after adding them.
+
 Server template:
 
 ```bash
 docker run -d --name llmbench-trtllm \
   --gpus "$GPU_ARG" \
+  --ipc=host \
+  --ulimit memlock=-1 \
+  --ulimit stack=67108864 \
+  --shm-size=16g \
   --network host \
   -v /data/.cache:/root/.cache \
   -e MODEL \
@@ -226,6 +235,7 @@ docker run -d --name llmbench-trtllm \
   -e PORT \
   -e HF_TOKEN \
   -e HUGGINGFACE_HUB_TOKEN \
+  -e NCCL_IB_DISABLE=1 \
   --entrypoint bash \
   nvcr.io/nvidia/tensorrt-llm/release:latest -lc '
 trtllm-serve serve "$MODEL" \

--- a/skills/llm-serving-auto-benchmark/references/container-runbook.md
+++ b/skills/llm-serving-auto-benchmark/references/container-runbook.md
@@ -45,6 +45,26 @@ export RUN_DIR=/tmp/llm-serving-auto-benchmark
 mkdir -p "$RUN_DIR"
 ```
 
+For synthetic validation, use two aligned scenarios rather than one tiny request
+shape:
+
+```bash
+# chat-like
+RANDOM_INPUT_LEN=1000
+RANDOM_OUTPUT_LEN=1000
+
+# summarization-like
+RANDOM_INPUT_LEN=8000
+RANDOM_OUTPUT_LEN=1000
+```
+
+For a fast smoke on larger models, 20 prompts per scenario is a reasonable
+minimum. Do not treat that as a performance result.
+
+Set each framework's sequence-length limit to cover the largest scenario. For
+the example above, use at least 9000 tokens for SGLang `--context-length`, vLLM
+`--max-model-len`, and TensorRT-LLM `--max_seq_len`.
+
 Before launching a server, save the help output:
 
 ```bash
@@ -118,7 +138,9 @@ python -m sglang.bench_serving \
   --random-output-len 8 \
   --num-prompts 4 \
   --request-rate 1 \
-  --max-concurrency 2
+  --max-concurrency 2 \
+  --output-file "$RUN_DIR/sglang/results.json" \
+  --output-details
 ```
 
 ## vLLM

--- a/skills/llm-serving-auto-benchmark/references/container-runbook.md
+++ b/skills/llm-serving-auto-benchmark/references/container-runbook.md
@@ -208,6 +208,11 @@ can be described with serve/bench parameter JSON files.
 
 ## TensorRT-LLM
 
+This skill only supports the TensorRT-LLM PyTorch server backend. Keep
+`--backend pytorch` in every `trtllm-serve serve` command. Do not switch the
+server to `--backend trt`, an engine path, or any other backend; mark that
+candidate unsupported instead.
+
 Server template:
 
 ```bash
@@ -267,8 +272,9 @@ python -m tensorrt_llm.serve.scripts.benchmark_serving \
 '
 ```
 
-For TensorRT-LLM 1.0.0, the serving benchmark `--backend` choices are `openai`
-and `openai-chat`. Do not pass `--backend trtllm`.
+For TensorRT-LLM 1.0.0, the serving benchmark client `--backend` choices are
+`openai` and `openai-chat`. Do not pass `--backend trtllm`. This client flag is
+separate from the server backend pinned above.
 
 ## Cleanup
 

--- a/skills/llm-serving-auto-benchmark/references/container-runbook.md
+++ b/skills/llm-serving-auto-benchmark/references/container-runbook.md
@@ -1,0 +1,268 @@
+# Container Runbook
+
+Use this runbook when the benchmark environment is container-based. It records
+the exact image, command, help output, server log, benchmark log, and cleanup
+step for each framework.
+
+## Common Setup
+
+Pull the images that will be used:
+
+```bash
+docker pull lmsysorg/sglang:dev
+docker pull vllm/vllm-openai:latest
+docker pull nvcr.io/nvidia/tensorrt-llm/release:latest
+```
+
+Use quoted Docker GPU device lists:
+
+```bash
+GPU_ARG='"device=6,7"'
+docker run --gpus "$GPU_ARG" ...
+```
+
+The unquoted form `--gpus device=6,7` can be parsed incorrectly by Docker.
+
+Mount the shared Hugging Face cache and pass tokens through environment variables
+when gated models are used:
+
+```bash
+-v /data/.cache:/root/.cache \
+-e HF_TOKEN \
+-e HUGGINGFACE_HUB_TOKEN
+```
+
+Do not print token values into logs.
+
+Set the run variables once and pass them into containers that need them:
+
+```bash
+export MODEL=TinyLlama/TinyLlama-1.1B-Chat-v1.0
+export TP=1
+export PP=1
+export PORT=8000
+export RUN_DIR=/tmp/llm-serving-auto-benchmark
+mkdir -p "$RUN_DIR"
+```
+
+Before launching a server, save the help output:
+
+```bash
+python -m sglang.launch_server --help > artifacts/help/sglang_launch_server.txt
+python -m sglang.bench_serving --help > artifacts/help/sglang_bench_serving.txt
+vllm serve --help=all > artifacts/help/vllm_serve_all.txt
+vllm bench serve --help=all > artifacts/help/vllm_bench_serve_all.txt
+vllm bench sweep serve --help=all > artifacts/help/vllm_bench_sweep_serve_all.txt
+trtllm-serve serve --help > artifacts/help/trtllm_serve.txt
+python -m tensorrt_llm.serve.scripts.benchmark_serving --help \
+  > artifacts/help/trtllm_benchmark_serving.txt
+```
+
+## SGLang
+
+On the prepared H100 host, the existing `sglang_bbuf` container can be used:
+
+```bash
+docker exec \
+  -e MODEL \
+  -e TP \
+  -e PORT \
+  sglang_bbuf bash -lc '
+cd /data/bbuf/repos/sglang
+python -m sglang.launch_server \
+  --model-path "$MODEL" \
+  --tp-size "$TP" \
+  --host 0.0.0.0 \
+  --port "$PORT"
+'
+```
+
+For a fresh container:
+
+```bash
+docker run -d --name llmbench-sglang \
+  --gpus "$GPU_ARG" \
+  --network host \
+  --ipc=host \
+  -v /data/.cache:/root/.cache \
+  -e MODEL \
+  -e TP \
+  -e PORT \
+  -e HF_TOKEN \
+  -e HUGGINGFACE_HUB_TOKEN \
+  --entrypoint bash \
+  lmsysorg/sglang:dev -lc '
+python -m sglang.launch_server \
+  --model-path "$MODEL" \
+  --tp-size "$TP" \
+  --host 0.0.0.0 \
+  --port "$PORT"
+'
+```
+
+Then run either SGLang auto benchmark:
+
+```bash
+python -m sglang.auto_benchmark run --config /path/to/sglang.yaml
+```
+
+or a tiny OpenAI-compatible smoke benchmark:
+
+```bash
+python -m sglang.bench_serving \
+  --backend sglang-oai \
+  --host 127.0.0.1 \
+  --port "$PORT" \
+  --dataset-name random \
+  --random-input-len 32 \
+  --random-output-len 8 \
+  --num-prompts 4 \
+  --request-rate 1 \
+  --max-concurrency 2
+```
+
+## vLLM
+
+Server template:
+
+```bash
+docker run -d --name llmbench-vllm \
+  --gpus "$GPU_ARG" \
+  --network host \
+  --ipc=host \
+  -v /data/.cache:/root/.cache \
+  -e MODEL \
+  -e TP \
+  -e PORT \
+  -e HF_TOKEN \
+  -e HUGGINGFACE_HUB_TOKEN \
+  --entrypoint bash \
+  vllm/vllm-openai:latest -lc '
+vllm serve "$MODEL" \
+  --host 0.0.0.0 \
+  --port "$PORT" \
+  --tensor-parallel-size "$TP" \
+  --dtype auto \
+  --gpu-memory-utilization 0.90 \
+  --max-model-len 4096 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 8192 \
+  --enable-chunked-prefill \
+  --kv-cache-dtype auto \
+  --enable-prefix-caching \
+  --trust-remote-code
+'
+```
+
+Benchmark template:
+
+```bash
+docker run --rm \
+  --network host \
+  -v /data/.cache:/root/.cache \
+  -v "$RUN_DIR:/artifacts" \
+  -e MODEL \
+  -e PORT \
+  --entrypoint bash \
+  vllm/vllm-openai:latest -lc '
+vllm bench serve \
+  --backend vllm \
+  --base-url "http://127.0.0.1:$PORT" \
+  --model "$MODEL" \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 256 \
+  --num-prompts 80 \
+  --request-rate 8 \
+  --max-concurrency 64 \
+  --save-result \
+  --result-dir /artifacts/vllm \
+  --result-filename results.json
+'
+```
+
+Use `vllm bench sweep serve` when the target image supports it and the search
+can be described with serve/bench parameter JSON files.
+
+## TensorRT-LLM
+
+Server template:
+
+```bash
+docker run -d --name llmbench-trtllm \
+  --gpus "$GPU_ARG" \
+  --network host \
+  -v /data/.cache:/root/.cache \
+  -e MODEL \
+  -e TP \
+  -e PP \
+  -e PORT \
+  -e HF_TOKEN \
+  -e HUGGINGFACE_HUB_TOKEN \
+  --entrypoint bash \
+  nvcr.io/nvidia/tensorrt-llm/release:latest -lc '
+trtllm-serve serve "$MODEL" \
+  --host 0.0.0.0 \
+  --port "$PORT" \
+  --backend pytorch \
+  --tp_size "$TP" \
+  --pp_size "$PP" \
+  --max_batch_size 64 \
+  --max_num_tokens 8192 \
+  --max_seq_len 4096 \
+  --kv_cache_free_gpu_memory_fraction 0.75 \
+  --trust_remote_code
+'
+```
+
+Benchmark template:
+
+```bash
+docker run --rm \
+  --network host \
+  -v /data/.cache:/root/.cache \
+  -v "$RUN_DIR:/artifacts" \
+  -e MODEL \
+  -e PORT \
+  --entrypoint bash \
+  nvcr.io/nvidia/tensorrt-llm/release:latest -lc '
+python -m tensorrt_llm.serve.scripts.benchmark_serving \
+  --backend openai \
+  --host 127.0.0.1 \
+  --port "$PORT" \
+  --endpoint /v1/completions \
+  --model "$MODEL" \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 256 \
+  --random-ids \
+  --num-prompts 80 \
+  --request-rate 8 \
+  --max-concurrency 64 \
+  --save-result \
+  --result-dir /artifacts/trtllm \
+  --result-filename results.json
+'
+```
+
+For TensorRT-LLM 1.0.0, the serving benchmark `--backend` choices are `openai`
+and `openai-chat`. Do not pass `--backend trtllm`.
+
+## Cleanup
+
+Use unique container names per run and clean up by name:
+
+```bash
+docker rm -f llmbench-sglang llmbench-vllm llmbench-trtllm
+```
+
+If a port remains bound after container cleanup, inspect it before killing
+anything:
+
+```bash
+ss -ltnp | grep ':8000'
+ps -eo pid,ppid,user,etime,cmd | grep '<model-or-port>'
+```
+
+Only kill raw PIDs when the command line proves they belong to the current
+validation run.

--- a/skills/llm-serving-auto-benchmark/references/cookbook-configs.md
+++ b/skills/llm-serving-auto-benchmark/references/cookbook-configs.md
@@ -1,0 +1,60 @@
+# Cookbook Configs
+
+`configs/cookbook-llm/` is the model-specific starting set for this skill.
+
+The files reuse the SGLang auto-benchmark cookbook model list. SGLang keeps the
+cookbook launch flags and search knobs, except for sequence limits that are too
+small for the shipped two-scenario synthetic workload. vLLM and TensorRT-LLM do
+not reuse SGLang flag names. They use their own serving CLIs and a matching set
+of batching, prefix-cache, and sequence-limit knobs.
+
+## Translation Rules
+
+- Keep the same model, tokenizer, GPU count, dataset scenarios, benchmark SLA,
+  and bounded candidate budget across all three frameworks.
+- Keep memory fractions in `base_server_flags` by default.
+- Keep TensorRT-LLM pinned to `trtllm-serve serve --backend pytorch`; never
+  place `backend` in its `search_space`.
+- Do not copy SGLang-only parser, scheduler, or attention flags into vLLM or
+  TensorRT-LLM unless the target framework exposes a matching server flag.
+- Raise `context_length`, `max_model_len`, or `max_seq_len` when needed so every
+  candidate can cover the largest default scenario.
+
+The vLLM and TensorRT-LLM sections are framework-native translations, not a
+claim that every upstream project publishes a model-specific recipe for every
+SGLang cookbook model. vLLM maintains recipe pages for selected model families,
+while TensorRT-LLM publishes model recipe commands and optional LLM API config
+files for selected popular models. Treat those upstream recipes as extra input
+when they exist, then run this skill's validator against the exact target CLI.
+
+## Validation
+
+Run the local schema and flag check:
+
+```bash
+python skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py \
+  skills/llm-serving-auto-benchmark/configs/cookbook-llm
+```
+
+When you have captured the target container help output, validate concrete flag
+names too:
+
+```bash
+python skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py \
+  --help-dir artifacts/help \
+  skills/llm-serving-auto-benchmark/configs/cookbook-llm
+```
+
+Expected help file names can be flexible, but they should include these words:
+
+- SGLang server help: `sglang` and `launch`
+- vLLM server help: `vllm` and `serve`
+- TensorRT-LLM server help: `trtllm` and `serve`
+
+This validation only reads YAML, checks flag names, and renders candidate server
+commands. It does not start a model server.
+
+## Config Count
+
+The current set contains 38 text-serving configs derived from the SGLang
+auto-benchmark cookbook references.

--- a/skills/llm-serving-auto-benchmark/references/example-plan.yaml
+++ b/skills/llm-serving-auto-benchmark/references/example-plan.yaml
@@ -1,11 +1,10 @@
-# Example run plan for the llm-serving-auto-benchmark skill.
-#
-# This file is intentionally a control-plane template. The skill can translate
-# it into native SGLang, vLLM, and TensorRT-LLM commands in the target runtime.
+# Example run plan for the llm-serving-auto-benchmark skill. The layout mirrors
+# SGLang auto benchmark: baseline flags stay in base_server_flags, search knobs
+# stay in search_space, and aligned dataset length pairs define scenarios.
 
 model:
-  name: meta-llama/Llama-3.1-70B-Instruct
-  tokenizer: meta-llama/Llama-3.1-70B-Instruct
+  name: Qwen/Qwen3-32B
+  tokenizer: Qwen/Qwen3-32B
   precision: bf16
   quantization: none
 
@@ -32,20 +31,29 @@ version_manifest:
 
 hardware:
   gpu_model: NVIDIA H100 80GB HBM3
-  gpu_count: 8
+  gpu_count: 4
   multi_node: false
 
-workload:
-  kind: custom
-  canonical_jsonl: /bench/workloads/prod_sample.autobench.jsonl
+dataset:
+  kind: random
+  num_prompts: 80
+  scenario_names: [chat, summarization]
+  input_len: [1000, 8000]
+  output_len: [1000, 1000]
+  canonical_jsonl: null
+
+benchmark:
   endpoint: /v1/chat/completions
-  num_prompts: 1000
-  request_rates: [4, 8, 12, 16]
-  max_concurrency: 256
-  synthetic_fallback:
-    dataset_name: random
-    input_len: 1024
-    output_len: 256
+  backend: auto
+  request_rates: null
+  max_concurrency: [null, 16, 32]
+  qps:
+    lower: 1.0
+    upper: 12.0
+    tolerance: 0.1
+    max_rounds: 5
+  extra_request_body:
+    temperature: 0.0
 
 sla:
   max_p99_ttft_ms: 2000
@@ -54,53 +62,59 @@ sla:
 
 search:
   tier: 2
-  max_candidates_per_framework: 8
-  max_qps_rounds: 5
+  max_candidates_per_framework: 10
+  candidate_generation: baseline_first_bounded_product
+  resume: true
   output_dir: /bench/results/llm-serving-auto-benchmark
 
 frameworks:
   sglang:
     enabled: true
     base_server_flags:
-      tp_size: 8
+      tp_size: 4
       trust_remote_code: true
+      mem_fraction_static: 0.82
+      schedule_policy: lpm
+      context_length: 12288
     search_space:
       # Verify these names against `python -m sglang.launch_server --help`.
-      attention_backend: [flashinfer, fa3]
+      prefill_attention_backend: [fa3, flashinfer]
+      decode_attention_backend: [fa3, flashinfer]
       chunked_prefill_size: [8192, 16384]
       max_running_requests: [64, 128]
 
   vllm:
     enabled: true
     base_server_flags:
-      tensor_parallel_size: 8
+      tensor_parallel_size: 4
       trust_remote_code: true
+      gpu_memory_utilization: 0.90
+      max_model_len: 12288
+      dtype: auto
     search_space:
-      # Verify these names against `vllm serve --help`.
-      gpu_memory_utilization: [0.9, 0.95]
+      # Verify these names against `vllm serve --help=all`.
       max_num_seqs: [64, 128]
       max_num_batched_tokens: [8192, 16384]
-      max_model_len: [4096, 8192]
       enable_chunked_prefill: [true]
-      max_num_partial_prefills: [1, 4]
+      # Raise above 1 only after the target model/runtime supports concurrent partial prefill.
+      max_num_partial_prefills: [1]
       max_long_partial_prefills: [1]
       long_prefill_token_threshold: [0, 4096]
       enable_prefix_caching: [true]
       kv_cache_dtype: [auto]
       block_size: [16]
-      enforce_eager: [false]
 
   tensorrt_llm:
     enabled: true
     base_server_flags:
-      tp_size: 8
+      backend: pytorch
+      tp_size: 4
       pp_size: 1
       kv_cache_free_gpu_memory_fraction: 0.75
+      trust_remote_code: true
     search_space:
       # Verify these names against `trtllm-serve serve --help` and the selected backend.
-      backend: [pytorch, trt]
       max_batch_size: [64, 128]
       max_num_tokens: [8192, 16384]
-      max_seq_len: [4096, 8192]
-      kv_cache_free_gpu_memory_fraction: [0.75, 0.85]
+      max_seq_len: [12288, 16384]
       extra_llm_api_options: [null]

--- a/skills/llm-serving-auto-benchmark/references/example-plan.yaml
+++ b/skills/llm-serving-auto-benchmark/references/example-plan.yaml
@@ -106,6 +106,7 @@ frameworks:
 
   tensorrt_llm:
     enabled: true
+    backend_policy: fixed_pytorch
     base_server_flags:
       backend: pytorch
       tp_size: 4
@@ -113,7 +114,8 @@ frameworks:
       kv_cache_free_gpu_memory_fraction: 0.75
       trust_remote_code: true
     search_space:
-      # Verify these names against `trtllm-serve serve --help` and the selected backend.
+      # Verify these names against `trtllm-serve serve --help`.
+      # Do not add backend choices here; TensorRT-LLM is fixed to the PyTorch backend.
       max_batch_size: [64, 128]
       max_num_tokens: [8192, 16384]
       max_seq_len: [12288, 16384]

--- a/skills/llm-serving-auto-benchmark/references/example-plan.yaml
+++ b/skills/llm-serving-auto-benchmark/references/example-plan.yaml
@@ -11,16 +11,20 @@ model:
 
 version_manifest:
   sglang:
+    container_image: lmsysorg/sglang:dev
     package_version: null
     git_commit: null
     server_help: artifacts/help/sglang_launch_server.txt
     benchmark_help: artifacts/help/sglang_bench_serving.txt
   vllm:
+    container_image: vllm/vllm-openai:latest
     package_version: null
     git_commit: null
-    server_help: artifacts/help/vllm_serve.txt
-    benchmark_help: artifacts/help/vllm_bench_serve.txt
+    server_help: artifacts/help/vllm_serve_all.txt
+    benchmark_help: artifacts/help/vllm_bench_serve_all.txt
+    sweep_help: artifacts/help/vllm_bench_sweep_serve_all.txt
   tensorrt_llm:
+    container_image: nvcr.io/nvidia/tensorrt-llm/release:latest
     package_version: null
     git_commit: null
     server_help: artifacts/help/trtllm_serve.txt
@@ -76,6 +80,15 @@ frameworks:
       gpu_memory_utilization: [0.9, 0.95]
       max_num_seqs: [64, 128]
       max_num_batched_tokens: [8192, 16384]
+      max_model_len: [4096, 8192]
+      enable_chunked_prefill: [true]
+      max_num_partial_prefills: [1, 4]
+      max_long_partial_prefills: [1]
+      long_prefill_token_threshold: [0, 4096]
+      enable_prefix_caching: [true]
+      kv_cache_dtype: [auto]
+      block_size: [16]
+      enforce_eager: [false]
 
   tensorrt_llm:
     enabled: true
@@ -88,3 +101,6 @@ frameworks:
       backend: [pytorch, trt]
       max_batch_size: [64, 128]
       max_num_tokens: [8192, 16384]
+      max_seq_len: [4096, 8192]
+      kv_cache_free_gpu_memory_fraction: [0.75, 0.85]
+      extra_llm_api_options: [null]

--- a/skills/llm-serving-auto-benchmark/references/example-plan.yaml
+++ b/skills/llm-serving-auto-benchmark/references/example-plan.yaml
@@ -55,24 +55,6 @@ benchmark:
   extra_request_body:
     temperature: 0.0
 
-accuracy:
-  enabled: true
-  evaluator: sglang.test.run_eval
-  run_after_search: selected_commands_only
-  full_dataset: true
-  api:
-    mmlu: chat
-    gsm8k: completion
-  tasks:
-    mmlu:
-      num_examples: null
-      require_subcategories: true
-      expected_subcategories: [stem, humanities, social_sciences, other]
-    gsm8k:
-      num_examples: null
-      num_shots: 5
-  output_dir: /bench/results/llm-serving-auto-benchmark/accuracy
-
 sla:
   max_p99_ttft_ms: 2000
   max_p99_tpot_ms: 80

--- a/skills/llm-serving-auto-benchmark/references/example-plan.yaml
+++ b/skills/llm-serving-auto-benchmark/references/example-plan.yaml
@@ -55,6 +55,24 @@ benchmark:
   extra_request_body:
     temperature: 0.0
 
+accuracy:
+  enabled: true
+  evaluator: sglang.test.run_eval
+  run_after_search: selected_commands_only
+  full_dataset: true
+  api:
+    mmlu: chat
+    gsm8k: completion
+  tasks:
+    mmlu:
+      num_examples: null
+      require_subcategories: true
+      expected_subcategories: [stem, humanities, social_sciences, other]
+    gsm8k:
+      num_examples: null
+      num_shots: 5
+  output_dir: /bench/results/llm-serving-auto-benchmark/accuracy
+
 sla:
   max_p99_ttft_ms: 2000
   max_p99_tpot_ms: 80

--- a/skills/llm-serving-auto-benchmark/references/example-plan.yaml
+++ b/skills/llm-serving-auto-benchmark/references/example-plan.yaml
@@ -82,8 +82,9 @@ frameworks:
     base_server_flags:
       tp_size: 8
       pp_size: 1
+      kv_cache_free_gpu_memory_fraction: 0.75
     search_space:
-      # Verify these names against `trtllm-serve --help` and the selected backend.
+      # Verify these names against `trtllm-serve serve --help` and the selected backend.
       backend: [pytorch, trt]
       max_batch_size: [64, 128]
       max_num_tokens: [8192, 16384]

--- a/skills/llm-serving-auto-benchmark/references/framework-matrix.md
+++ b/skills/llm-serving-auto-benchmark/references/framework-matrix.md
@@ -13,6 +13,8 @@ For parameter coverage by framework, see
 [parameter-coverage.md](parameter-coverage.md). For Docker image pull, launch,
 benchmark, and cleanup commands, see
 [container-runbook.md](container-runbook.md).
+For the reusable cookbook-derived config set and validation workflow, see
+[cookbook-configs.md](cookbook-configs.md).
 
 ## Source Links
 
@@ -20,6 +22,7 @@ benchmark, and cleanup commands, see
 - vLLM benchmark sweeps: <https://docs.vllm.ai/en/latest/benchmarking/sweeps/>
 - vLLM `bench sweep serve` CLI: <https://docs.vllm.ai/en/latest/cli/bench/sweep/serve.html>
 - TensorRT-LLM `trtllm-serve`: <https://nvidia.github.io/TensorRT-LLM/commands/trtllm-serve/trtllm-serve.html>
+- TensorRT-LLM model recipes: <https://nvidia.github.io/TensorRT-LLM/deployment-guide/index.html>
 - TensorRT-LLM serving benchmark tutorial: <https://nvidia.github.io/TensorRT-LLM/1.2.0rc6/commands/trtllm-serve/run-benchmark-with-trtllm-serve.html>
 
 ## Command Templates

--- a/skills/llm-serving-auto-benchmark/references/framework-matrix.md
+++ b/skills/llm-serving-auto-benchmark/references/framework-matrix.md
@@ -55,6 +55,7 @@ vllm bench sweep serve \
 trtllm-serve serve <model> \
   --tp_size <tp> \
   --pp_size <pp> \
+  --kv_cache_free_gpu_memory_fraction 0.75 \
   --host 0.0.0.0 \
   --port 8000
 ```
@@ -63,4 +64,16 @@ Then benchmark `http://127.0.0.1:8000/v1/completions` or
 `http://127.0.0.1:8000/v1/chat/completions` with the TensorRT-LLM serving
 benchmark client or the same OpenAI-compatible client used for the other
 frameworks. For TensorRT-LLM 1.0.0 synthetic random data, pass `--random-ids`
-unless you also provide a ShareGPT `--download-path`.
+unless you also provide a ShareGPT `--download-path`. In the 1.0.0 H100 image,
+`--free_gpu_memory_fraction` is not accepted by `trtllm-serve serve`; use
+`--kv_cache_free_gpu_memory_fraction` after checking `--help`.
+
+When launching Docker containers on a subset of GPUs, quote a comma-separated
+device list:
+
+```bash
+docker run --gpus '"device=6,7"' ...
+```
+
+`--gpus device=6,7` can be parsed incorrectly by Docker and fail before the
+server starts.

--- a/skills/llm-serving-auto-benchmark/references/framework-matrix.md
+++ b/skills/llm-serving-auto-benchmark/references/framework-matrix.md
@@ -9,6 +9,18 @@ actual CLI in the target container with `--help` before a long run.
 | vLLM | `vllm serve` | `vllm bench sweep serve` or `vllm bench serve` | `vllm bench sweep serve` can launch `vllm serve` repeatedly and sweep serve/bench parameter JSON files. |
 | TensorRT-LLM | `trtllm-serve serve --backend pytorch` | TensorRT-LLM serving benchmark client or a common OpenAI-compatible benchmark client | This skill pins TensorRT-LLM serving to the PyTorch backend. Non-PyTorch server backends and engine-serving paths are unsupported here. |
 
+## Accuracy Evaluation Feasibility
+
+Use a common OpenAI-compatible evaluator for final accuracy. The serving
+benchmark clients are for throughput and latency; do not rely on them for
+MMLU/GSM8K accuracy.
+
+| Framework | Can run full MMLU/GSM8K accuracy? | Subgroup notes |
+| --- | --- | --- |
+| SGLang | Yes, through `python -m sglang.test.run_eval` or another OpenAI-compatible evaluator. | The SGLang simple-evals MMLU path reports `stem`, `humanities`, `social_sciences`, and `other`. |
+| vLLM | Yes, through its OpenAI-compatible endpoint with the same evaluator. | vLLM's native serving benchmark does not report accuracy; use the common evaluator for MMLU subgroup output. |
+| TensorRT-LLM | Yes when `trtllm-serve serve --backend pytorch` exposes `/v1/completions` or `/v1/chat/completions`. | TensorRT-LLM's serving benchmark does not report accuracy; use the common evaluator. If subgroup metrics are unavailable, report final MMLU only. |
+
 For parameter coverage by framework, see
 [parameter-coverage.md](parameter-coverage.md). For Docker image pull, launch,
 benchmark, and cleanup commands, see

--- a/skills/llm-serving-auto-benchmark/references/framework-matrix.md
+++ b/skills/llm-serving-auto-benchmark/references/framework-matrix.md
@@ -9,18 +9,6 @@ actual CLI in the target container with `--help` before a long run.
 | vLLM | `vllm serve` | `vllm bench sweep serve` or `vllm bench serve` | `vllm bench sweep serve` can launch `vllm serve` repeatedly and sweep serve/bench parameter JSON files. |
 | TensorRT-LLM | `trtllm-serve serve --backend pytorch` | TensorRT-LLM serving benchmark client or a common OpenAI-compatible benchmark client | This skill pins TensorRT-LLM serving to the PyTorch backend. Non-PyTorch server backends and engine-serving paths are unsupported here. |
 
-## Accuracy Evaluation Feasibility
-
-Use a common OpenAI-compatible evaluator for final accuracy. The serving
-benchmark clients are for throughput and latency; do not rely on them for
-MMLU/GSM8K accuracy.
-
-| Framework | Can run full MMLU/GSM8K accuracy? | Subgroup notes |
-| --- | --- | --- |
-| SGLang | Yes, through `python -m sglang.test.run_eval` or another OpenAI-compatible evaluator. | The SGLang simple-evals MMLU path reports `stem`, `humanities`, `social_sciences`, and `other`. |
-| vLLM | Yes, through its OpenAI-compatible endpoint with the same evaluator. | vLLM's native serving benchmark does not report accuracy; use the common evaluator for MMLU subgroup output. |
-| TensorRT-LLM | Yes when `trtllm-serve serve --backend pytorch` exposes `/v1/completions` or `/v1/chat/completions`. | TensorRT-LLM's serving benchmark does not report accuracy; use the common evaluator. If subgroup metrics are unavailable, report final MMLU only. |
-
 For parameter coverage by framework, see
 [parameter-coverage.md](parameter-coverage.md). For Docker image pull, launch,
 benchmark, and cleanup commands, see

--- a/skills/llm-serving-auto-benchmark/references/framework-matrix.md
+++ b/skills/llm-serving-auto-benchmark/references/framework-matrix.md
@@ -9,6 +9,11 @@ actual CLI in the target container with `--help` before a long run.
 | vLLM | `vllm serve` | `vllm bench sweep serve` or `vllm bench serve` | `vllm bench sweep serve` can launch `vllm serve` repeatedly and sweep serve/bench parameter JSON files. |
 | TensorRT-LLM | `trtllm-serve serve` | TensorRT-LLM serving benchmark client or a common OpenAI-compatible benchmark client | `trtllm-serve serve` exposes OpenAI-compatible endpoints. Separate engine build time from serving performance. |
 
+For parameter coverage by framework, see
+[parameter-coverage.md](parameter-coverage.md). For Docker image pull, launch,
+benchmark, and cleanup commands, see
+[container-runbook.md](container-runbook.md).
+
 ## Source Links
 
 - SGLang Bench Serving Guide: <https://docs.sglang.ai/developer_guide/bench_serving.html>
@@ -41,6 +46,27 @@ python -m sglang.bench_serving \
 ### vLLM
 
 ```bash
+vllm serve <model> \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --tensor-parallel-size <tp> \
+  --gpu-memory-utilization 0.90 \
+  --max-model-len 4096 \
+  --max-num-seqs 64 \
+  --max-num-batched-tokens 8192 \
+  --enable-chunked-prefill
+
+vllm bench serve \
+  --backend vllm \
+  --base-url http://127.0.0.1:8000 \
+  --model <model> \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 256 \
+  --num-prompts 80 \
+  --request-rate 8 \
+  --max-concurrency 64
+
 vllm bench sweep serve \
   --serve-cmd 'vllm serve <model> --port 8000' \
   --bench-cmd 'vllm bench serve --backend vllm --model <model> --port 8000 --dataset-name random --num-prompts 80' \
@@ -66,7 +92,9 @@ benchmark client or the same OpenAI-compatible client used for the other
 frameworks. For TensorRT-LLM 1.0.0 synthetic random data, pass `--random-ids`
 unless you also provide a ShareGPT `--download-path`. In the 1.0.0 H100 image,
 `--free_gpu_memory_fraction` is not accepted by `trtllm-serve serve`; use
-`--kv_cache_free_gpu_memory_fraction` after checking `--help`.
+`--kv_cache_free_gpu_memory_fraction` after checking `--help`. The TensorRT-LLM
+1.0.0 benchmark client accepts `--backend openai` and `--backend openai-chat`,
+not `--backend trtllm`.
 
 When launching Docker containers on a subset of GPUs, quote a comma-separated
 device list:

--- a/skills/llm-serving-auto-benchmark/references/framework-matrix.md
+++ b/skills/llm-serving-auto-benchmark/references/framework-matrix.md
@@ -7,7 +7,7 @@ actual CLI in the target container with `--help` before a long run.
 | --- | --- | --- | --- |
 | SGLang | `python -m sglang.launch_server` | `python -m sglang.auto_benchmark` or `python -m sglang.bench_serving` | Use `auto_benchmark` when available for tiered server-flag search. `bench_serving` supports native and OpenAI-compatible endpoints. |
 | vLLM | `vllm serve` | `vllm bench sweep serve` or `vllm bench serve` | `vllm bench sweep serve` can launch `vllm serve` repeatedly and sweep serve/bench parameter JSON files. |
-| TensorRT-LLM | `trtllm-serve serve` | TensorRT-LLM serving benchmark client or a common OpenAI-compatible benchmark client | `trtllm-serve serve` exposes OpenAI-compatible endpoints. Separate engine build time from serving performance. |
+| TensorRT-LLM | `trtllm-serve serve --backend pytorch` | TensorRT-LLM serving benchmark client or a common OpenAI-compatible benchmark client | This skill pins TensorRT-LLM serving to the PyTorch backend. Non-PyTorch server backends and engine-serving paths are unsupported here. |
 
 For parameter coverage by framework, see
 [parameter-coverage.md](parameter-coverage.md). For Docker image pull, launch,
@@ -79,6 +79,7 @@ vllm bench sweep serve \
 
 ```bash
 trtllm-serve serve <model> \
+  --backend pytorch \
   --tp_size <tp> \
   --pp_size <pp> \
   --kv_cache_free_gpu_memory_fraction 0.75 \
@@ -95,6 +96,10 @@ unless you also provide a ShareGPT `--download-path`. In the 1.0.0 H100 image,
 `--kv_cache_free_gpu_memory_fraction` after checking `--help`. The TensorRT-LLM
 1.0.0 benchmark client accepts `--backend openai` and `--backend openai-chat`,
 not `--backend trtllm`.
+
+Do not replace the server-side `--backend pytorch` with `trt` or an engine
+backend in this skill. Treat those requests as unsupported candidates and record
+that reason in the result table.
 
 When launching Docker containers on a subset of GPUs, quote a comma-separated
 device list:

--- a/skills/llm-serving-auto-benchmark/references/parameter-coverage.md
+++ b/skills/llm-serving-auto-benchmark/references/parameter-coverage.md
@@ -34,7 +34,7 @@ Observed flag counts in that environment:
 
 | CLI | Flag Count | Note |
 | --- | ---: | --- |
-| `python -m sglang.launch_server --help` | 384 | Broad server surface. |
+| `python -m sglang.launch_server --help` | 384 | Large server flag surface. |
 | `vllm serve --help=all` | 302 | Plain `--help` only shows config groups. |
 | `vllm bench serve --help=all` | 97 | Covers random, ShareGPT, HF, custom, multimodal, and sampling knobs. |
 | `vllm bench sweep serve --help=all` | 15 | Sweeps serve and bench parameter JSON files. |
@@ -54,6 +54,10 @@ Observed flag counts in that environment:
 | Dtype, quantization, loading | `--dtype`, `--quantization`, `--load-format`, `--model-loader-extra-config`, `--trust-remote-code` | `--dtype`, `--quantization`, `--load-format`, `--model-loader-extra-config`, `--trust-remote-code`, `--hf-token` | `--trust_remote_code`, `--tokenizer`; quantization and engine options are often outside `trtllm-serve serve` |
 
 ## Benchmark Client Notes
+
+SGLang `bench_serving` in the H100 validation container writes artifacts with
+`--output-file` and `--output-details`. It does not accept the vLLM-style
+`--save-result`, `--result-dir`, and `--result-filename` flags in that image.
 
 Both vLLM and TensorRT-LLM benchmark clients accepted these shared random-workload
 flags in the H100 audit:
@@ -78,12 +82,38 @@ flag.
 
 ## Search Guidance
 
-- SGLang and vLLM both have broad runtime surfaces. Give both frameworks a real
-  sweep over memory, batching, scheduler, CUDA graph/compile, and prefix cache
-  options before comparing winners.
+- SGLang and vLLM both have large runtime flag surfaces. Give both frameworks a
+  sweep over batching, scheduler, CUDA graph/compile, and prefix cache options
+  before comparing winners.
 - TensorRT-LLM should still be searched, but its direct `trtllm-serve serve`
   surface is narrower. Search the exposed server flags first, then move deeper
   backend options into `--extra_llm_api_options` or an engine-build phase.
 - Keep every translated flag in the artifact manifest. If a family is not
   represented for one framework, say why instead of filling the gap with an
   unrelated option.
+
+Default searches should not sweep memory fractions:
+
+- keep SGLang `mem_fraction_static` in `base_server_flags`
+- keep vLLM `gpu_memory_utilization` in `base_server_flags`
+- keep TensorRT-LLM `kv_cache_free_gpu_memory_fraction` in `base_server_flags`
+
+Move them into `search_space` only for a fit/capacity study. For a normal serving
+comparison, search scheduler, batching, attention/backend, prefix cache, and
+CUDA graph or compile behavior first.
+
+In the 2026-04-22 H100 validation, vLLM accepted `--enable-dbo` but the server
+failed during config validation without a supported all2all backend. Treat DBO
+as a version- and environment-gated extension knob, not part of the default
+candidate list.
+
+The same validation showed that vLLM concurrent partial prefill is model/runtime
+gated: `--max-num-partial-prefills 1` ran on `Qwen/Qwen3-30B-A3B`, while
+`--max-num-partial-prefills 4` failed with "Concurrent Partial Prefill is not
+supported." Keep `1` in the default pass and only raise it after preflight.
+
+Sequence-length candidates must cover the largest dataset scenario. In the same
+H100 validation, a TensorRT-LLM candidate with `--max_seq_len 2048` passed the
+512-to-64 chat-like scenario but failed the 2048-to-128 summarization-like
+scenario. Do not include a `max_model_len`, `context_length`, or `max_seq_len`
+candidate below `max(input_len + output_len)`.

--- a/skills/llm-serving-auto-benchmark/references/parameter-coverage.md
+++ b/skills/llm-serving-auto-benchmark/references/parameter-coverage.md
@@ -38,8 +38,19 @@ Observed flag counts in that environment:
 | `vllm serve --help=all` | 302 | Plain `--help` only shows config groups. |
 | `vllm bench serve --help=all` | 97 | Covers random, ShareGPT, HF, custom, multimodal, and sampling knobs. |
 | `vllm bench sweep serve --help=all` | 15 | Sweeps serve and bench parameter JSON files. |
-| `trtllm-serve serve --help` | 23 | Direct serving surface is smaller; use backend config or build steps for deeper tuning. |
+| `trtllm-serve serve --help` | 23 | Direct serving surface is smaller; this skill fixes `--backend pytorch` and uses direct flags or PyTorch backend config for tuning. |
 | `python -m tensorrt_llm.serve.scripts.benchmark_serving --help` | 53 | OpenAI-compatible benchmark client. |
+
+## TensorRT-LLM Backend Policy
+
+For this skill, TensorRT-LLM serving is pinned to `trtllm-serve serve --backend
+pytorch`. Keep `backend: pytorch` in `base_server_flags`, and do not put
+`backend` in `search_space`.
+
+Reject `trt`, engine-backed serving, or any other non-PyTorch TensorRT-LLM
+server backend as unsupported for this skill. The benchmark client `--backend`
+is separate: TensorRT-LLM 1.0.0 uses `openai` or `openai-chat` to target the
+OpenAI-compatible endpoint.
 
 ## Knob Family Mapping
 
@@ -48,10 +59,10 @@ Observed flag counts in that environment:
 | Parallelism | `--tp-size`, `--pp-size`, `--dp-size`, `--ep-size`, `--expert-parallel-size`, `--attention-context-parallel-size` | `--tensor-parallel-size`, `--pipeline-parallel-size`, `--data-parallel-size`, `--decode-context-parallel-size`, `--enable-expert-parallel` | `--tp_size`, `--pp_size`, `--ep_size`, `--gpus_per_node`, `--cluster_size` |
 | Memory and KV cache | `--mem-fraction-static`, `--max-total-tokens`, `--kv-cache-dtype`, `--page-size`, `--cpu-offload-gb` | `--gpu-memory-utilization`, `--kv-cache-memory-bytes`, `--kv-cache-dtype`, `--block-size`, `--cpu-offload-gb` | `--kv_cache_free_gpu_memory_fraction`; combine with `--max_num_tokens`, `--max_seq_len`, and `--max_batch_size` |
 | Batching and scheduler | `--max-running-requests`, `--max-queued-requests`, `--schedule-policy`, `--schedule-conservativeness`, `--chunked-prefill-size`, `--max-prefill-tokens`, `--prefill-max-requests` | `--max-num-seqs`, `--max-num-batched-tokens`, `--enable-chunked-prefill`, `--max-num-partial-prefills`, `--max-long-partial-prefills`, `--long-prefill-token-threshold`, `--enable-dbo`, `--dbo-prefill-token-threshold`, `--dbo-decode-token-threshold` | `--max_batch_size`, `--max_num_tokens`, `--max_seq_len`; more scheduler details may require `--extra_llm_api_options` |
-| Attention/backend | `--attention-backend`, `--prefill-attention-backend`, `--decode-attention-backend`, `--sampling-backend`, `--grammar-backend` | `--attention-backend`, `--gdn-prefill-backend`, `--mm-encoder-attn-backend` | `--backend`; PyTorch backend details are mostly config-driven |
+| Attention/backend | `--attention-backend`, `--prefill-attention-backend`, `--decode-attention-backend`, `--sampling-backend`, `--grammar-backend` | `--attention-backend`, `--gdn-prefill-backend`, `--mm-encoder-attn-backend` | `--backend pytorch` is fixed; do not search backend choice |
 | CUDA graph and compile | `--disable-cuda-graph`, `--cuda-graph-bs`, `--cuda-graph-max-bs`, `--disable-piecewise-cuda-graph`, `--piecewise-cuda-graph-max-tokens`, `--enable-torch-compile` | `--enforce-eager`, `--compilation-config`, `--cudagraph-capture-sizes`, `--max-cudagraph-capture-size` | use `--extra_llm_api_options`; server logs expose the resolved `PyTorchConfig` |
-| Prefix/speculative | `--disable-radix-cache`, `--disable-chunked-prefix-cache`, `--speculative-algorithm`, `--speculative-draft-model-path`, `--speculative-num-steps`, `--speculative-num-draft-tokens` | `--enable-prefix-caching`, `--speculative-config` | usually via `--extra_llm_api_options` or a backend-specific flow |
-| Dtype, quantization, loading | `--dtype`, `--quantization`, `--load-format`, `--model-loader-extra-config`, `--trust-remote-code` | `--dtype`, `--quantization`, `--load-format`, `--model-loader-extra-config`, `--trust-remote-code`, `--hf-token` | `--trust_remote_code`, `--tokenizer`; quantization and engine options are often outside `trtllm-serve serve` |
+| Prefix/speculative | `--disable-radix-cache`, `--disable-chunked-prefix-cache`, `--speculative-algorithm`, `--speculative-draft-model-path`, `--speculative-num-steps`, `--speculative-num-draft-tokens` | `--enable-prefix-caching`, `--speculative-config` | only use PyTorch-backend options accepted by `--extra_llm_api_options` |
+| Dtype, quantization, loading | `--dtype`, `--quantization`, `--load-format`, `--model-loader-extra-config`, `--trust-remote-code` | `--dtype`, `--quantization`, `--load-format`, `--model-loader-extra-config`, `--trust-remote-code`, `--hf-token` | `--trust_remote_code`, `--tokenizer`; engine build and non-PyTorch quantization flows are outside this skill |
 
 ## Benchmark Client Notes
 
@@ -86,8 +97,8 @@ flag.
   sweep over batching, scheduler, CUDA graph/compile, and prefix cache options
   before comparing winners.
 - TensorRT-LLM should still be searched, but its direct `trtllm-serve serve`
-  surface is narrower. Search the exposed server flags first, then move deeper
-  backend options into `--extra_llm_api_options` or an engine-build phase.
+  surface is narrower. Search the exposed server flags first, then use only
+  PyTorch-backend options accepted by `--extra_llm_api_options`.
 - Keep every translated flag in the artifact manifest. If a family is not
   represented for one framework, say why instead of filling the gap with an
   unrelated option.

--- a/skills/llm-serving-auto-benchmark/references/parameter-coverage.md
+++ b/skills/llm-serving-auto-benchmark/references/parameter-coverage.md
@@ -1,0 +1,89 @@
+# Parameter Coverage
+
+Do not compare SGLang, vLLM, and TensorRT-LLM by copying the same flag names
+across frameworks. Compare knob families, then translate each family to the
+flags that the target CLI actually accepts.
+
+## H100 Audit Snapshot
+
+Captured on 2026-04-22 in:
+
+`/tmp/llm_serving_auto_benchmark_param_audit_20260422_094955`
+
+Versions:
+
+- SGLang: `sglang 0.5.10rc0`, repo commit
+  `30cd2cf32b20355e361f7e2b3badc376fc1330af`
+- vLLM image: `vllm/vllm-openai:latest`, `vllm 0.19.1`
+- TensorRT-LLM image: `nvcr.io/nvidia/tensorrt-llm/release:latest`,
+  `tensorrt_llm 1.0.0`
+
+Help files captured:
+
+- `help/sglang_launch_server.txt`
+- `help/sglang_bench_serving.txt`
+- `help/sglang_auto_benchmark_run.txt`
+- `help/vllm_serve_all.txt`
+- `help/vllm_bench_serve_all.txt`
+- `help/vllm_bench_sweep_serve_all.txt`
+- `help/trtllm_serve.txt`
+- `help/trtllm_benchmark_serving.txt`
+- `help/trtllm_bench.txt`
+
+Observed flag counts in that environment:
+
+| CLI | Flag Count | Note |
+| --- | ---: | --- |
+| `python -m sglang.launch_server --help` | 384 | Broad server surface. |
+| `vllm serve --help=all` | 302 | Plain `--help` only shows config groups. |
+| `vllm bench serve --help=all` | 97 | Covers random, ShareGPT, HF, custom, multimodal, and sampling knobs. |
+| `vllm bench sweep serve --help=all` | 15 | Sweeps serve and bench parameter JSON files. |
+| `trtllm-serve serve --help` | 23 | Direct serving surface is smaller; use backend config or build steps for deeper tuning. |
+| `python -m tensorrt_llm.serve.scripts.benchmark_serving --help` | 53 | OpenAI-compatible benchmark client. |
+
+## Knob Family Mapping
+
+| Family | SGLang | vLLM | TensorRT-LLM |
+| --- | --- | --- | --- |
+| Parallelism | `--tp-size`, `--pp-size`, `--dp-size`, `--ep-size`, `--expert-parallel-size`, `--attention-context-parallel-size` | `--tensor-parallel-size`, `--pipeline-parallel-size`, `--data-parallel-size`, `--decode-context-parallel-size`, `--enable-expert-parallel` | `--tp_size`, `--pp_size`, `--ep_size`, `--gpus_per_node`, `--cluster_size` |
+| Memory and KV cache | `--mem-fraction-static`, `--max-total-tokens`, `--kv-cache-dtype`, `--page-size`, `--cpu-offload-gb` | `--gpu-memory-utilization`, `--kv-cache-memory-bytes`, `--kv-cache-dtype`, `--block-size`, `--cpu-offload-gb` | `--kv_cache_free_gpu_memory_fraction`; combine with `--max_num_tokens`, `--max_seq_len`, and `--max_batch_size` |
+| Batching and scheduler | `--max-running-requests`, `--max-queued-requests`, `--schedule-policy`, `--schedule-conservativeness`, `--chunked-prefill-size`, `--max-prefill-tokens`, `--prefill-max-requests` | `--max-num-seqs`, `--max-num-batched-tokens`, `--enable-chunked-prefill`, `--max-num-partial-prefills`, `--max-long-partial-prefills`, `--long-prefill-token-threshold`, `--enable-dbo`, `--dbo-prefill-token-threshold`, `--dbo-decode-token-threshold` | `--max_batch_size`, `--max_num_tokens`, `--max_seq_len`; more scheduler details may require `--extra_llm_api_options` |
+| Attention/backend | `--attention-backend`, `--prefill-attention-backend`, `--decode-attention-backend`, `--sampling-backend`, `--grammar-backend` | `--attention-backend`, `--gdn-prefill-backend`, `--mm-encoder-attn-backend` | `--backend`; PyTorch backend details are mostly config-driven |
+| CUDA graph and compile | `--disable-cuda-graph`, `--cuda-graph-bs`, `--cuda-graph-max-bs`, `--disable-piecewise-cuda-graph`, `--piecewise-cuda-graph-max-tokens`, `--enable-torch-compile` | `--enforce-eager`, `--compilation-config`, `--cudagraph-capture-sizes`, `--max-cudagraph-capture-size` | use `--extra_llm_api_options`; server logs expose the resolved `PyTorchConfig` |
+| Prefix/speculative | `--disable-radix-cache`, `--disable-chunked-prefix-cache`, `--speculative-algorithm`, `--speculative-draft-model-path`, `--speculative-num-steps`, `--speculative-num-draft-tokens` | `--enable-prefix-caching`, `--speculative-config` | usually via `--extra_llm_api_options` or a backend-specific flow |
+| Dtype, quantization, loading | `--dtype`, `--quantization`, `--load-format`, `--model-loader-extra-config`, `--trust-remote-code` | `--dtype`, `--quantization`, `--load-format`, `--model-loader-extra-config`, `--trust-remote-code`, `--hf-token` | `--trust_remote_code`, `--tokenizer`; quantization and engine options are often outside `trtllm-serve serve` |
+
+## Benchmark Client Notes
+
+Both vLLM and TensorRT-LLM benchmark clients accepted these shared random-workload
+flags in the H100 audit:
+
+- `--dataset-name`
+- `--random-input-len`
+- `--random-output-len`
+- `--num-prompts`
+- `--request-rate`
+- `--max-concurrency`
+- `--save-result`
+- `--result-dir`
+- `--result-filename`
+- `--ignore-eos`
+- `--temperature`
+- `--top-p`
+- `--top-k`
+
+TensorRT-LLM 1.0.0 additionally needs `--random-ids` for a fast synthetic random
+run unless a ShareGPT download path is provided. vLLM 0.19.1 does not have that
+flag.
+
+## Search Guidance
+
+- SGLang and vLLM both have broad runtime surfaces. Give both frameworks a real
+  sweep over memory, batching, scheduler, CUDA graph/compile, and prefix cache
+  options before comparing winners.
+- TensorRT-LLM should still be searched, but its direct `trtllm-serve serve`
+  surface is narrower. Search the exposed server flags first, then move deeper
+  backend options into `--extra_llm_api_options` or an engine-build phase.
+- Keep every translated flag in the artifact manifest. If a family is not
+  represented for one framework, say why instead of filling the gap with an
+  unrelated option.

--- a/skills/llm-serving-auto-benchmark/references/result-schema.md
+++ b/skills/llm-serving-auto-benchmark/references/result-schema.md
@@ -95,7 +95,7 @@ The markdown summary must include these sections:
    vLLM, and TensorRT-LLM command for each scenario. Sort each scenario by the
    ranking rule above so the best deployment choice is first.
 3. `Failed Or SLA-Failing Candidates`: include this table when any candidate
-   failed, was skipped, or completed without passing SLA. Treat it as an audit
-   trail for explored but non-recommended configs, and keep each reason concrete
-   enough to tell whether the candidate needs a retry, lower concurrency, a
-   parameter fix, or no further action.
+   failed, was skipped, or completed without passing SLA. This table records
+   tried configs that were not selected. Keep each reason concrete enough to
+   tell whether the candidate needs a retry, lower concurrency, a parameter fix,
+   or no further action.

--- a/skills/llm-serving-auto-benchmark/references/result-schema.md
+++ b/skills/llm-serving-auto-benchmark/references/result-schema.md
@@ -94,3 +94,8 @@ The markdown summary must include these sections:
 2. `Cross-Framework Best Comparison`: one table that compares the best SGLang,
    vLLM, and TensorRT-LLM command for each scenario. Sort each scenario by the
    ranking rule above so the best deployment choice is first.
+3. `Failed Or SLA-Failing Candidates`: include this table when any candidate
+   failed, was skipped, or completed without passing SLA. Treat it as an audit
+   trail for explored but non-recommended configs, and keep each reason concrete
+   enough to tell whether the candidate needs a retry, lower concurrency, a
+   parameter fix, or no further action.

--- a/skills/llm-serving-auto-benchmark/references/result-schema.md
+++ b/skills/llm-serving-auto-benchmark/references/result-schema.md
@@ -48,27 +48,6 @@ the final summary explains what was tried.
   },
   "server_command": "python -m sglang.launch_server ...",
   "benchmark_command": "python -m sglang.bench_serving ...",
-  "accuracy": {
-    "mmlu": {
-      "accuracy": 0.742,
-      "num_examples": 14042,
-      "subcategories": {
-        "stem": 0.701,
-        "humanities": 0.781,
-        "social_sciences": 0.764,
-        "other": 0.733
-      },
-      "command": "python -m sglang.test.run_eval --eval-name mmlu ...",
-      "result_file": "/bench/sglang/accuracy/mmlu.json",
-      "report": "/bench/sglang/accuracy/mmlu.html"
-    },
-    "gsm8k": {
-      "accuracy": 0.835,
-      "num_examples": 1314,
-      "command": "python -m sglang.test.run_eval --eval-name gsm8k ...",
-      "result_file": "/bench/sglang/accuracy/gsm8k.json"
-    }
-  },
   "validated_cli_flags": {
     "server": ["tp_size", "attention_backend"],
     "benchmark": ["dataset_name", "request_rate", "max_concurrency"]
@@ -115,10 +94,3 @@ The markdown summary must include these sections:
 2. `Cross-Framework Best Comparison`: one table that compares the best SGLang,
    vLLM, and TensorRT-LLM command for each scenario. Sort each scenario by the
    ranking rule above so the best deployment choice is first.
-3. `Accuracy Of Selected Deployment Commands`: one table for the selected
-   deployment commands. Include MMLU final accuracy, MMLU subgroup accuracy when
-   available, GSM8K accuracy, evaluated example counts, and accuracy artifacts.
-
-Accuracy rows are required for a final report. If the evaluator cannot provide
-MMLU subgroup metrics for a framework, keep the final MMLU score and leave the
-subgroup columns empty with a note in the artifact or caveat text.

--- a/skills/llm-serving-auto-benchmark/references/result-schema.md
+++ b/skills/llm-serving-auto-benchmark/references/result-schema.md
@@ -21,6 +21,7 @@ the final summary explains what was tried.
   },
   "workload": {
     "kind": "custom",
+    "scenario": "chat",
     "dataset_path": "/bench/workload.autobench.jsonl",
     "num_prompts": 1000,
     "request_rate": 16,
@@ -47,6 +48,27 @@ the final summary explains what was tried.
   },
   "server_command": "python -m sglang.launch_server ...",
   "benchmark_command": "python -m sglang.bench_serving ...",
+  "accuracy": {
+    "mmlu": {
+      "accuracy": 0.742,
+      "num_examples": 14042,
+      "subcategories": {
+        "stem": 0.701,
+        "humanities": 0.781,
+        "social_sciences": 0.764,
+        "other": 0.733
+      },
+      "command": "python -m sglang.test.run_eval --eval-name mmlu ...",
+      "result_file": "/bench/sglang/accuracy/mmlu.json",
+      "report": "/bench/sglang/accuracy/mmlu.html"
+    },
+    "gsm8k": {
+      "accuracy": 0.835,
+      "num_examples": 1314,
+      "command": "python -m sglang.test.run_eval --eval-name gsm8k ...",
+      "result_file": "/bench/sglang/accuracy/gsm8k.json"
+    }
+  },
   "validated_cli_flags": {
     "server": ["tp_size", "attention_backend"],
     "benchmark": ["dataset_name", "request_rate", "max_concurrency"]
@@ -82,3 +104,21 @@ The default ranking is:
 
 If the user cares more about token throughput than request throughput, swap
 steps 3 and 4 and state that in the final report.
+
+## Final Report Tables
+
+The markdown summary must include these sections:
+
+1. `Best Commands By Framework`: one table per framework. Each table has one row
+   per workload scenario and includes the best candidate, SLA result, throughput,
+   latency metrics, GPU count, exact server command, and artifacts.
+2. `Cross-Framework Best Comparison`: one table that compares the best SGLang,
+   vLLM, and TensorRT-LLM command for each scenario. Sort each scenario by the
+   ranking rule above so the best deployment choice is first.
+3. `Accuracy Of Selected Deployment Commands`: one table for the selected
+   deployment commands. Include MMLU final accuracy, MMLU subgroup accuracy when
+   available, GSM8K accuracy, evaluated example counts, and accuracy artifacts.
+
+Accuracy rows are required for a final report. If the evaluator cannot provide
+MMLU subgroup metrics for a framework, keep the final MMLU score and leave the
+subgroup columns empty with a note in the artifact or caveat text.

--- a/skills/llm-serving-auto-benchmark/references/version-notes.md
+++ b/skills/llm-serving-auto-benchmark/references/version-notes.md
@@ -78,7 +78,7 @@ smoke used idle GPU 4 and is labeled as a one-GPU flow check.
 
 Audit lessons:
 
-- vLLM has a broad serving surface comparable to SGLang, but full discovery
+- vLLM has a large serving flag surface, but full discovery
   requires `vllm serve --help=all` and `vllm bench serve --help=all`.
 - TensorRT-LLM's direct `trtllm-serve serve` flag surface is smaller. The server
   logs show deeper PyTorch backend settings in `PyTorchConfig`, but many of
@@ -128,3 +128,59 @@ performance numbers.
   smoke-only check and do not compare throughput against the earlier runs.
 - Clean up by port and container name. Avoid killing raw PIDs unless they are
   proven to belong to the current validation run.
+
+### Larger Model Search Smoke
+
+On 2026-04-22, a larger H100 flow check used idle GPU 4 on `h100_sglang`. Other
+H100s were occupied, so these runs are not throughput comparisons against a
+4-GPU deployment. They are end-to-end checks that the search layout, framework
+commands, cleanup, and result collection work on larger models that fit within a
+4-H100 target budget.
+
+Common workload:
+
+- random `chat`: 512 input tokens, 64 output tokens
+- random `summarization`: 2048 input tokens, 128 output tokens
+- 20 prompts per scenario
+- request rate 1, max concurrency 4
+- 10 server candidates per framework
+
+Artifact directories:
+
+- `/tmp/llm_serving_auto_benchmark_big_models_20260422_101647`
+- `/tmp/llm_serving_auto_benchmark_big_models_20260422_110906`
+
+Both directories contain `summary.tsv`, per-candidate server logs, benchmark
+logs, and successful `results.json` files. The second directory also contains
+`metrics.tsv`; the first directory was interrupted after `Qwen/Qwen3-14B` and
+`metrics.tsv` was generated afterwards from the saved result JSON files.
+
+Scenario-level result counts:
+
+| Model | Framework | Pass | Fail | Notes |
+| --- | --- | ---: | ---: | --- |
+| `Qwen/Qwen3-14B` | SGLang | 16 | 2 | Two startup failures from searched SGLang candidates. |
+| `Qwen/Qwen3-14B` | vLLM | 16 | 2 | DBO candidates failed without a supported all2all backend. |
+| `Qwen/Qwen3-14B` | TensorRT-LLM | 16 | 4 | `max_seq_len 2048` candidates passed chat but failed summarization. |
+| `Qwen/Qwen3-30B-A3B` | SGLang | 16 | 2 | Same SGLang candidate pattern as `Qwen3-14B`. |
+| `Qwen/Qwen3-30B-A3B` | vLLM | 18 | 1 | `max_num_partial_prefills 4` failed; `1` passed. |
+| `Qwen/Qwen3-30B-A3B` | TensorRT-LLM | 20 | 0 | All corrected TensorRT-LLM candidates passed. |
+| `mistralai/Ministral-3-14B-Instruct-2512` | SGLang | 20 | 0 | All candidates passed. |
+| `mistralai/Ministral-3-14B-Instruct-2512` | vLLM | 18 | 1 | `max_num_partial_prefills 4` failed. |
+| `mistralai/Ministral-3-14B-Instruct-2512` | TensorRT-LLM | 0 | 10 | TensorRT-LLM 1.0.0 failed startup with `KeyError: 'ministral3'`. |
+
+Lessons from the larger run:
+
+- SGLang `bench_serving` in this container needs `--output-file` and
+  `--output-details`; the vLLM-style `--save-result` flags are not accepted.
+- Keep DBO out of the default vLLM search unless the environment has the
+  required all2all backend.
+- Keep vLLM concurrent partial prefill at `max_num_partial_prefills: 1` by
+  default. Raising it to 4 failed on the tested larger models.
+- TensorRT-LLM `max_seq_len` candidates must cover the largest input plus output
+  length in the dataset. The too-small `2048` candidates failed only on the
+  longer scenario.
+- TensorRT-LLM model support is version-specific. In the tested 1.0.0 image,
+  `Ministral-3-14B-Instruct-2512` failed before serving because the bundled
+  Transformers mapping did not include `ministral3`.
+- Cleanup used `codex-big-*` container names and left GPU 4 idle at the end.

--- a/skills/llm-serving-auto-benchmark/references/version-notes.md
+++ b/skills/llm-serving-auto-benchmark/references/version-notes.md
@@ -187,3 +187,74 @@ Lessons from the larger run:
   `Ministral-3-14B-Instruct-2512` failed before serving because the bundled
   Transformers mapping did not include `ministral3`.
 - Cleanup used `codex-big-*` container names and left GPU 4 idle at the end.
+
+### TensorRT-LLM PyTorch Backend 4-GPU Validation
+
+After pinning TensorRT-LLM to the PyTorch server backend, a focused H100 run
+validated the container path on four idle H100s.
+
+Run directory:
+
+`/tmp/llm_serving_auto_benchmark_trt_torch4_10cfg_20260422_131031`
+
+Setup:
+
+- model: `Qwen/Qwen3-30B-A3B`
+- GPUs: 0, 1, 2, 3 on `h100_sglang`
+- image: `nvcr.io/nvidia/tensorrt-llm/release:latest`
+- TensorRT-LLM: `1.0.0`
+- server backend: `trtllm-serve serve --backend pytorch`
+- workload: random `chat` 512 -> 64 and random `summarization` 2048 -> 128
+- request count: 20 per scenario
+- request rate: 1
+- max concurrency: 4
+- candidates: 10 TensorRT-LLM server configs over `max_batch_size`,
+  `max_num_tokens`, and `max_seq_len`
+
+The passing Docker server options included:
+
+```bash
+--ipc=host
+--ulimit memlock=-1
+--ulimit stack=67108864
+--shm-size=16g
+-e NCCL_IB_DISABLE=1
+```
+
+Result summary:
+
+| Candidates | Scenario cells | Pass | Fail |
+| ---: | ---: | ---: | ---: |
+| 10 | 20 | 20 | 0 |
+
+Candidate grid:
+
+| Candidate | `max_batch_size` | `max_num_tokens` | `max_seq_len` |
+| ---: | ---: | ---: | ---: |
+| 1 | 64 | 12288 | 4096 |
+| 2 | 64 | 16384 | 4096 |
+| 3 | 128 | 12288 | 4096 |
+| 4 | 128 | 16384 | 4096 |
+| 5 | 64 | 12288 | 8192 |
+| 6 | 64 | 16384 | 8192 |
+| 7 | 128 | 12288 | 8192 |
+| 8 | 128 | 16384 | 8192 |
+| 9 | 32 | 8192 | 4096 |
+| 10 | 32 | 8192 | 8192 |
+
+Representative metrics:
+
+| Candidate | Scenario | Completed | Request/s | Output tok/s | p99 TTFT ms | p99 TPOT ms |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | chat | 20 | 0.879 | 56.237 | 176.222 | 12.669 |
+| 1 | summarization | 20 | 0.879 | 112.483 | 70.347 | 6.889 |
+| 8 | chat | 20 | 0.878 | 56.221 | 178.766 | 4.998 |
+| 8 | summarization | 20 | 0.879 | 112.478 | 62.188 | 4.481 |
+| 10 | chat | 20 | 0.879 | 56.228 | 178.633 | 4.960 |
+| 10 | summarization | 20 | 0.879 | 112.485 | 68.294 | 4.530 |
+
+An earlier 10-candidate attempt in
+`/tmp/llm_serving_auto_benchmark_trt_torch4_20260422_130118` used the same
+model and backend but omitted the multi-GPU Docker options above. Each candidate
+entered `PyTorchConfig` and then failed startup at NCCL allreduce. Keep those
+container options in the runbook for multi-GPU TensorRT-LLM validation.

--- a/skills/llm-serving-auto-benchmark/references/version-notes.md
+++ b/skills/llm-serving-auto-benchmark/references/version-notes.md
@@ -98,6 +98,35 @@ empty, so `python -m sglang.auto_benchmark run` failed before launching a real
 candidate. Do not count those SGLang cells as validated. The later runs below
 supersede that note.
 
+### Cookbook Config Read Check
+
+On 2026-04-23, the reusable cookbook config set was checked on `h100_sglang`
+without launching model servers.
+
+Remote help directory:
+
+`/tmp/llm_serving_cookbook_config_help_20260423`
+
+Local validation command:
+
+```bash
+python skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py \
+  --help-dir /tmp/llm_serving_cookbook_config_help_20260423 \
+  skills/llm-serving-auto-benchmark/configs/cookbook-llm
+```
+
+Result: all 38 cookbook-derived configs loaded, generated bounded candidate
+server commands, and passed concrete server-flag validation against the captured
+help files. This check did not start model servers.
+
+Captured server help:
+
+| CLI | Help file | Flags |
+| --- | --- | ---: |
+| `python -m sglang.launch_server --help` | `sglang_launch_server.txt` | 384 |
+| `vllm serve --help=all` | `vllm_serve_all.txt` | 302 |
+| `trtllm-serve serve --help` | `trtllm_serve.txt` | 23 |
+
 ### Validated Smoke Matrix
 
 All rows used a tiny random workload: 4 prompts, 32 input tokens, 8 output

--- a/skills/llm-serving-auto-benchmark/references/version-notes.md
+++ b/skills/llm-serving-auto-benchmark/references/version-notes.md
@@ -29,34 +29,50 @@ When updating this skill:
 
 ## H100 Validation Notes
 
-On 2026-04-22, the `h100_sglang` environment had:
+On 2026-04-22, validation used the `h100_sglang` host:
 
-- GPUs 6 and 7 idle before validation: 0% utilization and 4 MiB allocated.
 - `sglang_bbuf` container: `sglang 0.5.10rc0`.
 - `vllm/vllm-openai:latest` image: `vllm 0.19.1`.
 - `nvcr.io/nvidia/tensorrt-llm/release:latest` image: `tensorrt_llm 1.0.0`.
+- Hugging Face access came from the local H100 skill and was passed as
+  environment variables. Do not print the token into logs.
 
-Smoke-tested on GPU 6 and 7 with tensor parallel size 2:
+The first smoke attempt for `Qwen/Qwen2.5-0.5B-Instruct` and
+`Qwen/Qwen2.5-1.5B-Instruct` had a bad SGLang artifact: the generated config was
+empty, so `python -m sglang.auto_benchmark run` failed before launching a real
+candidate. Do not count those SGLang cells as validated. The later runs below
+supersede that note.
 
-| Model | SGLang | vLLM | TensorRT-LLM |
-| --- | --- | --- | --- |
-| `Qwen/Qwen2.5-0.5B-Instruct` | pass: `python -m sglang.auto_benchmark run` with one tiny candidate | pass: `vllm serve` plus `vllm bench serve` | pass: `trtllm-serve serve --backend pytorch` plus TensorRT-LLM `benchmark_serving --random-ids` |
-| `Qwen/Qwen2.5-1.5B-Instruct` | pass: `python -m sglang.auto_benchmark run` with one tiny candidate | pass: `vllm serve` plus `vllm bench serve` | pass: `trtllm-serve serve --backend pytorch` plus TensorRT-LLM `benchmark_serving --random-ids` |
+### Validated Smoke Matrix
 
-Cleanup behavior used in validation:
+All rows used a tiny random workload: 4 prompts, 32 input tokens, 8 output
+tokens, request rate 1, and max concurrency 2. These are flow checks, not
+performance numbers.
 
-- SGLang: kill the test port with `fuser`, then kill matching
-  `sglang.launch_server` command lines for the same port.
-- vLLM and TensorRT-LLM: run each server in a uniquely named Docker container
-  and stop it with `docker rm -f`.
-- Re-check GPUs 6 and 7 after every framework. They returned to 0% utilization
-  and 4 MiB allocated after the final cleanup.
+| Model | GPU shape | SGLang auto benchmark | vLLM | TensorRT-LLM |
+| --- | --- | --- | --- | --- |
+| `Qwen/Qwen2.5-7B-Instruct` | GPUs 6,7; TP=2 | pass: `/tmp/llm_serving_auto_benchmark_three_models_20260422_091958/qwen25_7b/sglang_auto/container_results/live_results.jsonl` | pass: `vllm serve` plus `vllm bench serve` | pass after using `--kv_cache_free_gpu_memory_fraction`: `/tmp/llm_serving_auto_benchmark_trt_retry_20260422_092852/qwen25_7b/results.json` |
+| `google/gemma-3-4b-it` | GPUs 6,7; TP=2 for SGLang/vLLM | pass: `/tmp/llm_serving_auto_benchmark_three_models_20260422_091958/gemma3_4b/sglang_auto/container_results/live_results.jsonl` | pass: `vllm serve` plus `vllm bench serve` | fail in TensorRT-LLM 1.0.0: server container exited during startup, including a TP=1 retry on GPU 6 |
+| `mistralai/Ministral-3-8B-Instruct-2512` | GPUs 6,7; TP=2 for SGLang/vLLM | pass: `/tmp/llm_serving_auto_benchmark_three_models_20260422_091958/ministral3_8b/sglang_auto/container_results/live_results.jsonl` | pass: `vllm serve` plus `vllm bench serve` | fail in TensorRT-LLM 1.0.0: server container exited during startup, including a TP=1 retry on GPU 6 |
+| `TinyLlama/TinyLlama-1.1B-Chat-v1.0` | GPU 6 or 7; TP=1 | pass after disabling piecewise CUDA graph: `/tmp/llm_serving_auto_benchmark_tinyllama_sglang_fixed/container_results/live_results.jsonl` | pass: `/tmp/llm_serving_auto_benchmark_more_gpu7_20260422_091149/tinyllama_1_1b/vllm/results.json` | pass: `/tmp/llm_serving_auto_benchmark_tinyllama_trt_manual/results.json` |
 
-TensorRT-LLM notes from validation:
+### Validation Lessons
 
-- The Docker image worked when running `trtllm-serve serve` through `bash -lc`.
-  Overriding the Docker entrypoint directly to `trtllm-serve` missed library
-  setup in this environment and failed to load `libnvinfer.so.10`.
-- For `benchmark_serving --dataset-name random`, use `--random-ids` for fast
-  synthetic smoke tests. Without it, TensorRT-LLM 1.0.0 asks for a ShareGPT
-  `--download-path`.
+- SGLang smoke configs must be real files. After writing a config through
+  `docker exec`, read or checksum it before starting a long run.
+- For quick SGLang flow checks, add both `disable_cuda_graph: true` and
+  `disable_piecewise_cuda_graph: true`. TinyLlama hit a piecewise CUDA graph
+  warmup failure without the second flag.
+- In TensorRT-LLM 1.0.0, `trtllm-serve serve` accepts
+  `--kv_cache_free_gpu_memory_fraction`; `--free_gpu_memory_fraction` exits with
+  a CLI error.
+- `benchmark_serving --dataset-name random` needs `--random-ids` for fast
+  synthetic tests unless a ShareGPT `--download-path` is provided.
+- When using Docker with specific GPUs, quote comma-separated device lists:
+  `--gpus '"device=6,7"'`. The unquoted `--gpus device=6,7` form can fail before
+  the container starts.
+- Check GPU idleness before every framework run, not only at the start. Other
+  jobs can appear mid-validation. If the GPU count changes, record the run as a
+  smoke-only check and do not compare throughput against the earlier runs.
+- Clean up by port and container name. Avoid killing raw PIDs unless they are
+  proven to belong to the current validation run.

--- a/skills/llm-serving-auto-benchmark/references/version-notes.md
+++ b/skills/llm-serving-auto-benchmark/references/version-notes.md
@@ -37,6 +37,58 @@ On 2026-04-22, validation used the `h100_sglang` host:
 - Hugging Face access came from the local H100 skill and was passed as
   environment variables. Do not print the token into logs.
 
+### Parameter Audit
+
+On 2026-04-22, a separate H100 parameter audit captured help output and ran
+model-level smoke checks for expanded vLLM and TensorRT-LLM server flags.
+
+Audit directory:
+
+`/tmp/llm_serving_auto_benchmark_param_audit_20260422_094955`
+
+Captured help files include:
+
+- `help/sglang_launch_server.txt`
+- `help/sglang_bench_serving.txt`
+- `help/sglang_auto_benchmark_run.txt`
+- `help/vllm_serve_all.txt`
+- `help/vllm_bench_serve_all.txt`
+- `help/vllm_bench_sweep_serve_all.txt`
+- `help/trtllm_serve.txt`
+- `help/trtllm_benchmark_serving.txt`
+
+Flag-count summary from the captured help:
+
+| CLI | Flags |
+| --- | ---: |
+| `python -m sglang.launch_server --help` | 384 |
+| `vllm serve --help=all` | 302 |
+| `vllm bench serve --help=all` | 97 |
+| `vllm bench sweep serve --help=all` | 15 |
+| `trtllm-serve serve --help` | 23 |
+| `python -m tensorrt_llm.serve.scripts.benchmark_serving --help` | 53 |
+
+GPUs 6 and 7 were not idle during this later audit, so the model-level parameter
+smoke used idle GPU 4 and is labeled as a one-GPU flow check.
+
+| Framework | Model | Expanded flags checked | Result |
+| --- | --- | --- | --- |
+| vLLM 0.19.1 | `TinyLlama/TinyLlama-1.1B-Chat-v1.0` | `--tensor-parallel-size 1`, `--gpu-memory-utilization 0.65`, `--max-model-len 2048`, `--max-num-seqs 16`, `--max-num-batched-tokens 4096`, `--enable-chunked-prefill`, `--kv-cache-dtype auto`, `--block-size 16`, `--enable-prefix-caching`, `--enforce-eager`, `--trust-remote-code` | pass: `model_smoke/vllm/results.json`; completed 4 requests |
+| TensorRT-LLM 1.0.0 | `TinyLlama/TinyLlama-1.1B-Chat-v1.0` | `--backend pytorch`, `--tp_size 1`, `--pp_size 1`, `--max_batch_size 8`, `--max_num_tokens 4096`, `--max_seq_len 2048`, `--kv_cache_free_gpu_memory_fraction 0.65`, `--trust_remote_code` | pass: `model_smoke/trtllm/results.json`; completed 4 requests |
+
+Audit lessons:
+
+- vLLM has a broad serving surface comparable to SGLang, but full discovery
+  requires `vllm serve --help=all` and `vllm bench serve --help=all`.
+- TensorRT-LLM's direct `trtllm-serve serve` flag surface is smaller. The server
+  logs show deeper PyTorch backend settings in `PyTorchConfig`, but many of
+  those settings are not top-level CLI flags.
+- TensorRT-LLM 1.0.0 benchmark serving uses `--backend openai` or
+  `--backend openai-chat`. `--backend trtllm` is rejected.
+- The vLLM server log recorded the expanded non-default args exactly; the
+  TensorRT-LLM server log recorded `max_seq_len`, `max_num_tokens`,
+  `max_batch_size`, and the KV-cache fraction behavior.
+
 The first smoke attempt for `Qwen/Qwen2.5-0.5B-Instruct` and
 `Qwen/Qwen2.5-1.5B-Instruct` had a bad SGLang artifact: the generated config was
 empty, so `python -m sglang.auto_benchmark run` failed before launching a real

--- a/skills/llm-serving-auto-benchmark/references/version-notes.md
+++ b/skills/llm-serving-auto-benchmark/references/version-notes.md
@@ -258,3 +258,24 @@ An earlier 10-candidate attempt in
 model and backend but omitted the multi-GPU Docker options above. Each candidate
 entered `PyTorchConfig` and then failed startup at NCCL allreduce. Keep those
 container options in the runbook for multi-GPU TensorRT-LLM validation.
+
+### Accuracy Evaluation Feasibility
+
+On 2026-04-22, the accuracy reporting path was checked against local source
+trees:
+
+- SGLang local checkout includes `python -m sglang.test.run_eval` with `mmlu`
+  and `gsm8k` tasks. Its MMLU simple-evals path aggregates subgroup metrics for
+  `stem`, `humanities`, `social_sciences`, and `other`.
+- vLLM local checkout uses `lm_eval.simple_evaluate` against an
+  OpenAI-compatible `/v1/completions` endpoint in its accuracy tests. The native
+  serving benchmark remains a latency/throughput tool, not an accuracy tool.
+- TensorRT-LLM 1.0.0 exposes OpenAI-compatible endpoints through
+  `trtllm-serve serve --backend pytorch`, so the same external evaluator can be
+  used after the best deployment command is chosen. The TensorRT-LLM benchmark
+  client does not produce MMLU/GSM8K accuracy.
+
+The skill therefore treats accuracy as an endpoint-level final-winner evaluation:
+run full MMLU and GSM8K through one common evaluator after the performance
+search, attach the resulting metrics to the selected candidate rows, and report
+MMLU subgroup scores when the evaluator provides them.

--- a/skills/llm-serving-auto-benchmark/references/version-notes.md
+++ b/skills/llm-serving-auto-benchmark/references/version-notes.md
@@ -258,24 +258,3 @@ An earlier 10-candidate attempt in
 model and backend but omitted the multi-GPU Docker options above. Each candidate
 entered `PyTorchConfig` and then failed startup at NCCL allreduce. Keep those
 container options in the runbook for multi-GPU TensorRT-LLM validation.
-
-### Accuracy Evaluation Feasibility
-
-On 2026-04-22, the accuracy reporting path was checked against local source
-trees:
-
-- SGLang local checkout includes `python -m sglang.test.run_eval` with `mmlu`
-  and `gsm8k` tasks. Its MMLU simple-evals path aggregates subgroup metrics for
-  `stem`, `humanities`, `social_sciences`, and `other`.
-- vLLM local checkout uses `lm_eval.simple_evaluate` against an
-  OpenAI-compatible `/v1/completions` endpoint in its accuracy tests. The native
-  serving benchmark remains a latency/throughput tool, not an accuracy tool.
-- TensorRT-LLM 1.0.0 exposes OpenAI-compatible endpoints through
-  `trtllm-serve serve --backend pytorch`, so the same external evaluator can be
-  used after the best deployment command is chosen. The TensorRT-LLM benchmark
-  client does not produce MMLU/GSM8K accuracy.
-
-The skill therefore treats accuracy as an endpoint-level final-winner evaluation:
-run full MMLU and GSM8K through one common evaluator after the performance
-search, attach the resulting metrics to the selected candidate rows, and report
-MMLU subgroup scores when the evaluator provides them.

--- a/skills/llm-serving-auto-benchmark/references/version-notes.md
+++ b/skills/llm-serving-auto-benchmark/references/version-notes.md
@@ -14,7 +14,7 @@ The initial skill text was informed by these local/source snapshots:
 | --- | --- | --- |
 | SGLang | local checkout `7044d5fe7`; H100 container package `sglang 0.5.10rc0` at repo commit `30cd2cf32` | SGLang `bench_serving` help was checked in the H100 validation container. |
 | vLLM | local checkout `ed2f282bc`; H100 image `vllm/vllm-openai:latest` with `vllm 0.19.1`; official docs for `vllm bench sweep serve` and benchmark sweeps | `vllm serve` and `vllm bench serve` were smoke-tested in the H100 validation image. |
-| TensorRT-LLM | H100 image `nvcr.io/nvidia/tensorrt-llm/release:latest` with `tensorrt_llm 1.0.0`; official `trtllm-serve` and serving benchmark docs current on 2026-04-22 | `trtllm-serve serve` and `tensorrt_llm.serve.scripts.benchmark_serving` were smoke-tested in the H100 validation image. |
+| TensorRT-LLM | H100 image `nvcr.io/nvidia/tensorrt-llm/release:latest` with `tensorrt_llm 1.0.0`; official `trtllm-serve` and serving benchmark docs current on 2026-04-22 | `trtllm-serve serve --backend pytorch` and `tensorrt_llm.serve.scripts.benchmark_serving` were smoke-tested in the H100 validation image. Non-PyTorch server backends are out of scope for this skill. |
 
 ## Update Rule
 
@@ -36,6 +36,9 @@ On 2026-04-22, validation used the `h100_sglang` host:
 - `nvcr.io/nvidia/tensorrt-llm/release:latest` image: `tensorrt_llm 1.0.0`.
 - Hugging Face access came from the local H100 skill and was passed as
   environment variables. Do not print the token into logs.
+- TensorRT-LLM serving is pinned to `trtllm-serve serve --backend pytorch` in
+  this skill. Engine-backed and other non-PyTorch TensorRT-LLM server backends
+  are intentionally rejected instead of searched.
 
 ### Parameter Audit
 

--- a/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
+++ b/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
@@ -300,6 +300,8 @@ def render_markdown(rows: list[dict[str, Any]]) -> str:
                 "",
                 "## Failed Or SLA-Failing Candidates",
                 "",
+                "These rows are an audit trail for explored but non-recommended configs. They either failed, were skipped by policy, or completed without passing the SLA.",
+                "",
                 "| Framework | Candidate | Status | SLA | Reason |",
                 "| --- | --- | --- | --- | --- |",
             ]

--- a/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
+++ b/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
@@ -109,15 +109,6 @@ def load_rows(path: Path) -> list[dict[str, Any]]:
     return rows
 
 
-def best_by_framework(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    best: dict[str, dict[str, Any]] = {}
-    for row in rows:
-        framework = str(_get(row, "framework", "unknown"))
-        if framework not in best or _rank_key(row) > _rank_key(best[framework]):
-            best[framework] = row
-    return sorted(best.values(), key=_rank_key, reverse=True)
-
-
 def best_by_framework_and_scenario(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     best: dict[tuple[str, str], dict[str, Any]] = {}
     for row in rows:
@@ -240,54 +231,15 @@ def _append_cross_framework_table(
 
 
 def render_markdown(rows: list[dict[str, Any]]) -> str:
-    ranked = sorted(rows, key=_rank_key, reverse=True)
-    winners = best_by_framework(rows)
     scenario_winners = best_by_framework_and_scenario(rows)
-    overall = ranked[0] if ranked else None
 
     lines = ["# Benchmark Summary", ""]
-    if overall is None:
+    if not rows:
         lines.append("No rows found.")
         return "\n".join(lines) + "\n"
 
-    lines.extend(
-        [
-            "## Overall Winner",
-            "",
-            f"- Framework: `{_get(overall, 'framework', 'unknown')}`",
-            f"- Candidate: `{_get(overall, 'candidate_id', 'unknown')}`",
-            f"- SLA passed: `{_bool(overall, 'sla.passed')}`",
-            f"- Request throughput: `{_fmt(_get(overall, 'metrics.request_throughput'))}`",
-            f"- Output token throughput: `{_fmt(_get(overall, 'metrics.output_token_throughput'))}`",
-            "",
-        ]
-    )
-
     _append_best_commands_by_framework(lines, scenario_winners)
     _append_cross_framework_table(lines, scenario_winners)
-
-    lines.extend(
-        [
-            "## Best Per Framework",
-            "",
-            "| Framework | Candidate | Status | SLA | Req/s | Output tok/s | P99 TTFT ms | P99 TPOT ms | GPUs |",
-            "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |",
-        ]
-    )
-    for row in winners:
-        lines.append(
-            "| {framework} | {candidate} | {status} | {sla} | {rps} | {otps} | {ttft} | {tpot} | {gpus} |".format(
-                framework=_get(row, "framework", ""),
-                candidate=_get(row, "candidate_id", ""),
-                status=_get(row, "status", ""),
-                sla=_bool(row, "sla.passed"),
-                rps=_fmt(_get(row, "metrics.request_throughput")),
-                otps=_fmt(_get(row, "metrics.output_token_throughput")),
-                ttft=_fmt(_get(row, "metrics.p99_ttft_ms")),
-                tpot=_fmt(_get(row, "metrics.p99_tpot_ms")),
-                gpus=_fmt(_get(row, "hardware.gpu_count")),
-            )
-        )
 
     failed = [
         row
@@ -300,7 +252,7 @@ def render_markdown(rows: list[dict[str, Any]]) -> str:
                 "",
                 "## Failed Or SLA-Failing Candidates",
                 "",
-                "These rows are an audit trail for explored but non-recommended configs. They either failed, were skipped by policy, or completed without passing the SLA.",
+                "This table records tried configs that were not selected. They either failed, were skipped by policy, or completed without passing the SLA.",
                 "",
                 "| Framework | Candidate | Status | SLA | Reason |",
                 "| --- | --- | --- | --- | --- |",

--- a/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
+++ b/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
@@ -56,10 +56,6 @@ def _fmt(value: Any, digits: int = 2) -> str:
     return str(value)
 
 
-def _blank_none(value: Any) -> Any:
-    return "" if value is None else value
-
-
 def _cell(value: Any, digits: int = 2) -> str:
     text = _fmt(value, digits)
     return text.replace("\n", "<br>").replace("|", "\\|")
@@ -94,70 +90,6 @@ def _artifact_summary(row: dict[str, Any]) -> str:
         if value:
             parts.append(f"{key}: {value}")
     return "<br>".join(parts)
-
-
-def _accuracy_score(row: dict[str, Any], task: str) -> Any:
-    for path in (
-        f"accuracy.{task}.accuracy",
-        f"accuracy.{task}.score",
-        f"accuracy.{task}.exact_match",
-        f"evals.{task}.accuracy",
-        f"evals.{task}.score",
-    ):
-        value = _get(row, path)
-        if value is not None:
-            return value
-    return None
-
-
-def _accuracy_count(row: dict[str, Any], task: str) -> Any:
-    for path in (
-        f"accuracy.{task}.num_examples",
-        f"accuracy.{task}.num_requests",
-        f"accuracy.{task}.samples",
-        f"evals.{task}.num_examples",
-    ):
-        value = _get(row, path)
-        if value is not None:
-            return value
-    return None
-
-
-def _mmlu_subcategory(row: dict[str, Any], name: str) -> Any:
-    for path in (
-        f"accuracy.mmlu.subcategories.{name}",
-        f"accuracy.mmlu.metrics.{name}",
-        f"accuracy.mmlu.{name}",
-        f"evals.mmlu.subcategories.{name}",
-        f"evals.mmlu.metrics.{name}",
-    ):
-        value = _get(row, path)
-        if value is not None:
-            return value
-    return None
-
-
-def _accuracy_artifacts(row: dict[str, Any]) -> str:
-    parts = []
-    for task in ("mmlu", "gsm8k"):
-        for path in (
-            f"accuracy.{task}.artifact",
-            f"accuracy.{task}.result_file",
-            f"accuracy.{task}.report",
-            f"evals.{task}.artifact",
-        ):
-            value = _get(row, path)
-            if value:
-                parts.append(f"{task}: {value}")
-                break
-    return "<br>".join(parts)
-
-
-def _has_accuracy(row: dict[str, Any]) -> bool:
-    return (
-        _accuracy_score(row, "mmlu") is not None
-        or _accuracy_score(row, "gsm8k") is not None
-    )
 
 
 def load_rows(path: Path) -> list[dict[str, Any]]:
@@ -209,8 +141,6 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         "p99_ttft_ms",
         "p99_tpot_ms",
         "gpu_count",
-        "mmlu_accuracy",
-        "gsm8k_accuracy",
         "server_command",
         "failure_reason",
     ]
@@ -232,8 +162,6 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
                     "p99_ttft_ms": _get(row, "metrics.p99_ttft_ms", ""),
                     "p99_tpot_ms": _get(row, "metrics.p99_tpot_ms", ""),
                     "gpu_count": _get(row, "hardware.gpu_count", ""),
-                    "mmlu_accuracy": _blank_none(_accuracy_score(row, "mmlu")),
-                    "gsm8k_accuracy": _blank_none(_accuracy_score(row, "gsm8k")),
                     "server_command": _server_command(row),
                     "failure_reason": _get(row, "failure_reason", ""),
                 }
@@ -311,48 +239,6 @@ def _append_cross_framework_table(
     lines.append("")
 
 
-def _append_accuracy_table(
-    lines: list[str], scenario_winners: list[dict[str, Any]]
-) -> None:
-    selected: dict[tuple[str, str], dict[str, Any]] = {}
-    scenarios_by_key: dict[tuple[str, str], set[str]] = {}
-    for row in scenario_winners:
-        key = (str(_get(row, "framework", "")), str(_get(row, "candidate_id", "")))
-        if key not in selected or (
-            not _has_accuracy(selected[key]) and _has_accuracy(row)
-        ):
-            selected[key] = row
-        scenarios_by_key.setdefault(key, set()).add(_scenario(row))
-
-    lines.extend(
-        [
-            "## Accuracy Of Selected Deployment Commands",
-            "",
-            "| Framework | Candidate | Scenarios | MMLU | MMLU stem | MMLU humanities | MMLU social sciences | MMLU other | GSM8K | MMLU examples | GSM8K examples | Accuracy artifacts |",
-            "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
-        ]
-    )
-    for key, row in sorted(selected.items()):
-        scenarios = ", ".join(sorted(scenarios_by_key.get(key, set())))
-        lines.append(
-            "| {framework} | {candidate} | {scenarios} | {mmlu} | {stem} | {humanities} | {social} | {other} | {gsm8k} | {mmlu_n} | {gsm8k_n} | {artifacts} |".format(
-                framework=_cell(key[0]),
-                candidate=_cell(key[1]),
-                scenarios=_cell(scenarios),
-                mmlu=_cell(_accuracy_score(row, "mmlu"), digits=4),
-                stem=_cell(_mmlu_subcategory(row, "stem"), digits=4),
-                humanities=_cell(_mmlu_subcategory(row, "humanities"), digits=4),
-                social=_cell(_mmlu_subcategory(row, "social_sciences"), digits=4),
-                other=_cell(_mmlu_subcategory(row, "other"), digits=4),
-                gsm8k=_cell(_accuracy_score(row, "gsm8k"), digits=4),
-                mmlu_n=_cell(_accuracy_count(row, "mmlu"), digits=0),
-                gsm8k_n=_cell(_accuracy_count(row, "gsm8k"), digits=0),
-                artifacts=_cell(_accuracy_artifacts(row)),
-            )
-        )
-    lines.append("")
-
-
 def render_markdown(rows: list[dict[str, Any]]) -> str:
     ranked = sorted(rows, key=_rank_key, reverse=True)
     winners = best_by_framework(rows)
@@ -379,7 +265,6 @@ def render_markdown(rows: list[dict[str, Any]]) -> str:
 
     _append_best_commands_by_framework(lines, scenario_winners)
     _append_cross_framework_table(lines, scenario_winners)
-    _append_accuracy_table(lines, scenario_winners)
 
     lines.extend(
         [

--- a/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
+++ b/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
@@ -48,6 +48,10 @@ def _rank_key(row: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
+def _is_winner_candidate(row: dict[str, Any]) -> bool:
+    return _get(row, "status") == "ok" and _bool(row, "sla.passed")
+
+
 def _fmt(value: Any, digits: int = 2) -> str:
     if value is None:
         return ""
@@ -112,6 +116,8 @@ def load_rows(path: Path) -> list[dict[str, Any]]:
 def best_by_framework_and_scenario(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     best: dict[tuple[str, str], dict[str, Any]] = {}
     for row in rows:
+        if not _is_winner_candidate(row):
+            continue
         key = (str(_get(row, "framework", "unknown")), _scenario(row))
         if key not in best or _rank_key(row) > _rank_key(best[key]):
             best[key] = row

--- a/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
+++ b/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
@@ -56,6 +56,110 @@ def _fmt(value: Any, digits: int = 2) -> str:
     return str(value)
 
 
+def _blank_none(value: Any) -> Any:
+    return "" if value is None else value
+
+
+def _cell(value: Any, digits: int = 2) -> str:
+    text = _fmt(value, digits)
+    return text.replace("\n", "<br>").replace("|", "\\|")
+
+
+def _scenario(row: dict[str, Any]) -> str:
+    for path in (
+        "workload.scenario",
+        "workload.scenario_name",
+        "workload.dataset_scenario",
+        "workload.dataset_name",
+        "workload.kind",
+        "scenario",
+    ):
+        value = _get(row, path)
+        if value:
+            return str(value)
+    return "default"
+
+
+def _server_command(row: dict[str, Any]) -> str:
+    return str(_get(row, "server_command") or _get(row, "launch_command") or "")
+
+
+def _artifact_summary(row: dict[str, Any]) -> str:
+    artifacts = _get(row, "artifacts", {})
+    if not isinstance(artifacts, dict):
+        return ""
+    parts = []
+    for key in ("raw_result", "server_log", "benchmark_log", "summary"):
+        value = artifacts.get(key)
+        if value:
+            parts.append(f"{key}: {value}")
+    return "<br>".join(parts)
+
+
+def _accuracy_score(row: dict[str, Any], task: str) -> Any:
+    for path in (
+        f"accuracy.{task}.accuracy",
+        f"accuracy.{task}.score",
+        f"accuracy.{task}.exact_match",
+        f"evals.{task}.accuracy",
+        f"evals.{task}.score",
+    ):
+        value = _get(row, path)
+        if value is not None:
+            return value
+    return None
+
+
+def _accuracy_count(row: dict[str, Any], task: str) -> Any:
+    for path in (
+        f"accuracy.{task}.num_examples",
+        f"accuracy.{task}.num_requests",
+        f"accuracy.{task}.samples",
+        f"evals.{task}.num_examples",
+    ):
+        value = _get(row, path)
+        if value is not None:
+            return value
+    return None
+
+
+def _mmlu_subcategory(row: dict[str, Any], name: str) -> Any:
+    for path in (
+        f"accuracy.mmlu.subcategories.{name}",
+        f"accuracy.mmlu.metrics.{name}",
+        f"accuracy.mmlu.{name}",
+        f"evals.mmlu.subcategories.{name}",
+        f"evals.mmlu.metrics.{name}",
+    ):
+        value = _get(row, path)
+        if value is not None:
+            return value
+    return None
+
+
+def _accuracy_artifacts(row: dict[str, Any]) -> str:
+    parts = []
+    for task in ("mmlu", "gsm8k"):
+        for path in (
+            f"accuracy.{task}.artifact",
+            f"accuracy.{task}.result_file",
+            f"accuracy.{task}.report",
+            f"evals.{task}.artifact",
+        ):
+            value = _get(row, path)
+            if value:
+                parts.append(f"{task}: {value}")
+                break
+    return "<br>".join(parts)
+
+
+def _has_accuracy(row: dict[str, Any]) -> bool:
+    return (
+        _accuracy_score(row, "mmlu") is not None
+        or _accuracy_score(row, "gsm8k") is not None
+    )
+
+
 def load_rows(path: Path) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     with path.open(encoding="utf-8") as f:
@@ -82,9 +186,21 @@ def best_by_framework(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return sorted(best.values(), key=_rank_key, reverse=True)
 
 
+def best_by_framework_and_scenario(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    best: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in rows:
+        key = (str(_get(row, "framework", "unknown")), _scenario(row))
+        if key not in best or _rank_key(row) > _rank_key(best[key]):
+            best[key] = row
+    return sorted(
+        best.values(), key=lambda row: (_scenario(row), _rank_key(row)), reverse=True
+    )
+
+
 def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
     fields = [
         "framework",
+        "scenario",
         "candidate_id",
         "status",
         "sla_passed",
@@ -93,6 +209,9 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         "p99_ttft_ms",
         "p99_tpot_ms",
         "gpu_count",
+        "mmlu_accuracy",
+        "gsm8k_accuracy",
+        "server_command",
         "failure_reason",
     ]
     with path.open("w", encoding="utf-8", newline="") as f:
@@ -102,6 +221,7 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
             writer.writerow(
                 {
                     "framework": _get(row, "framework", ""),
+                    "scenario": _scenario(row),
                     "candidate_id": _get(row, "candidate_id", ""),
                     "status": _get(row, "status", ""),
                     "sla_passed": _bool(row, "sla.passed"),
@@ -112,14 +232,131 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
                     "p99_ttft_ms": _get(row, "metrics.p99_ttft_ms", ""),
                     "p99_tpot_ms": _get(row, "metrics.p99_tpot_ms", ""),
                     "gpu_count": _get(row, "hardware.gpu_count", ""),
+                    "mmlu_accuracy": _blank_none(_accuracy_score(row, "mmlu")),
+                    "gsm8k_accuracy": _blank_none(_accuracy_score(row, "gsm8k")),
+                    "server_command": _server_command(row),
                     "failure_reason": _get(row, "failure_reason", ""),
                 }
             )
 
 
+def _append_best_commands_by_framework(
+    lines: list[str], scenario_winners: list[dict[str, Any]]
+) -> None:
+    frameworks = sorted(
+        {str(_get(row, "framework", "unknown")) for row in scenario_winners}
+    )
+    lines.extend(["## Best Commands By Framework", ""])
+    for framework in frameworks:
+        lines.extend(
+            [
+                f"### `{framework}`",
+                "",
+                "| Scenario | Candidate | Status | SLA | Req/s | Output tok/s | Total tok/s | P99 TTFT ms | P99 TPOT ms | Success rate | GPUs | Server command | Artifacts |",
+                "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |",
+            ]
+        )
+        rows = [row for row in scenario_winners if _get(row, "framework") == framework]
+        for row in sorted(rows, key=_scenario):
+            lines.append(
+                "| {scenario} | {candidate} | {status} | {sla} | {rps} | {otps} | {ttps} | {ttft} | {tpot} | {success} | {gpus} | {command} | {artifacts} |".format(
+                    scenario=_cell(_scenario(row)),
+                    candidate=_cell(_get(row, "candidate_id", "")),
+                    status=_cell(_get(row, "status", "")),
+                    sla=_cell(_bool(row, "sla.passed")),
+                    rps=_cell(_get(row, "metrics.request_throughput")),
+                    otps=_cell(_get(row, "metrics.output_token_throughput")),
+                    ttps=_cell(_get(row, "metrics.total_token_throughput")),
+                    ttft=_cell(_get(row, "metrics.p99_ttft_ms")),
+                    tpot=_cell(_get(row, "metrics.p99_tpot_ms")),
+                    success=_cell(_get(row, "metrics.success_rate")),
+                    gpus=_cell(_get(row, "hardware.gpu_count")),
+                    command=_cell(_server_command(row)),
+                    artifacts=_cell(_artifact_summary(row)),
+                )
+            )
+        lines.append("")
+
+
+def _append_cross_framework_table(
+    lines: list[str], scenario_winners: list[dict[str, Any]]
+) -> None:
+    lines.extend(
+        [
+            "## Cross-Framework Best Comparison",
+            "",
+            "| Scenario | Rank | Framework | Candidate | SLA | Req/s | Output tok/s | P99 TTFT ms | P99 TPOT ms | GPUs | Server command |",
+            "| --- | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |",
+        ]
+    )
+    scenario_names = sorted({_scenario(row) for row in scenario_winners})
+    for scenario_name in scenario_names:
+        rows = [row for row in scenario_winners if _scenario(row) == scenario_name]
+        for rank, row in enumerate(sorted(rows, key=_rank_key, reverse=True), 1):
+            lines.append(
+                "| {scenario} | {rank} | {framework} | {candidate} | {sla} | {rps} | {otps} | {ttft} | {tpot} | {gpus} | {command} |".format(
+                    scenario=_cell(scenario_name),
+                    rank=rank,
+                    framework=_cell(_get(row, "framework", "")),
+                    candidate=_cell(_get(row, "candidate_id", "")),
+                    sla=_cell(_bool(row, "sla.passed")),
+                    rps=_cell(_get(row, "metrics.request_throughput")),
+                    otps=_cell(_get(row, "metrics.output_token_throughput")),
+                    ttft=_cell(_get(row, "metrics.p99_ttft_ms")),
+                    tpot=_cell(_get(row, "metrics.p99_tpot_ms")),
+                    gpus=_cell(_get(row, "hardware.gpu_count")),
+                    command=_cell(_server_command(row)),
+                )
+            )
+    lines.append("")
+
+
+def _append_accuracy_table(
+    lines: list[str], scenario_winners: list[dict[str, Any]]
+) -> None:
+    selected: dict[tuple[str, str], dict[str, Any]] = {}
+    scenarios_by_key: dict[tuple[str, str], set[str]] = {}
+    for row in scenario_winners:
+        key = (str(_get(row, "framework", "")), str(_get(row, "candidate_id", "")))
+        if key not in selected or (
+            not _has_accuracy(selected[key]) and _has_accuracy(row)
+        ):
+            selected[key] = row
+        scenarios_by_key.setdefault(key, set()).add(_scenario(row))
+
+    lines.extend(
+        [
+            "## Accuracy Of Selected Deployment Commands",
+            "",
+            "| Framework | Candidate | Scenarios | MMLU | MMLU stem | MMLU humanities | MMLU social sciences | MMLU other | GSM8K | MMLU examples | GSM8K examples | Accuracy artifacts |",
+            "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
+        ]
+    )
+    for key, row in sorted(selected.items()):
+        scenarios = ", ".join(sorted(scenarios_by_key.get(key, set())))
+        lines.append(
+            "| {framework} | {candidate} | {scenarios} | {mmlu} | {stem} | {humanities} | {social} | {other} | {gsm8k} | {mmlu_n} | {gsm8k_n} | {artifacts} |".format(
+                framework=_cell(key[0]),
+                candidate=_cell(key[1]),
+                scenarios=_cell(scenarios),
+                mmlu=_cell(_accuracy_score(row, "mmlu"), digits=4),
+                stem=_cell(_mmlu_subcategory(row, "stem"), digits=4),
+                humanities=_cell(_mmlu_subcategory(row, "humanities"), digits=4),
+                social=_cell(_mmlu_subcategory(row, "social_sciences"), digits=4),
+                other=_cell(_mmlu_subcategory(row, "other"), digits=4),
+                gsm8k=_cell(_accuracy_score(row, "gsm8k"), digits=4),
+                mmlu_n=_cell(_accuracy_count(row, "mmlu"), digits=0),
+                gsm8k_n=_cell(_accuracy_count(row, "gsm8k"), digits=0),
+                artifacts=_cell(_accuracy_artifacts(row)),
+            )
+        )
+    lines.append("")
+
+
 def render_markdown(rows: list[dict[str, Any]]) -> str:
     ranked = sorted(rows, key=_rank_key, reverse=True)
     winners = best_by_framework(rows)
+    scenario_winners = best_by_framework_and_scenario(rows)
     overall = ranked[0] if ranked else None
 
     lines = ["# Benchmark Summary", ""]
@@ -137,6 +374,15 @@ def render_markdown(rows: list[dict[str, Any]]) -> str:
             f"- Request throughput: `{_fmt(_get(overall, 'metrics.request_throughput'))}`",
             f"- Output token throughput: `{_fmt(_get(overall, 'metrics.output_token_throughput'))}`",
             "",
+        ]
+    )
+
+    _append_best_commands_by_framework(lines, scenario_winners)
+    _append_cross_framework_table(lines, scenario_winners)
+    _append_accuracy_table(lines, scenario_winners)
+
+    lines.extend(
+        [
             "## Best Per Framework",
             "",
             "| Framework | Candidate | Status | SLA | Req/s | Output tok/s | P99 TTFT ms | P99 TPOT ms | GPUs |",

--- a/skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py
+++ b/skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Validate cross-framework cookbook benchmark configs.
+
+The validator is intentionally shallow: it proves that every config can be
+loaded, translated into bounded candidate commands, and checked against the
+known server flag surface. It does not launch model servers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import re
+import shlex
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+FRAMEWORKS = ("sglang", "vllm", "tensorrt_llm")
+
+STATIC_SERVER_FLAGS = {
+    "sglang": {
+        "attention_backend",
+        "chunked_prefill_size",
+        "context_length",
+        "decode_attention_backend",
+        "dllm_algorithm",
+        "dtype",
+        "enable_multimodal",
+        "enable_symm_mem",
+        "ep_size",
+        "host",
+        "kv_cache_dtype",
+        "max_running_requests",
+        "mem_fraction_static",
+        "model_loader_extra_config",
+        "model_path",
+        "moe_runner_backend",
+        "nnodes",
+        "port",
+        "pp_size",
+        "prefill_attention_backend",
+        "reasoning_parser",
+        "schedule_policy",
+        "tool_call_parser",
+        "tp_size",
+        "trust_remote_code",
+    },
+    "vllm": {
+        "block_size",
+        "dtype",
+        "enable_chunked_prefill",
+        "enable_prefix_caching",
+        "gpu_memory_utilization",
+        "host",
+        "kv_cache_dtype",
+        "long_prefill_token_threshold",
+        "max_long_partial_prefills",
+        "max_model_len",
+        "max_num_batched_tokens",
+        "max_num_partial_prefills",
+        "max_num_seqs",
+        "pipeline_parallel_size",
+        "port",
+        "tensor_parallel_size",
+        "trust_remote_code",
+    },
+    "tensorrt_llm": {
+        "backend",
+        "ep_size",
+        "extra_llm_api_options",
+        "host",
+        "kv_cache_free_gpu_memory_fraction",
+        "max_batch_size",
+        "max_num_tokens",
+        "max_seq_len",
+        "port",
+        "pp_size",
+        "tp_size",
+        "trust_remote_code",
+    },
+}
+
+HELP_FILE_HINTS = {
+    "sglang": ("sglang", "launch"),
+    "vllm": ("vllm", "serve"),
+    "tensorrt_llm": ("trtllm", "serve"),
+}
+
+
+def flag_name(framework: str, key: str) -> str:
+    if framework in {"sglang", "vllm"}:
+        return "--" + key.replace("_", "-")
+    return "--" + key
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: expected a YAML mapping")
+    return data
+
+
+def _as_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _enabled(config: dict[str, Any], framework: str) -> bool:
+    return bool(config.get("frameworks", {}).get(framework, {}).get("enabled", False))
+
+
+def _max_required_sequence(dataset: dict[str, Any]) -> int:
+    input_len = dataset.get("input_len")
+    output_len = dataset.get("output_len")
+    if not isinstance(input_len, list) or not isinstance(output_len, list):
+        raise ValueError("dataset.input_len and dataset.output_len must be lists")
+    if len(input_len) != len(output_len):
+        raise ValueError("dataset.input_len and dataset.output_len must be aligned")
+    return max(int(i) + int(o) for i, o in zip(input_len, output_len, strict=True))
+
+
+def _candidate_dicts(
+    base_flags: dict[str, Any],
+    search_space: dict[str, Any],
+    limit: int,
+) -> list[dict[str, Any]]:
+    candidates = [dict(base_flags)]
+    keys = list(search_space)
+    values = [_as_list(search_space[key]) for key in keys]
+    for combo in itertools.product(*values):
+        candidate = dict(base_flags)
+        candidate.update(dict(zip(keys, combo, strict=True)))
+        if candidate not in candidates:
+            candidates.append(candidate)
+        if len(candidates) >= limit:
+            break
+    return candidates
+
+
+def _command_tokens(
+    framework: str,
+    config: dict[str, Any],
+    flags: dict[str, Any],
+) -> list[str]:
+    server = config["frameworks"][framework]
+    command = shlex.split(server["server_command"])
+    model = config["model"]["name"]
+
+    if framework in {"vllm", "tensorrt_llm"}:
+        command.append(model)
+
+    for key, value in flags.items():
+        if value is None or value is False:
+            continue
+        command.append(flag_name(framework, key))
+        if value is not True:
+            command.append(str(value))
+
+    return command
+
+
+def render_command(
+    framework: str, config: dict[str, Any], flags: dict[str, Any]
+) -> str:
+    return shlex.join(_command_tokens(framework, config, flags))
+
+
+def _extract_help_flags(text: str) -> set[str]:
+    return {
+        item.lstrip("-") for item in re.findall(r"--[A-Za-z0-9][A-Za-z0-9_-]*", text)
+    }
+
+
+def load_help_flags(help_dir: Path) -> dict[str, set[str]]:
+    help_flags: dict[str, set[str]] = {}
+    for framework, hints in HELP_FILE_HINTS.items():
+        matches = []
+        for path in help_dir.rglob("*.txt"):
+            name = path.name.lower()
+            if all(hint in name for hint in hints):
+                matches.append(path)
+        if matches:
+            text = "\n".join(
+                path.read_text(encoding="utf-8", errors="replace") for path in matches
+            )
+            help_flags[framework] = _extract_help_flags(text)
+    return help_flags
+
+
+def _known_flag(
+    framework: str,
+    key: str,
+    help_flags: dict[str, set[str]] | None,
+) -> bool:
+    static_keys = STATIC_SERVER_FLAGS[framework]
+    if key not in static_keys:
+        return False
+    if not help_flags or framework not in help_flags:
+        return True
+
+    concrete = flag_name(framework, key).lstrip("-")
+    aliases = {concrete, concrete.replace("-", "_"), concrete.replace("_", "-")}
+    return bool(aliases & help_flags[framework])
+
+
+def _validate_framework(
+    config: dict[str, Any],
+    framework: str,
+    help_flags: dict[str, set[str]] | None,
+) -> list[str]:
+    errors: list[str] = []
+    server = config["frameworks"].get(framework)
+    if not isinstance(server, dict):
+        return [f"missing frameworks.{framework}"]
+    if not server.get("enabled", False):
+        return []
+
+    base_flags = server.get("base_server_flags")
+    search_space = server.get("search_space")
+    if not isinstance(base_flags, dict):
+        errors.append(f"{framework}: base_server_flags must be a mapping")
+        base_flags = {}
+    if not isinstance(search_space, dict):
+        errors.append(f"{framework}: search_space must be a mapping")
+        search_space = {}
+    if not isinstance(server.get("server_command"), str):
+        errors.append(f"{framework}: server_command must be a string")
+
+    for key in set(base_flags) | set(search_space):
+        if not _known_flag(framework, key, help_flags):
+            errors.append(f"{framework}: unknown or unsupported server flag {key!r}")
+
+    if framework == "tensorrt_llm":
+        if server.get("backend_policy") != "fixed_pytorch":
+            errors.append("tensorrt_llm: backend_policy must be fixed_pytorch")
+        if base_flags.get("backend") != "pytorch":
+            errors.append("tensorrt_llm: base backend must be pytorch")
+        if "backend" in search_space:
+            errors.append("tensorrt_llm: backend must not appear in search_space")
+
+    max_candidates = int(config["search"].get("max_candidates_per_framework", 1))
+    candidates = _candidate_dicts(base_flags, search_space, max_candidates)
+    if not candidates:
+        errors.append(f"{framework}: no candidates generated")
+    for candidate in candidates:
+        command = render_command(framework, config, candidate)
+        if not command:
+            errors.append(f"{framework}: rendered an empty command")
+
+    return errors
+
+
+def validate_config(
+    path: Path,
+    help_flags: dict[str, set[str]] | None = None,
+) -> list[str]:
+    errors: list[str] = []
+    try:
+        config = load_yaml(path)
+    except Exception as exc:  # noqa: BLE001
+        return [str(exc)]
+
+    if config.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+    if not isinstance(config.get("model", {}).get("name"), str):
+        errors.append("model.name must be set")
+    if config.get("source", {}).get("kind") != "sglang_auto_benchmark_cookbook":
+        errors.append("source.kind must be sglang_auto_benchmark_cookbook")
+
+    try:
+        required_sequence = _max_required_sequence(config["dataset"])
+    except Exception as exc:  # noqa: BLE001
+        errors.append(str(exc))
+        required_sequence = 0
+
+    if int(config.get("search", {}).get("max_candidates_per_framework", 0)) < 1:
+        errors.append("search.max_candidates_per_framework must be positive")
+
+    frameworks = config.get("frameworks")
+    if not isinstance(frameworks, dict):
+        return errors + ["frameworks must be a mapping"]
+
+    for framework in FRAMEWORKS:
+        errors.extend(_validate_framework(config, framework, help_flags))
+
+    if _enabled(config, "sglang"):
+        sglang_flags = frameworks["sglang"]["base_server_flags"]
+        context_length = int(sglang_flags.get("context_length", required_sequence))
+        if context_length < required_sequence:
+            errors.append(
+                "sglang: context_length is smaller than the largest dataset scenario"
+            )
+
+    if _enabled(config, "vllm"):
+        vllm_flags = frameworks["vllm"]["base_server_flags"]
+        if int(vllm_flags.get("max_model_len", 0)) < required_sequence:
+            errors.append(
+                "vllm: max_model_len is smaller than the largest dataset scenario"
+            )
+
+    if _enabled(config, "tensorrt_llm"):
+        trt_flags = frameworks["tensorrt_llm"]["base_server_flags"]
+        if int(trt_flags.get("max_seq_len", 0)) < required_sequence:
+            errors.append(
+                "tensorrt_llm: max_seq_len is smaller than the largest dataset scenario"
+            )
+
+    return errors
+
+
+def iter_config_files(paths: list[Path]) -> list[Path]:
+    files: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            files.extend(sorted(path.rglob("*.yaml")))
+            files.extend(sorted(path.rglob("*.yml")))
+        else:
+            files.append(path)
+    return sorted(dict.fromkeys(files))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="+", type=Path)
+    parser.add_argument("--help-dir", type=Path)
+    parser.add_argument("--print-commands", action="store_true")
+    args = parser.parse_args()
+
+    help_flags = load_help_flags(args.help_dir) if args.help_dir else None
+    failed = False
+    for path in iter_config_files(args.paths):
+        errors = validate_config(path, help_flags)
+        if errors:
+            failed = True
+            for error in errors:
+                print(f"{path}: {error}")
+            continue
+
+        if args.print_commands:
+            config = load_yaml(path)
+            limit = int(config["search"].get("max_candidates_per_framework", 1))
+            for framework in FRAMEWORKS:
+                if not _enabled(config, framework):
+                    continue
+                server = config["frameworks"][framework]
+                candidates = _candidate_dicts(
+                    server["base_server_flags"],
+                    server["search_space"],
+                    limit,
+                )
+                print(f"# {path.name} {framework}")
+                print(render_command(framework, config, candidates[0]))
+
+    if failed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_compare_benchmark_results.py
+++ b/tests/test_compare_benchmark_results.py
@@ -28,12 +28,13 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
     def setUp(self) -> None:
         self.mod = load_module()
 
-    def test_best_candidate_prefers_successful_sla_passing_rows(self) -> None:
+    def test_scenario_winner_prefers_successful_sla_passing_rows(self) -> None:
         rows = [
             {
                 "framework": "sglang",
                 "candidate_id": "sglang-fast-fail",
                 "status": "ok",
+                "workload": {"scenario": "chat"},
                 "sla": {"passed": False},
                 "metrics": {
                     "request_throughput": 99,
@@ -47,6 +48,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                 "framework": "sglang",
                 "candidate_id": "sglang-steady",
                 "status": "ok",
+                "workload": {"scenario": "chat"},
                 "sla": {"passed": True},
                 "metrics": {
                     "request_throughput": 10,
@@ -60,6 +62,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                 "framework": "vllm",
                 "candidate_id": "vllm-best",
                 "status": "ok",
+                "workload": {"scenario": "chat"},
                 "sla": {"passed": True},
                 "metrics": {
                     "request_throughput": 12,
@@ -71,18 +74,19 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
             },
         ]
 
-        winners = self.mod.best_by_framework(rows)
+        winners = self.mod.best_by_framework_and_scenario(rows)
         self.assertEqual(
             [row["candidate_id"] for row in winners],
             ["vllm-best", "sglang-steady"],
         )
 
         summary = self.mod.render_markdown(rows)
-        self.assertIn("`vllm`", summary)
         self.assertIn("sglang-fast-fail", summary)
         self.assertIn("Best Commands By Framework", summary)
         self.assertIn("Cross-Framework Best Comparison", summary)
-        self.assertIn("audit trail for explored but non-recommended configs", summary)
+        self.assertNotIn("Overall Winner", summary)
+        self.assertNotIn("Best Per Framework", summary)
+        self.assertIn("records tried configs that were not selected", summary)
 
     def test_load_rows_rejects_non_object_json(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -175,6 +179,8 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
         self.assertIn("### `sglang`", summary)
         self.assertIn("| chat | sglang-c1", summary)
         self.assertIn("| summarization | sglang-c2", summary)
+        self.assertNotIn("Overall Winner", summary)
+        self.assertNotIn("Best Per Framework", summary)
         self.assertNotIn("Accuracy Of Selected Deployment Commands", summary)
         self.assertNotIn("MMLU", summary)
         self.assertNotIn("GSM8K", summary)

--- a/tests/test_compare_benchmark_results.py
+++ b/tests/test_compare_benchmark_results.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "llm-serving-auto-benchmark"
+    / "scripts"
+    / "compare_benchmark_results.py"
+)
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("compare_benchmark_results", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class CompareBenchmarkResultsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_best_candidate_prefers_successful_sla_passing_rows(self) -> None:
+        rows = [
+            {
+                "framework": "sglang",
+                "candidate_id": "sglang-fast-fail",
+                "status": "ok",
+                "sla": {"passed": False},
+                "metrics": {
+                    "request_throughput": 99,
+                    "output_token_throughput": 990,
+                    "p99_ttft_ms": 1,
+                    "p99_tpot_ms": 1,
+                },
+                "hardware": {"gpu_count": 1},
+            },
+            {
+                "framework": "sglang",
+                "candidate_id": "sglang-steady",
+                "status": "ok",
+                "sla": {"passed": True},
+                "metrics": {
+                    "request_throughput": 10,
+                    "output_token_throughput": 100,
+                    "p99_ttft_ms": 50,
+                    "p99_tpot_ms": 5,
+                },
+                "hardware": {"gpu_count": 1},
+            },
+            {
+                "framework": "vllm",
+                "candidate_id": "vllm-best",
+                "status": "ok",
+                "sla": {"passed": True},
+                "metrics": {
+                    "request_throughput": 12,
+                    "output_token_throughput": 90,
+                    "p99_ttft_ms": 60,
+                    "p99_tpot_ms": 6,
+                },
+                "hardware": {"gpu_count": 1},
+            },
+        ]
+
+        winners = self.mod.best_by_framework(rows)
+        self.assertEqual([row["candidate_id"] for row in winners], ["vllm-best", "sglang-steady"])
+
+        summary = self.mod.render_markdown(rows)
+        self.assertIn("`vllm`", summary)
+        self.assertIn("sglang-fast-fail", summary)
+
+    def test_load_rows_rejects_non_object_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bad.jsonl"
+            path.write_text("[1, 2, 3]\n", encoding="utf-8")
+
+            with self.assertRaises(SystemExit):
+                self.mod.load_rows(path)
+
+    def test_writes_csv_with_failed_reason(self) -> None:
+        rows = [
+            {
+                "framework": "trtllm",
+                "candidate_id": "trt-c1",
+                "status": "failed",
+                "failure_reason": "server exited",
+                "sla": {"passed": False},
+                "metrics": {},
+                "hardware": {"gpu_count": 1},
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "summary.csv"
+            self.mod.write_csv(path, rows)
+            text = path.read_text(encoding="utf-8")
+
+        self.assertIn("trt-c1", text)
+        self.assertIn("server exited", text)
+
+    def test_cli_writes_markdown_and_csv(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            input_path = root / "rows.jsonl"
+            output_path = root / "summary.md"
+            csv_path = root / "summary.csv"
+            row = {
+                "framework": "sglang",
+                "candidate_id": "candidate-1",
+                "status": "ok",
+                "sla": {"passed": True},
+                "metrics": {"request_throughput": 1.5, "output_token_throughput": 8.0},
+                "hardware": {"gpu_count": 1},
+            }
+            input_path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+            rows = self.mod.load_rows(input_path)
+            output_path.write_text(self.mod.render_markdown(rows), encoding="utf-8")
+            self.mod.write_csv(csv_path, rows)
+
+            self.assertIn("candidate-1", output_path.read_text(encoding="utf-8"))
+            self.assertIn("candidate-1", csv_path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_compare_benchmark_results.py
+++ b/tests/test_compare_benchmark_results.py
@@ -82,6 +82,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
         self.assertIn("sglang-fast-fail", summary)
         self.assertIn("Best Commands By Framework", summary)
         self.assertIn("Cross-Framework Best Comparison", summary)
+        self.assertIn("audit trail for explored but non-recommended configs", summary)
 
     def test_load_rows_rejects_non_object_json(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_compare_benchmark_results.py
+++ b/tests/test_compare_benchmark_results.py
@@ -72,11 +72,16 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
         ]
 
         winners = self.mod.best_by_framework(rows)
-        self.assertEqual([row["candidate_id"] for row in winners], ["vllm-best", "sglang-steady"])
+        self.assertEqual(
+            [row["candidate_id"] for row in winners],
+            ["vllm-best", "sglang-steady"],
+        )
 
         summary = self.mod.render_markdown(rows)
         self.assertIn("`vllm`", summary)
         self.assertIn("sglang-fast-fail", summary)
+        self.assertIn("Best Commands By Framework", summary)
+        self.assertIn("Cross-Framework Best Comparison", summary)
 
     def test_load_rows_rejects_non_object_json(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -106,6 +111,84 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
 
         self.assertIn("trt-c1", text)
         self.assertIn("server exited", text)
+
+    def test_renders_scenario_tables_and_accuracy(self) -> None:
+        rows = [
+            {
+                "framework": "sglang",
+                "candidate_id": "sglang-c1",
+                "status": "ok",
+                "workload": {"scenario": "chat"},
+                "sla": {"passed": True},
+                "metrics": {
+                    "request_throughput": 10,
+                    "output_token_throughput": 100,
+                    "p99_ttft_ms": 80,
+                    "p99_tpot_ms": 6,
+                    "success_rate": 1.0,
+                },
+                "hardware": {"gpu_count": 1},
+                "server_command": "python -m sglang.launch_server --model-path m",
+                "accuracy": {
+                    "mmlu": {
+                        "accuracy": 0.72,
+                        "num_examples": 14042,
+                        "subcategories": {
+                            "stem": 0.68,
+                            "humanities": 0.74,
+                            "social_sciences": 0.76,
+                            "other": 0.71,
+                        },
+                    },
+                    "gsm8k": {"accuracy": 0.81, "num_examples": 1319},
+                },
+            },
+            {
+                "framework": "vllm",
+                "candidate_id": "vllm-c1",
+                "status": "ok",
+                "workload": {"scenario": "chat"},
+                "sla": {"passed": True},
+                "metrics": {
+                    "request_throughput": 12,
+                    "output_token_throughput": 90,
+                    "p99_ttft_ms": 85,
+                    "p99_tpot_ms": 7,
+                },
+                "hardware": {"gpu_count": 1},
+                "server_command": "vllm serve m",
+            },
+            {
+                "framework": "sglang",
+                "candidate_id": "sglang-c2",
+                "status": "ok",
+                "workload": {"scenario": "summarization"},
+                "sla": {"passed": True},
+                "metrics": {
+                    "request_throughput": 8,
+                    "output_token_throughput": 140,
+                    "p99_ttft_ms": 120,
+                    "p99_tpot_ms": 8,
+                },
+                "hardware": {"gpu_count": 1},
+                "server_command": "python -m sglang.launch_server --model-path m --long",
+            },
+        ]
+
+        scenario_winners = self.mod.best_by_framework_and_scenario(rows)
+        self.assertEqual(
+            {(row["framework"], row["workload"]["scenario"]) for row in scenario_winners},
+            {("sglang", "chat"), ("vllm", "chat"), ("sglang", "summarization")},
+        )
+
+        summary = self.mod.render_markdown(rows)
+        self.assertIn("### `sglang`", summary)
+        self.assertIn("| chat | sglang-c1", summary)
+        self.assertIn("| summarization | sglang-c2", summary)
+        self.assertIn("Accuracy Of Selected Deployment Commands", summary)
+        self.assertIn("| sglang | sglang-c1 | chat | 0.7200", summary)
+        self.assertIn("0.6800", summary)
+        self.assertIn("0.8100", summary)
 
     def test_cli_writes_markdown_and_csv(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_compare_benchmark_results.py
+++ b/tests/test_compare_benchmark_results.py
@@ -46,6 +46,16 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
             },
             {
                 "framework": "sglang",
+                "candidate_id": "sglang-startup-fail",
+                "status": "failed",
+                "failure_reason": "server did not become ready",
+                "workload": {"scenario": "startup"},
+                "sla": {"passed": False},
+                "metrics": {},
+                "hardware": {"gpu_count": 1},
+            },
+            {
+                "framework": "sglang",
                 "candidate_id": "sglang-steady",
                 "status": "ok",
                 "workload": {"scenario": "chat"},
@@ -82,10 +92,12 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
 
         summary = self.mod.render_markdown(rows)
         self.assertIn("sglang-fast-fail", summary)
+        self.assertIn("sglang-startup-fail", summary)
         self.assertIn("Best Commands By Framework", summary)
         self.assertIn("Cross-Framework Best Comparison", summary)
         self.assertNotIn("Overall Winner", summary)
         self.assertNotIn("Best Per Framework", summary)
+        self.assertNotIn("| startup |", summary)
         self.assertIn("records tried configs that were not selected", summary)
 
     def test_load_rows_rejects_non_object_json(self) -> None:

--- a/tests/test_compare_benchmark_results.py
+++ b/tests/test_compare_benchmark_results.py
@@ -111,8 +111,10 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
 
         self.assertIn("trt-c1", text)
         self.assertIn("server exited", text)
+        self.assertNotIn("mmlu_accuracy", text)
+        self.assertNotIn("gsm8k_accuracy", text)
 
-    def test_renders_scenario_tables_and_accuracy(self) -> None:
+    def test_renders_scenario_tables(self) -> None:
         rows = [
             {
                 "framework": "sglang",
@@ -129,19 +131,6 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                 },
                 "hardware": {"gpu_count": 1},
                 "server_command": "python -m sglang.launch_server --model-path m",
-                "accuracy": {
-                    "mmlu": {
-                        "accuracy": 0.72,
-                        "num_examples": 14042,
-                        "subcategories": {
-                            "stem": 0.68,
-                            "humanities": 0.74,
-                            "social_sciences": 0.76,
-                            "other": 0.71,
-                        },
-                    },
-                    "gsm8k": {"accuracy": 0.81, "num_examples": 1319},
-                },
             },
             {
                 "framework": "vllm",
@@ -185,10 +174,9 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
         self.assertIn("### `sglang`", summary)
         self.assertIn("| chat | sglang-c1", summary)
         self.assertIn("| summarization | sglang-c2", summary)
-        self.assertIn("Accuracy Of Selected Deployment Commands", summary)
-        self.assertIn("| sglang | sglang-c1 | chat | 0.7200", summary)
-        self.assertIn("0.6800", summary)
-        self.assertIn("0.8100", summary)
+        self.assertNotIn("Accuracy Of Selected Deployment Commands", summary)
+        self.assertNotIn("MMLU", summary)
+        self.assertNotIn("GSM8K", summary)
 
     def test_cli_writes_markdown_and_csv(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_llm_serving_cookbook_configs.py
+++ b/tests/test_llm_serving_cookbook_configs.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_ROOT = ROOT / "skills" / "llm-serving-auto-benchmark"
+CONFIG_ROOT = SKILL_ROOT / "configs" / "cookbook-llm"
+VALIDATOR = SKILL_ROOT / "scripts" / "validate_cookbook_configs.py"
+
+
+def load_validator():
+    spec = importlib.util.spec_from_file_location("validate_cookbook_configs", VALIDATOR)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class LlmServingCookbookConfigsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_validator()
+
+    def config_paths(self) -> list[Path]:
+        return sorted(CONFIG_ROOT.glob("*.yaml"))
+
+    def load_config(self, path: Path) -> dict:
+        return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    def test_all_cookbook_configs_validate(self) -> None:
+        paths = self.config_paths()
+        self.assertGreaterEqual(len(paths), 38)
+
+        for path in paths:
+            with self.subTest(path=path.name):
+                self.assertEqual(self.mod.validate_config(path), [])
+
+    def test_every_config_has_three_framework_sections(self) -> None:
+        for path in self.config_paths():
+            with self.subTest(path=path.name):
+                config = self.load_config(path)
+                self.assertEqual(
+                    set(config["frameworks"]),
+                    {"sglang", "vllm", "tensorrt_llm"},
+                )
+
+                trt = config["frameworks"]["tensorrt_llm"]
+                self.assertEqual(trt["backend_policy"], "fixed_pytorch")
+                self.assertEqual(trt["base_server_flags"]["backend"], "pytorch")
+                self.assertNotIn("backend", trt["search_space"])
+
+    def test_rendered_commands_use_framework_native_flags(self) -> None:
+        config = self.load_config(CONFIG_ROOT / "qwen3-235b-a22b.yaml")
+
+        sglang = config["frameworks"]["sglang"]
+        sglang_command = self.mod.render_command(
+            "sglang", config, sglang["base_server_flags"]
+        )
+        self.assertIn("--model-path Qwen/Qwen3-235B-A22B", sglang_command)
+        self.assertIn("--tp-size 8", sglang_command)
+
+        vllm = config["frameworks"]["vllm"]
+        vllm_command = self.mod.render_command("vllm", config, vllm["base_server_flags"])
+        self.assertIn("vllm serve Qwen/Qwen3-235B-A22B", vllm_command)
+        self.assertIn("--tensor-parallel-size 8", vllm_command)
+        self.assertNotIn("--tp-size", vllm_command)
+
+        trt = config["frameworks"]["tensorrt_llm"]
+        trt_command = self.mod.render_command(
+            "tensorrt_llm", config, trt["base_server_flags"]
+        )
+        self.assertIn("trtllm-serve serve Qwen/Qwen3-235B-A22B", trt_command)
+        self.assertIn("--backend pytorch", trt_command)
+        self.assertIn("--tp_size 8", trt_command)
+        self.assertNotIn("--tp-size", trt_command)
+
+    def test_help_snapshot_path_validates_all_config_flags(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            help_dir = Path(tmp)
+            for framework in self.mod.FRAMEWORKS:
+                flag_text = "\n".join(
+                    self.mod.flag_name(framework, key)
+                    for key in sorted(self.mod.STATIC_SERVER_FLAGS[framework])
+                )
+                if framework == "sglang":
+                    name = "sglang_launch_server.txt"
+                elif framework == "vllm":
+                    name = "vllm_serve_all.txt"
+                else:
+                    name = "trtllm_serve.txt"
+                (help_dir / name).write_text(flag_text, encoding="utf-8")
+
+            help_flags = self.mod.load_help_flags(help_dir)
+            self.assertEqual(set(help_flags), set(self.mod.FRAMEWORKS))
+
+            for path in self.config_paths():
+                with self.subTest(path=path.name):
+                    self.assertEqual(self.mod.validate_config(path, help_flags), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_serving_docs.py
+++ b/tests/test_llm_serving_docs.py
@@ -86,7 +86,8 @@ class LlmServingDocsTest(unittest.TestCase):
 
         for text in (skill, schema):
             normalized = " ".join(text.split())
-            self.assertIn("audit trail", normalized)
+            self.assertIn("tried configs", normalized)
+            self.assertIn("not selected", normalized)
             self.assertIn("failed", normalized)
             self.assertIn("skipped", normalized)
             self.assertIn("SLA", normalized)

--- a/tests/test_llm_serving_docs.py
+++ b/tests/test_llm_serving_docs.py
@@ -43,6 +43,7 @@ class LlmServingDocsTest(unittest.TestCase):
             "references/parameter-coverage.md",
             "references/container-runbook.md",
             "references/version-notes.md",
+            "references/cookbook-configs.md",
         ]
 
         for rel_path in expected_files:
@@ -63,6 +64,7 @@ class LlmServingDocsTest(unittest.TestCase):
             "references/framework-matrix.md",
             "references/result-schema.md",
             "references/version-notes.md",
+            "references/cookbook-configs.md",
         ]
 
         blocked_terms = [

--- a/tests/test_llm_serving_docs.py
+++ b/tests/test_llm_serving_docs.py
@@ -80,6 +80,17 @@ class LlmServingDocsTest(unittest.TestCase):
                 for term in blocked_terms:
                     self.assertNotIn(term, text)
 
+    def test_failed_candidate_table_is_explained(self) -> None:
+        skill = read_skill_file("SKILL.md")
+        schema = read_skill_file("references", "result-schema.md")
+
+        for text in (skill, schema):
+            normalized = " ".join(text.split())
+            self.assertIn("audit trail", normalized)
+            self.assertIn("failed", normalized)
+            self.assertIn("skipped", normalized)
+            self.assertIn("SLA", normalized)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm_serving_docs.py
+++ b/tests/test_llm_serving_docs.py
@@ -52,6 +52,8 @@ class LlmServingDocsTest(unittest.TestCase):
 
         runbook = read_skill_file("references", "container-runbook.md")
         self.assertIn("separate from the server backend pinned above", runbook)
+        self.assertIn("--ipc=host", runbook)
+        self.assertIn("-e NCCL_IB_DISABLE=1", runbook)
 
 
 if __name__ == "__main__":

--- a/tests/test_llm_serving_docs.py
+++ b/tests/test_llm_serving_docs.py
@@ -55,6 +55,31 @@ class LlmServingDocsTest(unittest.TestCase):
         self.assertIn("--ipc=host", runbook)
         self.assertIn("-e NCCL_IB_DISABLE=1", runbook)
 
+    def test_dataset_accuracy_is_not_in_default_contract(self) -> None:
+        expected_files = [
+            "SKILL.md",
+            "agents/openai.yaml",
+            "references/example-plan.yaml",
+            "references/framework-matrix.md",
+            "references/result-schema.md",
+            "references/version-notes.md",
+        ]
+
+        blocked_terms = [
+            "accuracy",
+            "Accuracy",
+            "mmlu",
+            "MMLU",
+            "gsm8k",
+            "GSM8K",
+            "run_eval",
+        ]
+        for rel_path in expected_files:
+            with self.subTest(rel_path=rel_path):
+                text = read_skill_file(*rel_path.split("/"))
+                for term in blocked_terms:
+                    self.assertNotIn(term, text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_llm_serving_docs.py
+++ b/tests/test_llm_serving_docs.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_ROOT = ROOT / "skills" / "llm-serving-auto-benchmark"
+
+
+def read_skill_file(*parts: str) -> str:
+    return (SKILL_ROOT.joinpath(*parts)).read_text(encoding="utf-8")
+
+
+class LlmServingDocsTest(unittest.TestCase):
+    def test_tensorrt_llm_backend_policy_is_explicit(self) -> None:
+        text = read_skill_file("SKILL.md")
+
+        self.assertIn("`trtllm-serve serve --backend pytorch`", text)
+        self.assertIn("do not search tensorrt-llm backend", text.lower())
+        self.assertIn("reject", text.lower())
+        self.assertIn("non-PyTorch TensorRT-LLM server backend", text)
+
+    def test_example_plan_pins_tensorrt_backend_outside_search_space(self) -> None:
+        text = read_skill_file("references", "example-plan.yaml")
+        frameworks = text.split("frameworks:\n", 1)[1]
+        trt_section = frameworks.split("  tensorrt_llm:\n", 1)[1]
+
+        self.assertIn("backend_policy: fixed_pytorch", trt_section)
+        self.assertRegex(
+            trt_section,
+            r"base_server_flags:\n(?:      .+\n)*      backend: pytorch",
+        )
+
+        search_space = trt_section.split("    search_space:\n", 1)[1]
+        self.assertNotRegex(search_space, re.compile(r"^\s+backend:", re.MULTILINE))
+        self.assertIn("Do not add backend choices here", search_space)
+
+    def test_reference_files_keep_server_backend_pinned(self) -> None:
+        expected_files = [
+            "references/framework-matrix.md",
+            "references/parameter-coverage.md",
+            "references/container-runbook.md",
+            "references/version-notes.md",
+        ]
+
+        for rel_path in expected_files:
+            with self.subTest(rel_path=rel_path):
+                text = read_skill_file(*rel_path.split("/"))
+                self.assertIn("--backend pytorch", text)
+
+        runbook = read_skill_file("references", "container-runbook.md")
+        self.assertIn("separate from the server backend pinned above", runbook)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Update the `llm-serving-auto-benchmark` skill after the H100 smoke runs across SGLang, vLLM, and TensorRT-LLM.

## What changed

- Require exact framework version or commit capture before a real run.
- Tighten the preflight `--help` checks for SGLang, vLLM, and TensorRT-LLM subcommands.
- Document the TensorRT-LLM 1.0.0 flag correction: use `--kv_cache_free_gpu_memory_fraction`, not `--free_gpu_memory_fraction`.
- Add GPU idleness checks and safer cleanup notes for repeated H100 validation runs.
- Replace the earlier invalid SGLang smoke note with the verified H100 matrix for Qwen2.5-7B, Gemma3-4B, Ministral3-8B, and TinyLlama.

## Validation

- `python3 -m py_compile skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py`
- `python3 skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py --help`
- `git diff --check`
- `SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`
