### PR TITLE
[codex] Review and harden AI infra skills

### DIFF
--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -90,58 +90,35 @@ that the next run happens on the same hardware or framework version.
 
 ## Skill Scope
 
-This skill is a playbook plus a config+validator toolchain, not a
-turn-key orchestrator. The `scripts/` directory contains exactly two tools:
+This skill is a playbook plus a config+validator toolchain, not a turn-key
+orchestrator. The operator still launches servers, drives workloads, and writes
+one normalized JSONL row per candidate.
 
-- `validate_cookbook_configs.py`: reads YAML, renders bounded candidate server
-  commands, and checks flag names against captured `--help` snapshots. It never
-  launches a model server.
-- `compare_benchmark_results.py`: takes the normalized per-candidate JSONL and
-  emits the markdown tables described in the Output Contract.
+The `scripts/` directory contains exactly two tools:
 
-Launching servers, driving the workload, and writing one JSONL row per
-candidate are the operator's responsibility; the skill tells you how to do
-them, and the validator keeps your inputs honest.
+- `validate_cookbook_configs.py`: load cookbook YAML, render bounded candidate
+  server commands, and check flag names against captured `--help` snapshots
+  without launching servers.
+- `compare_benchmark_results.py`: turn normalized per-candidate JSONL into the
+  markdown and optional CSV tables described in the Output Contract.
 
-The cookbook configs under `configs/cookbook-llm/` and the sample runtime plan
-at `references/example-plan.yaml` use related but not identical schemas:
-
-- Cookbook configs carry `schema_version: 1`, `source.kind` set to
-  `llm_serving_cookbook`,
-  `benchmark.sla` (nested), and `frameworks.*.server_command`; they must pass
-  `validate_cookbook_configs.py`.
-- `example-plan.yaml` is a shorter runtime plan shape with top-level `sla` and
-  no `server_command`. It is the skeleton a caller fills in for a one-off run
-  and is not expected to pass the cookbook validator as-is.
-
-Either shape can feed a benchmark run; the SLA key names in
-[references/result-schema.md](references/result-schema.md) are the single
-source of truth.
+Cookbook configs under `configs/cookbook-llm/` must pass the validator. The
+shorter [references/example-plan.yaml](references/example-plan.yaml) is a
+one-off runtime-plan skeleton and is not expected to pass as-is. Use
+[references/result-schema.md](references/result-schema.md) as the single source
+of truth for SLA key names.
 
 ## Required Inputs
 
-Collect these before starting a long run:
+Collect these before a long run:
 
-- model path or Hugging Face repo id
-- tokenizer path if it differs from the model
-- target frameworks: any subset of `sglang`, `vllm`, `tensorrt-llm`
-- GPU model, GPU count, and whether multi-node is allowed
-- precision and quantization constraints
-- endpoint shape: completions, chat completions, responses, or custom
-- workload source: real traffic JSONL, ShareGPT, random synthetic, or generated
-  shared-prefix synthetic
-- dataset scenarios when synthetic traffic is used, for example `chat` and
-  `summarization`
-- SLA target: TTFT, TPOT/ITL, end-to-end latency, success rate, or goodput
-- search budget: quick smoke, default search, or exhaustive search
-- output directory for logs and result artifacts
-
-Also collect a version manifest:
-
-- framework package version and git commit when available
-- container image or Python environment identifier
-- `--help` snapshots for the server command and benchmark command
-- whether each parameter in the search plan was accepted by that exact CLI
+- model and tokenizer path, target frameworks, GPU model/count, multi-node
+  allowance, precision, and quantization constraints
+- endpoint shape, workload source, dataset scenarios, SLA target, search budget,
+  and artifact output directory
+- version manifest: framework package version or git commit, container/Python
+  environment, `--help` snapshots, and whether each search parameter was
+  accepted by that exact CLI
 
 If real production traffic is the goal, use the real request distribution. A
 synthetic workload is fine for bring-up and first-pass comparison, but it is not
@@ -239,13 +216,10 @@ For TensorRT-LLM, also confirm that `trtllm-serve serve --help` accepts
 `--backend pytorch`. If it does not, mark TensorRT-LLM unsupported in that
 environment rather than falling back to a different server backend.
 
-For each framework:
-
-1. Launch a minimal server.
-2. Confirm `/v1/models` or the framework-native model-info endpoint works.
-3. Send one streaming request and verify TTFT can be measured.
-4. Run one tiny benchmark with at least 5 requests.
-5. Save the launch command, benchmark command, server log, and benchmark output.
+For each framework, launch a minimal server, confirm `/v1/models` or the native
+model-info endpoint, send one streaming request, run one tiny benchmark with at
+least 5 requests, then save the launch command, benchmark command, server log,
+and benchmark output.
 
 Before any GPU-backed smoke run, check the requested GPU ids directly with
 `nvidia-smi`. If a requested GPU is already in use, stop and record that fact.
