### PR TITLE
llm-serving-auto-benchmark: tighten schema, canonicalize SLA keys, decouple from H100

### DIFF
--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -66,6 +66,58 @@ a mostly pure-TP baseline, sweep a small set of high-impact runtime knobs, and
 cap the first pass around 10 candidates per framework. Do not search memory
 fractions by default.
 
+## Validation Environment
+
+This skill is target-agnostic. It assumes any one of the following is
+available, and nothing more:
+
+- a local GPU host with Docker/Podman and the target framework images pulled;
+- a remote GPU host reached via `ssh <host>` with the framework images already
+  running in a container there;
+- a CI runner that can exec into a pre-built image for each framework.
+
+Do not assume a specific operator host name (`h100_sglang`, `b200_*`,
+`radixark*`, `rtx5090_*`, etc.) inside this skill's own workflow. The concrete
+SSH wiring, container names, workspace paths, and HF token plumbing for a given
+box live in the operator-side per-host skills (for example `h100`,
+`h100-sglang-diffusion`, `b200`, `rtx5090`, `radixark02`, `radixark03`); this
+skill only requires that the caller can reach a shell inside a container with
+`sglang`, `vllm`, or `tensorrt_llm` installed.
+
+Historical validation snapshots in `references/` (for example the
+H100-recorded parameter audit) are evidence of which flag names and failure
+modes were seen in a specific image and are not a requirement that the next
+run happens on the same hardware.
+
+## Skill Scope
+
+This skill is a playbook plus a config+validator toolchain, not a
+turn-key orchestrator. The `scripts/` directory contains exactly two tools:
+
+- `validate_cookbook_configs.py`: reads YAML, renders bounded candidate server
+  commands, and checks flag names against captured `--help` snapshots. It never
+  launches a model server.
+- `compare_benchmark_results.py`: takes the normalized per-candidate JSONL and
+  emits the markdown tables described in the Output Contract.
+
+Launching servers, driving the workload, and writing one JSONL row per
+candidate are the operator's responsibility; the skill tells you how to do
+them, and the validator keeps your inputs honest.
+
+The cookbook configs under `configs/cookbook-llm/` and the sample runtime plan
+at `references/example-plan.yaml` use related but not identical schemas:
+
+- Cookbook configs carry `schema_version: 1`, `source.kind`,
+  `benchmark.sla` (nested), and `frameworks.*.server_command`; they must pass
+  `validate_cookbook_configs.py`.
+- `example-plan.yaml` is a shorter runtime plan shape with top-level `sla` and
+  no `server_command`. It is the skeleton a caller fills in for a one-off run
+  and is not expected to pass the cookbook validator as-is.
+
+Either shape can feed a benchmark run; the SLA key names in
+[references/result-schema.md](references/result-schema.md) are the single
+source of truth.
+
 ## Required Inputs
 
 Collect these before starting a long run:
@@ -94,6 +146,49 @@ Also collect a version manifest:
 If real production traffic is the goal, use the real request distribution. A
 synthetic workload is fine for bring-up and first-pass comparison, but it is not
 enough for a production choice.
+
+## Known Gotchas
+
+Short list of failure modes that have bitten past validation runs. Check these
+before starting a long sweep.
+
+- SGLang `fa3` attention backends need Hopper or newer. On A100, L40S, RTX
+  5090, and older GPUs, drop `fa3` from the SGLang `search_space` and keep
+  `flashinfer` (or `triton` when FlashInfer is unavailable).
+- SGLang `bench_serving` has two SGLang-facing backends: `--backend sglang` for
+  the native `/generate` endpoint and `--backend sglang-oai` for the
+  OpenAI-compatible endpoint. For cross-framework comparisons, prefer
+  `sglang-oai` so every framework is measured on the same request path.
+- vLLM `--enable-dbo` only works when the target vLLM image is built with a
+  supported all2all backend. Keep DBO out of the default candidate list unless
+  the operator has verified the image.
+- vLLM `--max-num-partial-prefills > 1` is model- and runtime-gated. Keep `1`
+  in the default pass; raise only after a preflight with the actual model.
+- In the validated TensorRT-LLM 1.0.0 image, `trtllm-serve serve` accepts
+  `--kv_cache_free_gpu_memory_fraction`; the older `--free_gpu_memory_fraction`
+  exits with a CLI error. Re-check the accepted flag name via `--help` on the
+  target image before a real run.
+- TensorRT-LLM 1.0.0 multi-GPU PyTorch-backend servers need `--ipc=host`,
+  `--ulimit memlock=-1`, `--ulimit stack=67108864`, `--shm-size=16g`, and
+  `NCCL_IB_DISABLE=1` (for single-node) or an equivalent NCCL setup.
+- TensorRT-LLM 1.0.0 benchmark client takes `--backend openai` or
+  `--backend openai-chat`; `--backend trtllm` is rejected. This is separate
+  from the server backend, which is pinned to `pytorch` by this skill.
+- `trtllm` `benchmark_serving --dataset-name random` silently falls back to
+  ShareGPT sampling without `--random-ids` (or `--download-path`).
+- `max_seq_len` / `max_model_len` / `context_length` candidates must cover
+  `max(input_len + output_len)` across every scenario, including values inside
+  `search_space`, not just the baseline. The validator checks this; do not
+  bypass it.
+
+## Secrets Hygiene
+
+- Never print `HF_TOKEN`, `HUGGINGFACE_HUB_TOKEN`, or any upstream API key into
+  a saved artifact. Pass them through container `-e VAR` (unquoted on the right
+  side so the host value is inherited) and keep them out of `server_command`
+  and `benchmark_command` fields written to the result JSONL.
+- When a framework echoes the full argv at startup, scrub the log or redact
+  token-shaped substrings before uploading the artifact.
 
 ## Fairness Rules
 