@@ -254,9 +228,8 @@ fine to run a smaller one-GPU smoke only when the result is clearly labeled as a
 flow check rather than a fair throughput comparison.
 
 If the target environment runs through containers, follow
-[references/container-runbook.md](references/container-runbook.md). Save the
-image tags, pull commands, launch commands, server logs, benchmark logs, and
-cleanup commands in the artifact directory.
+[references/container-runbook.md](references/container-runbook.md) and save image
+tags, pull commands, launch/benchmark logs, and cleanup commands.
 
 ### 2. Normalize The Workload
 
@@ -502,24 +475,16 @@ Rank candidates in this order:
 
 ## Output Contract
 
-Return a compact report with:
+Return a compact report with workload/SLA, hardware and framework versions, best
+deployment-command tables per framework/scenario, one cross-framework comparison
+table, exact launch and benchmark commands for winners, and artifact paths for
+workload, raw/normalized results, CSV or markdown summary, and server logs.
 
-- workload and SLA used
-- hardware and framework versions
-- for each framework, one table listing the best deployment command for each
-  dataset scenario and all relevant performance metrics
-- one cross-framework comparison table for the selected best command per
-  framework and scenario, including the command, so the deployment choice is
-  clear for each dataset
-- failed or excluded candidates with reasons. Explain that this table is an
-  record of tried configs that were not selected: candidates that failed, were
-  skipped by policy, or completed but missed the SLA.
-- exact launch command and benchmark command for each winner
-- artifact paths: canonical workload, raw results JSONL, normalized JSONL, CSV or
-  markdown summary, and server logs needed to debug winners or failures
-- a caveat if the workload was synthetic, if any framework did not complete a
-  fair search, or if any framework needed framework-specific parameter
-  substitutions
+Include failed or excluded candidates with reasons. Explain that this table is a
+record of tried configs that were not selected: candidates that failed, were
+skipped by policy, or completed but missed the SLA. Add caveats for synthetic
+workloads, incomplete fair searches, or framework-specific parameter
+substitutions.
 
 Use [references/framework-matrix.md](references/framework-matrix.md) when you
 need command templates or source links for each framework. Use

--- a/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
+++ b/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
@@ -267,11 +267,11 @@ def render_markdown(rows: list[dict[str, Any]]) -> str:
         for row in failed:
             lines.append(
                 "| {framework} | {candidate} | {status} | {sla} | {reason} |".format(
-                    framework=_get(row, "framework", ""),
-                    candidate=_get(row, "candidate_id", ""),
-                    status=_get(row, "status", ""),
-                    sla=_bool(row, "sla.passed"),
-                    reason=str(_get(row, "failure_reason", "")).replace("|", "\\|"),
+                    framework=_cell(_get(row, "framework", "")),
+                    candidate=_cell(_get(row, "candidate_id", "")),
+                    status=_cell(_get(row, "status", "")),
+                    sla=_cell(_bool(row, "sla.passed")),
+                    reason=_cell(_get(row, "failure_reason", "")),
                 )
             )
     return "\n".join(lines) + "\n"

--- a/skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py
+++ b/skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py
@@ -140,6 +140,8 @@ def _max_required_sequence(dataset: dict[str, Any]) -> int:
         raise ValueError("dataset.input_len and dataset.output_len must be lists")
     if len(input_len) != len(output_len):
         raise ValueError("dataset.input_len and dataset.output_len must be aligned")
+    if not input_len:
+        raise ValueError("dataset.input_len and dataset.output_len must not be empty")
     return max(int(i) + int(o) for i, o in zip(input_len, output_len, strict=True))
 
 
@@ -231,6 +233,7 @@ def _validate_framework(
     config: dict[str, Any],
     framework: str,
     help_flags: dict[str, set[str]] | None,
+    max_candidates: int,
 ) -> list[str]:
     errors: list[str] = []
     server = config["frameworks"].get(framework)