@@ -223,7 +318,9 @@ Use the smallest tier that can answer the user's question:
 
 Default budget:
 
-- `num_prompts: 80` for quick comparison
+- `num_prompts: 80` for the default cross-framework comparison; `num_prompts:
+  20` per scenario is acceptable for a smoke/flow check and must be labeled as
+  such in the artifact (not as a performance result).
 - `search.max_candidates_per_framework: 10` for the first useful pass
 - candidate generation: baseline first, then a bounded product or ordered
   candidate list from `search_space`
@@ -315,7 +412,9 @@ Version-sensitive vLLM knob families to verify:
 
 vLLM should get a normal sweep, not one baseline command. See
 [references/parameter-coverage.md](references/parameter-coverage.md) for the
-H100-verified flag families.
+validated flag families. The historical audit happens to use an H100 host, but
+the flag-family coverage is not H100-specific; confirm each flag on the target
+image's `--help` before a run.
 
 Keep `gpu_memory_utilization` in the baseline for the default pass. Search it
 only when the question is explicitly about fitting the model or trading capacity
@@ -351,11 +450,11 @@ For TensorRT-LLM 1.0.0, `benchmark_serving --dataset-name random` samples from
 ShareGPT unless you pass either `--download-path` or `--random-ids`. For a fast
 synthetic smoke test, pass `--random-ids`.
 
-TensorRT-LLM flag names are especially version-sensitive. In the H100
+TensorRT-LLM flag names are especially version-sensitive. In the validated
 TensorRT-LLM 1.0.0 image, the KV-cache memory flag accepted by
 `trtllm-serve serve` is `--kv_cache_free_gpu_memory_fraction`, not
 `--free_gpu_memory_fraction`. Verify this with `trtllm-serve serve --help`
-before running a search.
+before running a search on any GPU target.
 
 TensorRT-LLM backend policy for this skill:
 

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-math-v2.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-math-v2.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/deepseek-math-v2
 search:
   tier: 2
@@ -123,8 +124,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-r1-0528.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-r1-0528.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/deepseek-r1-0528
 search:
   tier: 2
@@ -126,8 +127,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.1.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.1.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/deepseek-v3.1
 search:
   tier: 2
@@ -125,8 +126,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.2.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.2.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/deepseek-v3.2
 search:
   tier: 2
@@ -125,8 +126,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/deepseek-v3
 search:
   tier: 2
@@ -126,8 +127,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/devstral-small-2-24b-instruct-2512.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/devstral-small-2-24b-instruct-2512.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 16.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/devstral-small-2-24b-instruct-2512
 search:
   tier: 2
@@ -120,5 +121,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ernie-4.5-21b-a3b-pt.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ernie-4.5-21b-a3b-pt.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 16.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/ernie-4.5-21b-a3b-pt
 search:
   tier: 2
@@ -114,5 +115,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.5.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.5.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 8.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/glm-4.5
 search:
   tier: 2
@@ -116,5 +117,3 @@ frameworks:
       max_seq_len:
       - 9000
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.6.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.6.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/glm-4.6
 search:
   tier: 2
@@ -125,8 +126,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7-flash.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7-flash.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 16.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/glm-4.7-flash
 search:
   tier: 2
@@ -120,5 +121,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 8.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/glm-4.7
 search:
   tier: 2
@@ -120,8 +121,6 @@ frameworks:
       max_seq_len:
       - 9000
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 2

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-5-fp8.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-5-fp8.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/glm-5-fp8
 search:
   tier: 2
@@ -125,8 +126,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glyph.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glyph.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 8.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/glyph
 search:
   tier: 2
@@ -123,5 +124,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/gpt-oss-120b.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/gpt-oss-120b.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/gpt-oss-120b
 search:
   tier: 2
@@ -125,8 +126,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/intern-s1.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/intern-s1.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/intern-s1
 search:
   tier: 2
@@ -128,8 +129,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-k2-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-k2-instruct.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/kimi-k2-instruct
 search:
   tier: 2
@@ -127,8 +128,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-k2.5.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-k2.5.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/kimi-k2.5
 search:
   tier: 2
@@ -124,5 +125,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-linear-48b-a3b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-linear-48b-a3b-instruct.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 8.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/kimi-linear-48b-a3b-instruct
 search:
   tier: 2
@@ -118,5 +119,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ling-2.5-1t.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ling-2.5-1t.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 2.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/ling-2.5-1t
 search:
   tier: 2
@@ -131,5 +132,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llada2-1-mini.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llada2-1-mini.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/llada2-1-mini
 search:
   tier: 2
@@ -127,5 +128,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-3.1-70b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-3.1-70b-instruct.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 12.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/llama-3.1-70b-instruct
 search:
   tier: 2
@@ -121,5 +122,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-3.3-70b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-3.3-70b-instruct.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 16.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/llama-3.3-70b-instruct
 search:
   tier: 2
@@ -115,5 +116,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-4-maverick-17b-128e-instruct-fp8.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-4-maverick-17b-128e-instruct-fp8.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 2.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/llama-4-maverick-17b-128e-instruct-fp8
 search:
   tier: 2
@@ -119,5 +120,3 @@ frameworks:
       - 16384
       max_seq_len:
       - 1000000
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-4-scout-17b-16e-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-4-scout-17b-16e-instruct.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/llama-4-scout-17b-16e-instruct
 search:
   tier: 2
@@ -126,5 +127,3 @@ frameworks:
       - 16384
       max_seq_len:
       - 65536
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/mimo-v2-flash.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/mimo-v2-flash.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/mimo-v2-flash
 search:
   tier: 2
@@ -130,5 +131,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/minimax-m2.1.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/minimax-m2.1.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 8.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/minimax-m2.1
 search:
   tier: 2
@@ -118,5 +119,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/minimax-m2.5.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/minimax-m2.5.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/minimax-m2.5
 search:
   tier: 2
@@ -127,8 +128,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ministral-3-8b-instruct-2512.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ministral-3-8b-instruct-2512.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 16.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/ministral-3-8b-instruct-2512
 search:
   tier: 2
@@ -118,5 +119,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/mistral-small-4-119b-2603.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/mistral-small-4-119b-2603.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 6.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/mistral-small-4-119b-2603
 search:
   tier: 2
@@ -121,5 +122,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/nemotron-3-nano-30b-a3b-bf16.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/nemotron-3-nano-30b-a3b-bf16.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 16.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/nemotron-3-nano-30b-a3b-bf16
 search:
   tier: 2
@@ -125,5 +126,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/nemotron-3-super-120b-a12b-bf16.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/nemotron-3-super-120b-a12b-bf16.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 6.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/nemotron-3-super-120b-a12b-bf16
 search:
   tier: 2
@@ -125,5 +126,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-235b-a22b.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-235b-a22b.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/qwen3-235b-a22b
 search:
   tier: 2
@@ -125,8 +126,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-coder-480b-a35b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-coder-480b-a35b-instruct.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/qwen3-coder-480b-a35b-instruct
 search:
   tier: 2
@@ -125,8 +126,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 2

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-coder-next.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-coder-next.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 12.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/qwen3-coder-next
 search:
   tier: 2
@@ -121,5 +122,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-next-80b-a3b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-next-80b-a3b-instruct.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 12.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/qwen3-next-80b-a3b-instruct
 search:
   tier: 2
@@ -124,8 +125,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 2

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen35-397b-a17b-fp8.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen35-397b-a17b-fp8.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 4.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/qwen35-397b-a17b-fp8
 search:
   tier: 2
@@ -125,8 +126,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 4

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ring-2.5-1t.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ring-2.5-1t.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 2.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/ring-2.5-1t
 search:
   tier: 2
@@ -121,5 +122,3 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/step-3.5-flash.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/step-3.5-flash.yaml
@@ -38,8 +38,9 @@ benchmark:
     upper: 8.0
     tolerance: 0.1
   sla:
-    max_ttft_ms: 1500
-    max_tpot_ms: 30
+    max_p99_ttft_ms: 1500
+    max_p99_tpot_ms: 30
+    min_success_rate: 0.99
   output_dir: ./auto_benchmark_results/cookbook-llm/step-3.5-flash
 search:
   tier: 2