@@ -247,7 +250,8 @@ def _validate_framework(
     if not isinstance(search_space, dict):
         errors.append(f"{framework}: search_space must be a mapping")
         search_space = {}
-    if not isinstance(server.get("server_command"), str):
+    server_command_is_valid = isinstance(server.get("server_command"), str)
+    if not server_command_is_valid:
         errors.append(f"{framework}: server_command must be a string")
 
     for key in set(base_flags) | set(search_space):
@@ -262,14 +266,17 @@ def _validate_framework(
         if "backend" in search_space:
             errors.append("tensorrt_llm: backend must not appear in search_space")
 
-    max_candidates = int(config["search"].get("max_candidates_per_framework", 1))
     candidates = _candidate_dicts(base_flags, search_space, max_candidates)
     if not candidates:
         errors.append(f"{framework}: no candidates generated")
-    for candidate in candidates:
-        command = render_command(framework, config, candidate)
-        if not command:
-            errors.append(f"{framework}: rendered an empty command")
+    can_render = server_command_is_valid and isinstance(
+        config.get("model", {}).get("name"), str
+    )
+    if can_render:
+        for candidate in candidates:
+            command = render_command(framework, config, candidate)
+            if not command:
+                errors.append(f"{framework}: rendered an empty command")
 
     return errors
 
@@ -297,15 +304,28 @@ def validate_config(
         errors.append(str(exc))
         required_sequence = 0
 
-    if int(config.get("search", {}).get("max_candidates_per_framework", 0)) < 1:
-        errors.append("search.max_candidates_per_framework must be positive")
+    search = config.get("search")
+    if not isinstance(search, dict):
+        errors.append("search must be a mapping")
+        max_candidates = 1
+    else:
+        try:
+            max_candidates = int(search.get("max_candidates_per_framework", 0))
+        except (TypeError, ValueError):
+            errors.append("search.max_candidates_per_framework must be an integer")
+            max_candidates = 1
+        if max_candidates < 1:
+            errors.append("search.max_candidates_per_framework must be positive")
+            max_candidates = 1
 
     frameworks = config.get("frameworks")
     if not isinstance(frameworks, dict):
         return errors + ["frameworks must be a mapping"]
 
     for framework in FRAMEWORKS:
-        errors.extend(_validate_framework(config, framework, help_flags))
+        errors.extend(
+            _validate_framework(config, framework, help_flags, max_candidates)
+        )
 
     for framework in FRAMEWORKS:
         if not _enabled(config, framework):
@@ -314,11 +334,17 @@ def validate_config(
         fw = frameworks[framework]
         base_flags = fw.get("base_server_flags", {}) or {}
         search_space = fw.get("search_space", {}) or {}
+        if not isinstance(base_flags, dict) or not isinstance(search_space, dict):
+            continue
 
-        if framework == "sglang":
-            base_value = int(base_flags.get(key, required_sequence))
-        else:
-            base_value = int(base_flags.get(key, 0))
+        try:
+            if framework == "sglang":
+                base_value = int(base_flags.get(key, required_sequence))
+            else:
+                base_value = int(base_flags.get(key, 0))
+        except (TypeError, ValueError):
+            errors.append(f"{framework}: base {key} is not an integer")
+            continue
         if base_value < required_sequence:
             errors.append(
                 f"{framework}: base {key} ({base_value}) is smaller than the largest dataset scenario ({required_sequence})"

--- a/skills/llm-torch-profiler-analysis/scripts/analyze_llm_torch_profile.py
+++ b/skills/llm-torch-profiler-analysis/scripts/analyze_llm_torch_profile.py
@@ -350,25 +350,6 @@ def stage_display(stage: str) -> str:
     return kernel_helpers.stage_label(stage)
 
 
-def pick_trace_for_stage(stage_to_trace: Dict[str, Path], stage: str) -> Optional[Path]:
-    if stage in stage_to_trace:
-        return stage_to_trace[stage]
-    if "all" in stage_to_trace:
-        return stage_to_trace["all"]
-    if len(stage_to_trace) == 1:
-        return next(iter(stage_to_trace.values()))
-    return None
-
-
-def build_stage_trace_map(trace_paths: Sequence[Path]) -> Dict[str, Path]:
-    stage_map: Dict[str, Path] = {}
-    for trace_path in sorted(
-        trace_paths, key=lambda item: (stage_index(parse_stage(item)), item.name)
-    ):
-        stage_map[parse_stage(trace_path)] = trace_path
-    return stage_map
-
-
 def pick_stage_value(stage_to_value: Dict[str, object], stage: str) -> Optional[object]:
     if stage in stage_to_value:
         return stage_to_value[stage]
@@ -604,6 +585,7 @@ def run_triage(args: argparse.Namespace) -> int:
 
     kernel_rows_rendered: List[dict] = []
     fuse_rows_rendered: List[dict] = []
+    formal_stage_payloads: Dict[str, dict] = {}
 
     for formal_trace in formal_traces:
         trace = load_trace_json(formal_trace)
@@ -619,7 +601,6 @@ def run_triage(args: argparse.Namespace) -> int:
             launch_events
         )
         formal_site_context_cache = {}
-        formal_local_stage_payloads: Dict[str, dict] = {}
         for stage_name, stage_kernels in stage_groups.items():
             local_site_stats = kernel_helpers.aggregate_kernel_sites(
                 stage_kernels,
@@ -628,14 +609,9 @@ def run_triage(args: argparse.Namespace) -> int:
                 launches_by_correlation=formal_launches_by_correlation,
                 site_context_cache=formal_site_context_cache,
             )
-            formal_local_stage_payloads[stage_name] = (
-                kernel_helpers.build_stage_payload(
-                    local_site_stats,
-                    {
-                        kernel.canonical_name: kernel.category
-                        for kernel in stage_kernels
-                    },
-                )
+            formal_stage_payloads[stage_name] = kernel_helpers.build_stage_payload(
+                local_site_stats,
+                {kernel.canonical_name: kernel.category for kernel in stage_kernels},
             )
         trace_total_us = sum(kernel.dur for kernel in kernels)
         for stage in sorted(stage_groups, key=stage_index):
@@ -659,9 +635,7 @@ def run_triage(args: argparse.Namespace) -> int:
                 stage=stage,
                 kernel_stats=kernel_stats,
                 kernel_categories=kernel_categories,
-                local_stage_payload=formal_local_stage_payloads.get(
-                    stage, {"kernels": {}}
-                ),
+                local_stage_payload=formal_stage_payloads.get(stage, {"kernels": {}}),
                 external_kernel_map=mapping_kernel_map,
             )
             visible_kernel_rows = kernel_helpers.limit_kernel_rows(
@@ -742,7 +716,7 @@ def run_triage(args: argparse.Namespace) -> int:
             )
             source_map = overlap_helpers.merge_source_map_from_kernel_payload(
                 source_map,
-                pick_stage_value(formal_local_stage_payloads, stage),
+                pick_stage_value(formal_stage_payloads, stage),
             )
             stage_rows = overlap_helpers.build_action_rows(
                 aggregates,

--- a/skills/model-optimization/sglang/sglang-kimi-k2-k25-optimization/SKILL.md
+++ b/skills/model-optimization/sglang/sglang-kimi-k2-k25-optimization/SKILL.md
@@ -9,10 +9,17 @@ description: PR-backed and current-main optimization manual for `moonshotai/Kimi
 
 The skill is an optimization ladder. Identify which stage the current code is at, apply the next missing optimization, and only move deeper after the earlier stage is satisfied.
 
-Current-main snapshot:
-This skill was refreshed against SGLang `origin/main` commit `c122d343a` on `2026-04-21`. Since the older PR ladder was written, current main has added a Kimi-K2.5 usage doc, parser and OpenAI-serving tests for `kimi_k2`, Kimi-K2.5 LoRA regression coverage, AMD/GB300 validation lanes, and a Kimi-K2-Thinking stress test. Treat those as part of the active validation surface, not as optional CI trivia.
-Active open PRs now also define several next likely skill updates: W4AFP8 loading, W4A16 DeepEP low-latency, Kimi-K2.5 multimodal processor fixes, ROCm fused QK RMSNorm, and JIT migration of the older K2 fused gate path.
-One important non-open gap is Kimi-K2-Thinking DeepEP plus int4/Marlin: [#13789](https://github.com/sgl-project/sglang/pull/13789) tried to support it but was closed unmerged after hitting an illegal memory access in the `fused_marlin_moe` path. Do not mark that combination as mainline-supported just because the generic Marlin JIT work in [#19181](https://github.com/sgl-project/sglang/pull/19181) landed.
+Current-main snapshot: refreshed against SGLang `origin/main` commit `c122d343a`
+on `2026-04-21`. Treat the Kimi-K2.5 usage doc, `kimi_k2` parser/OpenAI tests,
+Kimi-K2.5 LoRA regression, AMD/GB300 lanes, and Kimi-K2-Thinking stress test as
+active validation surfaces.
+
+Active open PRs define likely updates for W4AFP8 loading, W4A16 DeepEP
+low-latency, Kimi-K2.5 multimodal processor fixes, ROCm fused QK RMSNorm, and
+JIT migration of the older K2 fused gate path. Keep Kimi-K2-Thinking DeepEP plus
+int4/Marlin marked unsupported: [#13789](https://github.com/sgl-project/sglang/pull/13789)
+closed unmerged after an illegal memory access in `fused_marlin_moe`, even though
+generic Marlin JIT work landed in [#19181](https://github.com/sgl-project/sglang/pull/19181).
 
 The historical evidence for every stage lives in:
 
@@ -384,24 +391,19 @@ Current main has enough Kimi-K2.5 coverage that optimization work should preserv
 - keep the documented Kimi-K2.5 launch contract in sync with tests: `--tool-call-parser kimi_k2` and `--reasoning-parser kimi_k2`
 - preserve Kimi grid metadata flow: `grid_thws`, `KimiGridMMDataMixin`, and the GPU image preprocessing path with CPU-compatible inputs
 - if LoRA, MoE LoRA sharing, attention backend selection, or logprob paths are touched, include the Kimi-K2.5 LoRA regression
-- choose AMD validation by backend and quant shape:
-  - native Kimi-K2.5 with `aiter` MLA uses TP4 on MI35x because 64 heads at TP8 gives only 8 heads per GPU
-  - Kimi-K2.5-MXFP4 MI35x coverage uses TP8 and validates default plus FP8 KV-cache variants
+- choose AMD validation by backend and quant shape: native Kimi-K2.5 with
+  `aiter` MLA uses TP4 on MI35x; Kimi-K2.5-MXFP4 MI35x coverage uses TP8 and
+  validates default plus FP8 KV-cache variants
 - use GB300/NVFP4 lanes when changing Blackwell-specific quant, cache, or kernel behavior
 - use the Kimi-K2-Thinking stress test when parser, long-run stability, or K2 thinking serving paths are involved
 
-- `docs_new/docs/basic_usage/kimi_k2_5.mdx`
-- `python/sglang/srt/function_call/kimik2_detector.py`
-- `python/sglang/srt/parser/reasoning_parser.py`
-- `python/sglang/srt/multimodal/processors/kimi_common.py`
-- `python/sglang/srt/multimodal/processors/kimi_k25.py`
-- `test/registered/function_call/test_kimik2_detector.py`
-- `test/registered/lora/test_lora_kimi_k25_logprob_diff.py`
-- `test/registered/amd/accuracy/mi35x/test_kimi_k25_aiter_mla_eval_mi35x.py`
-- `test/registered/amd/accuracy/mi35x/test_kimi_k25_mxfp4_eval_mi35x.py`
-- `test/registered/gb300/test_kimi_k25.py`
-- `test/registered/gb300/test_kimi_k25_nvfp4.py`
-- `test/registered/stress/test_stress_kimi_k2.py`
+Key files/tests:
+
+- docs/parser/processors: `kimi_k2_5.mdx`, `kimik2_detector.py`,
+  `reasoning_parser.py`, `kimi_common.py`, `kimi_k25.py`
+- registered lanes: `test_kimik2_detector.py`,
+  `test_lora_kimi_k25_logprob_diff.py`, the two MI35x Kimi-K2.5 accuracy tests,
+  `test_kimi_k25.py`, `test_kimi_k25_nvfp4.py`, and `test_stress_kimi_k2.py`
 
 - docs, registered launches, and stress tests agree on the parser flags
 - image token expansion still derives from grid metadata instead of placeholder counts alone
@@ -420,27 +422,17 @@ Use this decision process:
 4. Validate narrowly on the exact serving shape.
 5. Only after that, widen to more topology combinations.
 
-Examples:
-
-- K2 decode is still spending time in generic grouped-topk:
-  you are missing `K2-2`, so do not jump straight to fused-MoE tuning files.
-- K2 fused gate exists but PCG crashes:
-  you are at `K2-6`, so focus on fake op registration or invalid-selection guards.
-- K2.5 int4 on AMD uses a default config:
-  you are at `K25-5`, so tune the wrapper-aware fused-MoE path before editing the model wrapper again.
-- K2.5 PP works but Eagle3 multimodal crashes:
-  you are at `K25-6` or `K25-7`, not at the early support stages.
-- K2.5 tool calls, thinking output, image requests, or LoRA logprobs regress after a runtime change:
-  you are at `K25-8`; check launch parser flags, grid metadata, OpenAI-serving parser tests, and the targeted backend lane before blaming the MoE kernel.
+Quick mapping examples: generic grouped-topk means `K2-2`; fused-gate PCG crash
+means `K2-6`; AMD int4 default config means `K25-5`; Eagle3 multimodal crash
+after PP works means `K25-6` or `K25-7`; parser, thinking, image, or LoRA
+logprob regressions after runtime work mean `K25-8`.
 
 For non-Kimi models, map them by structure:
 
-- a new sparse MoE model with non-generic expert count or router shape:
-  treat it like the K2 path first
-- a quantized sparse MoE model whose hot path runs through Marlin:
-  treat it like the K2 thinking Marlin path
-- a wrapped multimodal model whose PP, PD, DP encoder, or speculative decode support keeps breaking:
-  treat it like the K2.5 path first
+- non-generic sparse MoE expert count or router shape: K2 path first
+- quantized sparse MoE hot path through Marlin: K2 thinking Marlin path
+- wrapped multimodal model with PP, PD, DP encoder, or speculative decode issues:
+  K2.5 path first
 
 ## Guardrails
 
@@ -498,13 +490,11 @@ pytest -q test/registered/gb300/test_kimi_k25_nvfp4.py
 pytest -q test/registered/stress/test_stress_kimi_k2.py
 ```
 
-For tuning work:
-
-- rerun only the relevant tuning script
-- keep the real model, quant, TP, EP, and backend
-- save output under the exact config filename contract
+For tuning work, rerun only the relevant tuning script, keep the real model,
+quant, TP, EP, and backend, and save output under the exact config filename
+contract.
 
 ## References
 
-- Historical evidence and benchmark tables: [references/pr-history.md](references/pr-history.md)
-- Symptom mapping and validation order: [references/playbook.md](references/playbook.md)
+Use [references/pr-history.md](references/pr-history.md) for PR evidence and
+[references/playbook.md](references/playbook.md) for symptom mapping and validation order.

--- a/skills/model-optimization/sglang/sglang-kimi-k2-k25-optimization/agents/openai.yaml
+++ b/skills/model-optimization/sglang/sglang-kimi-k2-k25-optimization/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "SGLang Kimi K2/K2.5 Optimization"
   short_description: "Current-main Kimi playbook for MoE, VLM, parser, quant, LoRA, backend validation, and open PR radar"
-  default_prompt: "Optimize or debug moonshotai/Kimi-K2 or Kimi-K2.5 in SGLang, including K2 router/MoE paths, K2.5 wrapper and multimodal plumbing, W4AFP8/W4A16 quant tracks, kimi_k2 parser behavior, LoRA, and backend-specific validation lanes."
+  default_prompt: "Use $sglang-kimi-k2-k25-optimization to optimize or debug moonshotai/Kimi-K2 or Kimi-K2.5 in SGLang, including K2 router/MoE paths, K2.5 wrapper and multimodal plumbing, W4AFP8/W4A16 quant tracks, kimi_k2 parser behavior, LoRA, and backend-specific validation lanes."

--- a/tests/test_compare_benchmark_results.py
+++ b/tests/test_compare_benchmark_results.py
@@ -131,6 +131,26 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
         self.assertNotIn("mmlu_accuracy", text)
         self.assertNotIn("gsm8k_accuracy", text)
 
+    def test_failed_candidate_table_escapes_markdown_cells(self) -> None:
+        rows = [
+            {
+                "framework": "trt|llm",
+                "candidate_id": "trt|bad",
+                "status": "failed|startup",
+                "failure_reason": "server | exited",
+                "sla": {"passed": False},
+                "metrics": {},
+                "hardware": {"gpu_count": 1},
+            }
+        ]
+
+        summary = self.mod.render_markdown(rows)
+
+        self.assertIn("trt\\|llm", summary)
+        self.assertIn("trt\\|bad", summary)
+        self.assertIn("failed\\|startup", summary)
+        self.assertIn("server \\| exited", summary)
+
     def test_renders_scenario_tables(self) -> None:
         rows = [
             {
@@ -183,7 +203,10 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
 
         scenario_winners = self.mod.best_by_framework_and_scenario(rows)
         self.assertEqual(
-            {(row["framework"], row["workload"]["scenario"]) for row in scenario_winners},
+            {
+                (row["framework"], row["workload"]["scenario"])
+                for row in scenario_winners
+            },
             {("sglang", "chat"), ("vllm", "chat"), ("sglang", "summarization")},
         )
 

--- a/tests/test_llm_serving_cookbook_configs.py
+++ b/tests/test_llm_serving_cookbook_configs.py
@@ -15,7 +15,9 @@ VALIDATOR = SKILL_ROOT / "scripts" / "validate_cookbook_configs.py"
 
 
 def load_validator():
-    spec = importlib.util.spec_from_file_location("validate_cookbook_configs", VALIDATOR)
+    spec = importlib.util.spec_from_file_location(
+        "validate_cookbook_configs", VALIDATOR
+    )
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -65,7 +67,9 @@ class LlmServingCookbookConfigsTest(unittest.TestCase):
         self.assertIn("--tp-size 8", sglang_command)
 
         vllm = config["frameworks"]["vllm"]
-        vllm_command = self.mod.render_command("vllm", config, vllm["base_server_flags"])
+        vllm_command = self.mod.render_command(
+            "vllm", config, vllm["base_server_flags"]
+        )
         self.assertIn("vllm serve Qwen/Qwen3-235B-A22B", vllm_command)
         self.assertIn("--tensor-parallel-size 8", vllm_command)
         self.assertNotIn("--tp-size", vllm_command)
@@ -101,6 +105,34 @@ class LlmServingCookbookConfigsTest(unittest.TestCase):
             for path in self.config_paths():
                 with self.subTest(path=path.name):
                     self.assertEqual(self.mod.validate_config(path, help_flags), [])
+
+    def test_invalid_config_reports_errors_without_crashing(self) -> None:
+        config = {
+            "schema_version": 1,
+            "source": {"kind": "llm_serving_cookbook"},
+            "model": {"name": "example/model"},
+            "dataset": {"input_len": [], "output_len": []},
+            "frameworks": {
+                "sglang": {
+                    "enabled": True,
+                    "base_server_flags": {},
+                    "search_space": {},
+                },
+                "vllm": {"enabled": False},
+                "tensorrt_llm": {"enabled": False},
+            },
+        }
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "invalid.yaml"
+            path.write_text(yaml.safe_dump(config), encoding="utf-8")
+            errors = self.mod.validate_config(path)
+
+        self.assertIn(
+            "dataset.input_len and dataset.output_len must not be empty", errors
+        )
+        self.assertIn("search must be a mapping", errors)
+        self.assertIn("sglang: server_command must be a string", errors)
 
 
 if __name__ == "__main__":

--- a/tests/test_llm_torch_profiler_analysis.py
+++ b/tests/test_llm_torch_profiler_analysis.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+SCRIPT_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "skills"
+    / "llm-torch-profiler-analysis"
+    / "scripts"
+)
+SCRIPT = SCRIPT_DIR / "analyze_llm_torch_profile.py"
+
+
+def load_module():
+    sys.path.insert(0, str(SCRIPT_DIR))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "analyze_llm_torch_profile", SCRIPT
+        )
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.path.remove(str(SCRIPT_DIR))
+
+
+class KernelStub:
+    def __init__(self, name: str, stage: str) -> None:
+        self.name = name
+        self.canonical_name = name
+        self.category = "compute"
+        self.stage = stage
+        self.dur = 100.0
+        self.ts = 0.0
+
+
+class LlmTorchProfilerAnalysisTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = load_module()
+
+    def test_mapping_formal_overlap_uses_matching_formal_stage_payload(self) -> None:
+        args = SimpleNamespace(
+            input=None,
+            url=None,
+            mapping_input="mapping",
+            mapping_url=None,
+            formal_input="formal",
+            formal_url=None,
+            output_dir=None,
+            mapping_output_dir=None,
+            formal_output_dir=None,
+            profile_prefix=None,
+            mapping_profile_prefix="mapping-trace",
+            formal_profile_prefix="formal-trace",
+            num_steps=5,
+            profile_by_stage=True,
+            merge_profiles=False,
+            probe_requests=0,
+            probe_prompt="x",
+            probe_max_new_tokens=None,
+            probe_delay=0.0,
+            start_step=None,
+            framework="sglang",
+            pid_substring=None,
+            kernel_table_limit=0,
+            overlap_table_limit=0,
+        )
+
+        mapping_trace = Path("mapping.trace.json")
+        formal_extend_trace = Path("formal-extend.trace.json")
+        formal_decode_trace = Path("formal-decode.trace.json")
+        payloads_seen_by_overlap = []
+
+        def fake_resolve_profile_targets(*, label, **_kwargs):
+            if label == "mapping":
+                return [mapping_trace], None, "sglang"
+            return [formal_extend_trace, formal_decode_trace], None, "sglang"
+
+        def fake_extract_trace_data(_trace):
+            call_index = fake_extract_trace_data.call_count
+            fake_extract_trace_data.call_count += 1
+            if call_index == 0:
+                kernel = KernelStub("k_mapping", "all")
+            elif call_index == 1:
+                kernel = KernelStub("k_extend", "extend")
+            else:
+                kernel = KernelStub("k_decode", "decode")
+            return [kernel], [], {}, [], None, 100.0
+
+        fake_extract_trace_data.call_count = 0
+
+        def fake_group_kernels_by_stage(kernels, _default_stage):
+            return {kernels[0].stage: kernels}
+
+        def fake_build_stage_payload(_site_stats, kernel_categories):
+            kernel_name = next(iter(kernel_categories))
+            return {"kernels": {kernel_name: {"best_location": kernel_name}}}
+
+        def fake_build_overlap_stage_bundle_map(_traces, **_kwargs):
+            return {
+                "extend": SimpleNamespace(events=[], raw_events=[], server_args=None),
+                "decode": SimpleNamespace(events=[], raw_events=[], server_args=None),
+            }
+
+        def fake_merge_source_map_from_kernel_payload(source_map, stage_payload):
+            payloads_seen_by_overlap.append(stage_payload)
+            return source_map
+
+        with (
+            mock.patch.object(
+                self.mod, "resolve_profile_targets", fake_resolve_profile_targets
+            ),
+            mock.patch.object(self.mod, "load_trace_json", return_value={}),
+            mock.patch.object(
+                self.mod,
+                "build_overlap_stage_bundle_map",
+                fake_build_overlap_stage_bundle_map,
+            ),
+            mock.patch.object(
+                self.mod.kernel_helpers, "extract_trace_data", fake_extract_trace_data
+            ),
+            mock.patch.object(
+                self.mod.kernel_helpers,
+                "group_kernels_by_stage",
+                fake_group_kernels_by_stage,
+            ),
+            mock.patch.object(
+                self.mod.kernel_helpers, "build_cpu_op_index", return_value={}
+            ),
+            mock.patch.object(
+                self.mod.kernel_helpers, "build_launch_index", return_value={}
+            ),
+            mock.patch.object(
+                self.mod.kernel_helpers, "aggregate_kernel_sites", return_value={}
+            ),
+            mock.patch.object(
+                self.mod.kernel_helpers, "build_stage_payload", fake_build_stage_payload
+            ),
+            mock.patch.object(self.mod.kernel_helpers, "aggregate", return_value={}),
+            mock.patch.object(
+                self.mod.kernel_helpers, "build_kernel_rows", return_value=[]
+            ),
+            mock.patch.object(
+                self.mod.kernel_helpers, "detect_fusion_opportunities", return_value=[]
+            ),
+            mock.patch.object(
+                self.mod.overlap_helpers,
+                "analyze_overlap",
+                return_value={"total_busy_us": 100.0},
+            ),
+            mock.patch.object(
+                self.mod.overlap_helpers, "aggregate_events", return_value={}
+            ),
+            mock.patch.object(
+                self.mod.overlap_helpers, "build_kernel_source_map", return_value={}
+            ),
+            mock.patch.object(
+                self.mod.overlap_helpers,
+                "merge_source_map_from_kernel_payload",
+                fake_merge_source_map_from_kernel_payload,
+            ),
+            mock.patch.object(
+                self.mod.overlap_helpers, "build_action_rows", return_value=[]
+            ),
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            self.assertEqual(self.mod.run_triage(args), 0)
+
+        self.assertEqual(
+            [set(payload["kernels"]) for payload in payloads_seen_by_overlap],
+            [{"k_extend"}, {"k_decode"}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Harden the LLM torch profiler mapping/formal analysis so overlap source mapping uses the matching formal stage payload for extend/decode traces.
- Simplify long skill docs without changing the documented workflows, and fix the Kimi K2 agent prompt skill reference.
- Make benchmark cookbook/config reporting more robust and escape Markdown cells in failed benchmark candidate tables.
- Add regression coverage for profiler stage payload mapping, config validation failures, and benchmark table escaping.

## Validation

- `python3 -m pytest -q` -> 17 passed
- `python3 -m ruff check .`
- `python3 -m compileall -q skills tests`
- `pre-commit run --all-files`
- Checked all `SKILL.md` frontmatter and ensured no `SKILL.md` exceeds 500 lines.
- H100 real-model validation with `mistralai/Mistral-7B-Instruct-v0.3` using SGLang live profiling. Artifacts are under `/data/bbuf/validate/unified_llm_profiler_skill/runs/20260424_post_review_mistral7b_sglang_live_pcg_off`; live probe returned 3/3 successful non-empty responses, generated fresh EXTEND/DECODE traces, and rendered Kernel, Overlap Opportunity, and Fuse Opportunity tables for both live and mapping/formal analysis.

## Notes

The first H100 server startup hit SGLang piecewise CUDA graph illegal-memory-access during warmup. The successful validation used `--disable-piecewise-cuda-graph`, matching the server log recommendation; this was a SGLang runtime startup issue rather than a profiler skill regression.