@@ -127,8 +128,6 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
-      extra_llm_api_options:
-      - null
       ep_size:
       - 1
       - 4

--- a/skills/llm-serving-auto-benchmark/references/container-runbook.md
+++ b/skills/llm-serving-auto-benchmark/references/container-runbook.md
@@ -4,6 +4,14 @@ Use this runbook when the benchmark environment is container-based. It records
 the exact image, command, help output, server log, benchmark log, and cleanup
 step for each framework.
 
+This runbook is target-agnostic. Every `docker run` / `docker exec` command
+works on a local box, an SSH-reachable remote GPU host, or a CI runner; the
+per-host skills (for example `h100`, `b200`, `rtx5090`, `radixark02`,
+`radixark03`) only add the SSH wrapper, container name, and workspace path
+for a specific operator box. Substitute those values where you see
+`$SGLANG_CONTAINER`, `$SGLANG_WORKSPACE`, and similar; nothing below assumes
+an H100.
+
 ## Common Setup
 
 Pull the images that will be used:
@@ -80,21 +88,26 @@ python -m tensorrt_llm.serve.scripts.benchmark_serving --help \
 
 ## SGLang
 
-On the prepared H100 host, the existing `sglang_bbuf` container can be used:
+If a prepared GPU host already has a long-running SGLang container (local or
+reached via ssh; name is operator-specific), reuse it via `docker exec`
+instead of creating a new container. The per-host skills — `h100`,
+`h100-sglang-diffusion`, `b200`, `rtx5090`, `radixark02`, `radixark03`,
+and similar — provide the concrete container name and workspace path for
+that box; this runbook assumes the operator substitutes them:
 
 ```bash
 docker exec \
   -e MODEL \
   -e TP \
   -e PORT \
-  sglang_bbuf bash -lc '
-cd /data/bbuf/repos/sglang
-python -m sglang.launch_server \
-  --model-path "$MODEL" \
-  --tp-size "$TP" \
-  --host 0.0.0.0 \
-  --port "$PORT"
-'
+  "$SGLANG_CONTAINER" bash -lc "
+cd \"\$SGLANG_WORKSPACE\"
+python -m sglang.launch_server \\
+  --model-path \"\$MODEL\" \\
+  --tp-size \"\$TP\" \\
+  --host 0.0.0.0 \\
+  --port \"\$PORT\"
+"
 ```
 
 For a fresh container:
@@ -214,9 +227,11 @@ server to `--backend trt`, an engine path, or any other backend; mark that
 candidate unsupported instead.
 
 For single-node multi-GPU TensorRT-LLM containers, keep the IPC, ulimit, shared
-memory, and NCCL settings below. In H100 validation, a 4-GPU PyTorch-backend
-server entered `PyTorchConfig` but failed NCCL allreduce without these container
-options; the same model and candidate list passed after adding them.
+memory, and NCCL settings below. In a multi-GPU PyTorch-backend validation
+run (captured on an H100 host; the rule is not H100-specific), the server
+entered `PyTorchConfig` but failed NCCL allreduce without these container
+options; the same model and candidate list passed after adding them. Expect
+the same requirement on any single-node multi-GPU target.
 
 Server template:
 

--- a/skills/llm-serving-auto-benchmark/references/example-plan.yaml
+++ b/skills/llm-serving-auto-benchmark/references/example-plan.yaml
@@ -1,6 +1,11 @@
 # Example run plan for the llm-serving-auto-benchmark skill. The layout mirrors
 # SGLang auto benchmark: baseline flags stay in base_server_flags, search knobs
 # stay in search_space, and aligned dataset length pairs define scenarios.
+#
+# Note: this is the runtime plan shape (top-level `sla`, no `schema_version` or
+# `server_command`). Cookbook configs in configs/cookbook-llm/ use the extended
+# schema enforced by scripts/validate_cookbook_configs.py; do not run the
+# validator against this file as-is.
 
 model:
   name: Qwen/Qwen3-32B
@@ -30,6 +35,9 @@ version_manifest:
     benchmark_help: artifacts/help/trtllm_benchmark_serving.txt
 
 hardware:
+  # Example values; replace with the actual target GPU (A100, H100, H200,
+  # B200, MI300, RTX 5090, etc.). gpu_model is recorded for fairness audit,
+  # not used as a scheduling hint.
   gpu_model: NVIDIA H100 80GB HBM3
   gpu_count: 4
   multi_node: false
@@ -119,4 +127,7 @@ frameworks:
       max_batch_size: [64, 128]
       max_num_tokens: [8192, 16384]
       max_seq_len: [12288, 16384]
-      extra_llm_api_options: [null]
+      # Uncomment and point at concrete config files to sweep PyTorch-backend
+      # options via --extra_llm_api_options. A single [null] value contributes
+      # no dimension to the search.
+      # extra_llm_api_options: [null, /path/to/trt_llm_config_A.yaml]

--- a/skills/llm-serving-auto-benchmark/references/framework-matrix.md
+++ b/skills/llm-serving-auto-benchmark/references/framework-matrix.md
@@ -46,6 +46,20 @@ python -m sglang.bench_serving \
   --request-rate 8
 ```
 
+`sglang.bench_serving` has two SGLang-facing backends:
+
+- `--backend sglang` targets SGLang's native `/generate` endpoint. Use this for
+  SGLang-internal comparisons where the native request path is the most direct
+  measurement.
+- `--backend sglang-oai` targets the OpenAI-compatible endpoint
+  (`/v1/completions` or `/v1/chat/completions`). Use this when the cross-framework
+  comparison requires an identical OpenAI-compatible request path for every
+  framework.
+
+For this skill, prefer `--backend sglang-oai` whenever the same benchmark run
+has to compare SGLang against vLLM and TensorR-LLM, and note the backend choice
+in the result row's `workload.endpoint`.
+
 ### vLLM
 
 ```bash
@@ -94,11 +108,11 @@ Then benchmark `http://127.0.0.1:8000/v1/completions` or
 `http://127.0.0.1:8000/v1/chat/completions` with the TensorRT-LLM serving
 benchmark client or the same OpenAI-compatible client used for the other
 frameworks. For TensorRT-LLM 1.0.0 synthetic random data, pass `--random-ids`
-unless you also provide a ShareGPT `--download-path`. In the 1.0.0 H100 image,
-`--free_gpu_memory_fraction` is not accepted by `trtllm-serve serve`; use
-`--kv_cache_free_gpu_memory_fraction` after checking `--help`. The TensorRT-LLM
-1.0.0 benchmark client accepts `--backend openai` and `--backend openai-chat`,
-not `--backend trtllm`.
+unless you also provide a ShareGPT `--download-path`. In the validated
+TensorRT-LLM 1.0.0 image, `--free_gpu_memory_fraction` is not accepted by
+`trtllm-serve serve`; use `--kv_cache_free_gpu_memory_fraction` after checking
+`--help` on the target image. The TensorRT-LLM 1.0.0 benchmark client accepts
+`--backend openai` and `--backend openai-chat`, not `--backend trtllm`.
 
 Do not replace the server-side `--backend pytorch` with `trt` or an engine
 backend in this skill. Treat those requests as unsupported candidates and record

--- a/skills/llm-serving-auto-benchmark/references/parameter-coverage.md
+++ b/skills/llm-serving-auto-benchmark/references/parameter-coverage.md
@@ -4,7 +4,13 @@ Do not compare SGLang, vLLM, and TensorRT-LLM by copying the same flag names
 across frameworks. Compare knob families, then translate each family to the
 flags that the target CLI actually accepts.
 
-## H100 Audit Snapshot
+## Historical Audit Snapshot
+
+The concrete flag counts and captured help output below come from a single
+historical audit on a 4xH100 host. They are evidence of what each CLI exposed
+in a specific image, not a requirement that the next run uses that hardware.
+When you repeat the audit on a different GPU target, re-capture `--help` on
+that image and update the numbers.
 
 Captured on 2026-04-22 in:
 
@@ -66,12 +72,14 @@ OpenAI-compatible endpoint.
 
 ## Benchmark Client Notes
 
-SGLang `bench_serving` in the H100 validation container writes artifacts with
-`--output-file` and `--output-details`. It does not accept the vLLM-style
+SGLang `bench_serving` in the validated SGLang container image writes artifacts
+with `--output-file` and `--output-details`. It does not accept the vLLM-style
 `--save-result`, `--result-dir`, and `--result-filename` flags in that image.
+Re-check on the target image; this is an SGLang CLI difference, not an H100
+behavior.
 
-Both vLLM and TensorRT-LLM benchmark clients accepted these shared random-workload
-flags in the H100 audit:
+Both vLLM and TensorRT-LLM benchmark clients accepted these shared
+random-workload flags in the captured audit:
 
 - `--dataset-name`
 - `--random-input-len`
@@ -103,6 +111,21 @@ flag.
   represented for one framework, say why instead of filling the gap with an
   unrelated option.
 
+Attention backend hardware notes:
+
+- SGLang's `fa3` (FlashAttention-3) prefill and decode backends require Hopper
+  (H100/H200/GB200). On non-Hopper GPUs (A100, L40S, RTX 5090, older cards)
+  `fa3` is not available: drop it from the SGLang `search_space` and fall back
+  to `flashinfer`, or to `triton` for the non-Blackwell path when FlashInfer is
+  missing.
+- vLLM `--attention-backend` has a similar shape: `FLASH_ATTN` and `FLASHINFER`
+  are the safer defaults, and `FLASHINFER_MLA` or DeepSeek-MLA specific paths
+  need a verified driver/vLLM combination in the target image.
+- TensorRT-LLM's backend here is always `pytorch`; attention backend choice
+  inside `PyTorchConfig` is version- and model-dependent. Prefer the defaults
+  emitted in the server log until you have a reason to override them via
+  `--extra_llm_api_options`.
+
 Default searches should not sweep memory fractions:
 
 - keep SGLang `mem_fraction_static` in `base_server_flags`
@@ -113,18 +136,19 @@ Move them into `search_space` only for a fit/capacity study. For a normal servin
 comparison, search scheduler, batching, attention/backend, prefix cache, and
 CUDA graph or compile behavior first.
 
-In the 2026-04-22 H100 validation, vLLM accepted `--enable-dbo` but the server
+In the 2026-04-22 validation run, vLLM accepted `--enable-dbo` but the server
 failed during config validation without a supported all2all backend. Treat DBO
-as a version- and environment-gated extension knob, not part of the default
-candidate list.
+as a version- and environment-gated extension knob on any GPU target, not part
+of the default candidate list.
 
-The same validation showed that vLLM concurrent partial prefill is model/runtime
-gated: `--max-num-partial-prefills 1` ran on `Qwen/Qwen3-30B-A3B`, while
-`--max-num-partial-prefills 4` failed with "Concurrent Partial Prefill is not
-supported." Keep `1` in the default pass and only raise it after preflight.
+The same validation showed that vLLM concurrent partial prefill is model- and
+runtime-gated: `--max-num-partial-prefills 1` ran on `Qwen/Qwen3-30B-A3B`,
+while `--max-num-partial-prefills 4` failed with "Concurrent Partial Prefill is
+not supported." Keep `1` in the default pass and only raise it after a
+model-level preflight in the target image.
 
 Sequence-length candidates must cover the largest dataset scenario. In the same
-H100 validation, a TensorRT-LLM candidate with `--max_seq_len 2048` passed the
+validation run, a TensorRT-LLM candidate with `--max_seq_len 2048` passed the
 512-to-64 chat-like scenario but failed the 2048-to-128 summarization-like
 scenario. Do not include a `max_model_len`, `context_length`, or `max_seq_len`
-candidate below `max(input_len + output_len)`.
+candidate below `max(input_len + output_len)` on any target.

--- a/skills/llm-serving-auto-benchmark/references/result-schema.md
+++ b/skills/llm-serving-auto-benchmark/references/result-schema.md
@@ -3,7 +3,31 @@
 Write one JSON object per candidate. Keep failed candidates in the same file so
 the final summary explains what was tried.
 
+## SLA Key Convention
+
+One canonical naming across this skill. Config files and normalized result rows
+must agree.
+
+| Key | Where | Type |
+| --- | --- | --- |
+| `max_p99_ttft_ms` | both | float, milliseconds, p99 |
+| `max_p99_tpot_ms` | both | float, milliseconds, p99 |
+| `min_success_rate` | both | float in [0, 1] |
+| `passed` | result only | bool; recomputed after the run |
+
+Do not use `max_ttft_ms` or `max_tpot_ms` without the `p99_` prefix; those names
+hide whether the target is a mean or a tail. Older cookbook configs used mean
+latency targets by accident and have been migrated to the p99 names above.
+
+The config-level SLA block lives under `benchmark.sla` (cookbook configs) or at
+the top level (example plan). Either location is acceptable, but the key names
+must match this table.
+
 ## JSONL Row
+
+The values below (`gpu_model`, `gpu_count`, file paths, numeric metrics, etc.)
+are illustrative. Replace them with the actual target hardware and measured
+values; this schema is not tied to H100.
 
 ```json
 {
@@ -83,6 +107,17 @@ The default ranking is:
 
 If the user cares more about token throughput than request throughput, swap
 steps 3 and 4 and state that in the final report.
+
+Missing metric semantics:
+
+- If a latency field is absent from a row, the ranking script treats it as the
+  worst possible value, so that row falls below any candidate with a real
+  measurement. Do not write `0` as a placeholder for "no measurement"; leave the
+  field out or set it to `null`.
+- If `metrics.request_throughput` or `metrics.output_token_throughput` is
+  missing, the row ranks below any candidate with a real measurement in those
+  keys. A failed candidate that still produced partial metrics should keep the
+  metrics it did produce.
 
 ## Final Report Tables
 

--- a/skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py
+++ b/skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py
@@ -19,6 +19,25 @@ import yaml
 
 FRAMEWORKS = ("sglang", "vllm", "tensorrt_llm")
 
+SEQUENCE_LIMIT_KEY = {
+    "sglang": "context_length",
+    "vllm": "max_model_len",
+    "tensorrt_llm": "max_seq_len",
+}
+
+ALLOWED_SLA_KEYS = {
+    "max_p99_ttft_ms",
+    "max_p99_tpot_ms",
+    "min_success_rate",
+    "max_p99_e2e_ms",
+}
+
+DEPRECATED_SLA_KEYS = {
+    "max_ttft_ms": "max_p99_ttft_ms",
+    "max_tpot_ms": "max_p99_tpot_ms",
+    "max_e2e_ms": "max_p99_e2e_ms",
+}
+
 STATIC_SERVER_FLAGS = {
     "sglang": {
         "attention_backend",
@@ -287,27 +306,52 @@ def validate_config(
     for framework in FRAMEWORKS:
         errors.extend(_validate_framework(config, framework, help_flags))
 
-    if _enabled(config, "sglang"):
-        sglang_flags = frameworks["sglang"]["base_server_flags"]
-        context_length = int(sglang_flags.get("context_length", required_sequence))
-        if context_length < required_sequence:
+    for framework in FRAMEWORKS:
+        if not _enabled(config, framework):
+            continue
+        key = SEQUENCE_LIMIT_KEY[framework]
+        fw = frameworks[framework]
+        base_flags = fw.get("base_server_flags", {}) or {}
+        search_space = fw.get("search_space", {}) or {}
+
+        if framework == "sglang":
+            base_value = int(base_flags.get(key, required_sequence))
+        else:
+            base_value = int(base_flags.get(key, 0))
+        if base_value < required_sequence:
             errors.append(
-                "sglang: context_length is smaller than the largest dataset scenario"
+                f"{framework}: base {key} ({base_value}) is smaller than the largest dataset scenario ({required_sequence})"
             )
 
-    if _enabled(config, "vllm"):
-        vllm_flags = frameworks["vllm"]["base_server_flags"]
-        if int(vllm_flags.get("max_model_len", 0)) < required_sequence:
-            errors.append(
-                "vllm: max_model_len is smaller than the largest dataset scenario"
-            )
+        if key in search_space:
+            for value in _as_list(search_space[key]):
+                try:
+                    if int(value) < required_sequence:
+                        errors.append(
+                            f"{framework}: search_space {key} candidate {value} is smaller than the largest dataset scenario ({required_sequence})"
+                        )
+                except (TypeError, ValueError):
+                    errors.append(
+                        f"{framework}: search_space {key} candidate {value!r} is not an integer"
+                    )
 
-    if _enabled(config, "tensorrt_llm"):
-        trt_flags = frameworks["tensorrt_llm"]["base_server_flags"]
-        if int(trt_flags.get("max_seq_len", 0)) < required_sequence:
-            errors.append(
-                "tensorrt_llm: max_seq_len is smaller than the largest dataset scenario"
-            )
+    sla_block = (
+        config.get("benchmark", {}).get("sla")
+        if isinstance(config.get("benchmark"), dict)
+        else None
+    )
+    if sla_block is None:
+        sla_block = config.get("sla")
+    if isinstance(sla_block, dict):
+        for key in sla_block:
+            if key in DEPRECATED_SLA_KEYS:
+                errors.append(
+                    f"sla: {key!r} is deprecated; use {DEPRECATED_SLA_KEYS[key]!r} (see references/result-schema.md)"
+                )
+            elif key not in ALLOWED_SLA_KEYS:
+                errors.append(
+                    f"sla: unknown key {key!r}; allowed keys are {sorted(ALLOWED_SLA_KEYS)}"
+                )
 
     return errors
 


### PR DESCRIPTION
## Summary

Consolidates two rounds of review on the `llm-serving-auto-benchmark` skill into one PR. All changes are scoped to `skills/llm-serving-auto-benchmark/`.

### 1. Schema / validator / docs cleanup

- **Canonical SLA schema.** `result-schema.md` now defines `max_p99_ttft_ms`, `max_p99_tpot_ms`, `min_success_rate` as the canonical SLA keys and documents missing-metric ranking semantics (missing latency / throughput sorts to the bottom; do not use `0` as a placeholder).
- **Cookbook config rename.** All 38 configs under `configs/cookbook-llm/*.yaml` were programmatically updated: `max_ttft_ms` → `max_p99_ttft_ms`, `max_tpot_ms` → `max_p99_tpot_ms`, and `min_success_rate: 0.99` added where missing. The no-op `extra_llm_api_options: [null]` candidate was removed from every `tensorrt_llm.search_space`.
- **Stronger validator.** `validate_cookbook_configs.py` now:
  - checks every `search_space` candidate for `context_length` / `max_model_len` / `max_seq_len` against `max(input_len + output_len)` across dataset scenarios (not only the baseline), so a too-small sequence-limit candidate cannot slip through;
  - rejects deprecated SLA keys (`max_ttft_ms`, `max_tpot_ms`, `max_e2e_ms`) and unknown SLA keys, pointing to the canonical names.
- **Targeted docs additions.**
  - `parameter-coverage.md`: attention-backend hardware notes (FA3 Hopper-only with suggested fallbacks; vLLM / TRT-LLM attention-backend caveats).
  - `framework-matrix.md`: explicit note on `sglang.bench_serving --backend sglang` vs `sglang-oai`, recommending `sglang-oai` for cross-framework comparisons.
  - `SKILL.md`: new *Skill Scope*, *Known Gotchas*, *Secrets Hygiene* sections and clearer `num_prompts` guidance (80 default, 20 smoke).

### 2. Decouple the skill from a specific host (no hardcoded H100)

The skill used to phrase generic operator actions as \"on the prepared H100 host\" / \"in the H100 image\" / \"H100-verified flag families\". That coupling is now removed.

- New **Validation Environment** section in `SKILL.md`: the skill is target-agnostic (local GPU box, remote GPU host via SSH, or CI runner); concrete SSH wiring, container names, workspace paths, and HF token plumbing live in the **operator-side per-host skills** — `h100`, `h100-sglang-diffusion`, `b200`, `rtx5090`, `radixark02`, `radixark03`, etc.
- `container-runbook.md`: replaced the H100-specific preamble with target-agnostic wording and generic `docker exec \"$SGLANG_CONTAINER\"` / `$SGLANG_WORKSPACE` variables; added a pointer to per-host skills as the source of those values. The 4-GPU TRT-LLM NCCL note keeps the H100-on-that-day evidence but states explicitly the rule is not H100-specific.
- `framework-matrix.md`: `In the 1.0.0 H100 image ...` → `In the validated TensorRT-LLM 1.0.0 image ...` with \"check `--help` on the target image\".
- `parameter-coverage.md`: `H100 Audit Snapshot` header becomes `Historical Audit Snapshot` with a lead paragraph that makes clear the snapshot is evidence, not a hardware requirement; guidance lines like \"In the H100 validation container\" become \"in the validated container image\" / \"in the captured audit\" / \"on any GPU target\". The Hopper capability statement (`H100/H200/GB200`) is preserved because that is a hardware fact.
- `example-plan.yaml` and `result-schema.md`: `gpu_model: NVIDIA H100 80GB HBM3` is now explicitly annotated as an example placeholder.

### Intentionally *not* changed

- `version-notes.md` keeps its H100 references because that file is a historical validation snapshot (which host / image / commit was used on which date). Stripping hostnames there would destroy provenance.
- Per-host skills `h100/` and `h100-sglang-diffusion/` are unchanged; they are host-bound by design.
- Factual PR / test-lane / config-filename references in `sglang-deepseek-v3-r1-optimization` (\"H200 ladder\"), `sglang-kimi-k2-k25-optimization` (`device_name=NVIDIA_H200` etc.), `sglang-minimax-m2-series-optimization`, and `sglang-torch-profiler-analysis` are unchanged — they point to real filenames / real registered test lanes / real hardware-specific PRs.

## Test plan

- [x] `python3 skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py skills/llm-serving-auto-benchmark/configs/cookbook-llm` passes on all 38 configs after the rename and `extra_llm_api_options` cleanup.
- [x] `rg` sweep over `skills/llm-serving-auto-benchmark/` confirms the remaining H100 mentions are either in `version-notes.md` (historical snapshot), pointer lists to per-host skills (`h100`, `b200`, `rtx5090`, `radixark02/03`), or explicit \"not H100-specific\" disclaimers.
- [x] Broader `rg` sweep over all 10 skills confirms other generic skills (`sglang-prod-incident-triage`, `sglang-torch-profiler-analysis`, `sglang-deepseek-v3-r1/v3.1/v3.2-optimization`, `sglang-kimi-*`, `sglang-minimax-*`) already use generic validation language (\"validate on the exact topology that triggered the issue\", \"run only on matching hardware\", \"use the narrowest lane that matches the change\") and do not need the same rewrite.

Made with [Cursor](https://cursor.com)