### PR TITLE
Add vLLM model skill and history coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,128 +6,90 @@ Agent skills for SGLang/vLLM/TensorRT-LLM development, profiling, and production
 
 ```
 skills/
-├── model-optimization/            # model-family optimization handbook series
-│   ├── model-pr-diff-dossier/     # shared per-PR dossier production standard
-│   ├── sglang/                    # SGLang model-family skills
-│   └── vllm/                      # reserved for future vLLM model-family skills
-├── llm-serving-auto-benchmark/    # framework-neutral serving benchmark playbook
-│   ├── SKILL.md
-│   ├── agents/
-│   ├── configs/cookbook-llm/
-│   ├── references/
-│   └── scripts/                   # validate_cookbook_configs.py, compare_benchmark_results.py
-├── llm-torch-profiler-analysis/   # unified torch-profiler triage for SGLang / vLLM / TensorRT-LLM
-│   ├── SKILL.md
-│   ├── agents/
-│   ├── references/
-│   └── scripts/                   # analyze_llm_torch_profile.py (preferred) + helpers + host runners
-├── sglang-prod-incident-triage/   # replay-first debug flow for SGLang serving
-│   ├── SKILL.md
-│   ├── agents/
-│   ├── references/
-│   └── scripts/                   # incident_artifact_tool.py, replay_trusted_request_dump.py
-├── h100/                          # operator skill for the h100_sglang host
-│   └── SKILL.md
-└── h100-sglang-diffusion/         # h100 operator skill with diffusion-specific overrides
-    └── SKILL.md
+├── model-optimization/
+│   ├── model-pr-diff-dossier/
+│   ├── sglang/
+│   └── vllm/
+├── llm-serving-auto-benchmark/
+├── llm-torch-profiler-analysis/
+├── sglang-prod-incident-triage/
+├── h100/
+└── h100-sglang-diffusion/
 ```
 
-Run each skill's `ls` to see its exact current file set; this overview is a
-high-level map, not a line-level inventory.
+Model histories are framework-scoped under `model-pr-optimization-history/sglang/` and `model-pr-optimization-history/vllm/`.
 
-Model PR histories are framework-scoped:
-
-```
-model-pr-optimization-history/
-├── sglang/
-│   ├── model-skill-pr-dossier-quality-scan-2026-04-23.md
-│   ├── deepseek-v3-r1/
-│   ├── qwen3-core/
-│   ├── glm45/
-│   └── ...
-└── vllm/
-    └── README.md
-```
-
-## Placeholders
-
-The `h100` and `h100-sglang-diffusion` skills document a concrete remote
-environment (SSH alias `h100_sglang`, container `sglang_bbuf`, repo paths
-`/sgl-workspace/sglang` and `/data/bbuf/repos/sglang`) because they are the
-operator's own runbooks. Only secret-shaped values are templated with
-placeholders that you must replace before running:
-
-| Placeholder       | Meaning                                                 |
-| ----------------- | ------------------------------------------------------- |
-| `<your-hf-token>` | Hugging Face access token (never commit the real value) |
-
-When adapting these skills to a different host/container/repo layout, copy the
-SKILL and replace the concrete SSH alias, Docker name, and workspace path in
-one pass rather than introducing generic `<...>` placeholders that drift out of
-sync.
-
-## Model Optimization Skills
-
-The model optimization handbook series keeps shared production rules at the `model-optimization/` root, then splits framework-specific model-family skills by serving framework. This keeps SGLang and future vLLM model dossiers organized without duplicating common requirements.
-
-SGLang model optimization skills live under `skills/model-optimization/sglang/`:
+## SGLang Model Skills
 
 - `sglang-deepseek-v3-r1-optimization`
 - `sglang-deepseek-v31-optimization`
 - `sglang-deepseek-v32-optimization`
-- `sglang-kimi-k2-k25-optimization`
-- `sglang-minimax-m2-series-optimization`
+- `sglang-deepseek-v4-optimization`
+- `sglang-glm-vlm-ocr-optimization`
+- `sglang-glm45-optimization`
+- `sglang-glm46-glm47-optimization`
+- `sglang-glm5-glm51-optimization`
+- `sglang-hunyuan3-preview-optimization`
+- `sglang-kimi-optimization`
+- `sglang-ltx23-hq-optimization`
+- `sglang-minimax-optimization`
+- `sglang-mixtral-quark-int4fp8-moe-optimization`
+- `sglang-moss-vl-optimization`
+- `sglang-qwen-image-optimization`
+- `sglang-qwen-vlm-omni-asr-optimization`
+- `sglang-qwen3-coder-optimization`
 - `sglang-qwen3-core-optimization`
 - `sglang-qwen3-next-optimization`
 - `sglang-qwen35-optimization`
 - `sglang-qwen36-optimization`
-- `sglang-qwen3-coder-optimization`
-- `sglang-qwen-vlm-omni-asr-optimization`
-- `sglang-qwen-image-optimization`
-- `sglang-glm45-optimization`
-- `sglang-glm46-glm47-optimization`
-- `sglang-glm5-glm51-optimization`
-- `sglang-glm-vlm-ocr-optimization`
+- `sglang-z-image-turbo-optimization`
+- `sglang-ernie45-optimization`
+- `sglang-gemma4-optimization`
+- `sglang-gpt-oss-optimization`
+- `sglang-intern-s1-optimization`
+- `sglang-internvl35-optimization`
+- `sglang-llama4-optimization`
+- `sglang-mimo-v2-flash-optimization`
+- `sglang-mistral-small-4-optimization`
+- `sglang-nemotron-super-optimization`
+- `sglang-step35-optimization`
+## vLLM Model Skills
 
-The shared `skills/model-optimization/model-pr-diff-dossier/` skill records the mandatory production standard for model PR histories: read every PR diff and write motivation, implementation, code excerpt, and validation/risk.
-
-Future vLLM model optimization skills should live under `skills/model-optimization/vllm/` and follow the same per-PR dossier standard.
-
-## Model PR Optimization History
-
-The `model-pr-optimization-history/` directory is framework-scoped.
-
-SGLang bilingual model evolution notes live under `model-pr-optimization-history/sglang/`:
-
-- `deepseek-v3-r1`
-- `deepseek-v31`
-- `deepseek-v32`
-- `kimi`
-- `minimax`
-- `qwen3-core`
-- `qwen3-next`
-- `qwen35`
-- `qwen36`
-- `qwen3-coder`
-- `qwen-vlm-omni-asr`
-- `qwen-image`
-- `glm45`
-- `glm46-glm47`
-- `glm5-glm51`
-- `glm-vlm-ocr`
-
-Cross-family audits sit next to those directories (not as a family of their own):
-
-- `model-pr-optimization-history/sglang/model-skill-pr-dossier-quality-scan-2026-04-23.md`
-
-Future vLLM model histories should live under `model-pr-optimization-history/vllm/`.
-
+- `vllm-deepseek-v3-r1-optimization`
+- `vllm-deepseek-v31-optimization`
+- `vllm-deepseek-v32-optimization`
+- `vllm-deepseek-v4-optimization`
+- `vllm-glm-vlm-ocr-optimization`
+- `vllm-glm45-optimization`
+- `vllm-glm46-glm47-optimization`
+- `vllm-glm5-glm51-optimization`
+- `vllm-hunyuan3-preview-optimization`
+- `vllm-kimi-optimization`
+- `vllm-ltx23-hq-optimization`
+- `vllm-minimax-optimization`
+- `vllm-mixtral-quark-int4fp8-moe-optimization`
+- `vllm-moss-vl-optimization`
+- `vllm-qwen-image-optimization`
+- `vllm-qwen-vlm-omni-asr-optimization`
+- `vllm-qwen3-coder-optimization`
+- `vllm-qwen3-core-optimization`
+- `vllm-qwen3-next-optimization`
+- `vllm-qwen35-optimization`
+- `vllm-qwen36-optimization`
+- `vllm-z-image-turbo-optimization`
+- `vllm-ernie45-optimization`
+- `vllm-gemma4-optimization`
+- `vllm-gpt-oss-optimization`
+- `vllm-intern-s1-optimization`
+- `vllm-internvl35-optimization`
+- `vllm-llama4-optimization`
+- `vllm-mimo-v2-flash-optimization`
+- `vllm-mistral-small-4-optimization`
+- `vllm-nemotron-super-optimization`
+- `vllm-step35-optimization`
 ## Install
 
-Copy the desired skill directory into your local skill path:
-
 ```bash
-cp -r skills/sglang-prod-incident-triage <agent-skill-dir>/sglang-prod-incident-triage
-cp -r skills/llm-torch-profiler-analysis <agent-skill-dir>/llm-torch-profiler-analysis
 cp -r skills/model-optimization/sglang/sglang-qwen3-core-optimization <agent-skill-dir>/sglang-qwen3-core-optimization
+cp -r skills/model-optimization/vllm/vllm-qwen3-core-optimization <agent-skill-dir>/vllm-qwen3-core-optimization
 ```

--- a/model-pr-optimization-history/README.md
+++ b/model-pr-optimization-history/README.md
@@ -3,6 +3,6 @@
 This directory stores model PR optimization histories by serving framework.
 
 - `sglang/`: SGLang model histories and audits.
-- `vllm/`: reserved for future vLLM model histories.
+- `vllm/`: vLLM model histories and audits.
 
 Each model history is bilingual when practical (`README.zh.md` and `README.en.md`) and should mirror the corresponding model skill's `references/pr-history.md`.

--- a/model-pr-optimization-history/sglang/README.md
+++ b/model-pr-optimization-history/sglang/README.md
@@ -1,33 +1,41 @@
 # SGLang Model PR Optimization History
 
-SGLang model PR histories are grouped by model family/generation.
-
 Current families:
 
 - `deepseek-v3-r1`
 - `deepseek-v31`
 - `deepseek-v32`
 - `deepseek-v4`
+- `glm-vlm-ocr`
+- `glm45`
+- `glm46-glm47`
+- `glm5-glm51`
 - `hunyuan3-preview`
 - `kimi`
 - `ltx23-hq`
 - `minimax`
 - `mixtral-quark-int4fp8-moe`
 - `moss-vl`
+- `qwen-image`
+- `qwen-vlm-omni-asr`
+- `qwen3-coder`
 - `qwen3-core`
 - `qwen3-next`
 - `qwen35`
 - `qwen36`
-- `qwen3-coder`
-- `qwen-vlm-omni-asr`
-- `qwen-image`
 - `z-image-turbo`
-- `glm45`
-- `glm46-glm47`
-- `glm5-glm51`
-- `glm-vlm-ocr`
+- `ernie45`
+- `gemma4`
+- `gpt-oss`
+- `intern-s1`
+- `internvl35`
+- `llama4`
+- `mimo-v2-flash`
+- `mistral-small-4`
+- `nemotron-super`
+- `step35`
 
-The cross-family quality scan lives directly in this directory:
+Cross-family audits:
 
 - `model-skill-pr-dossier-quality-scan-2026-04-23.md`
 - `model-skill-pr-dossier-quality-scan-2026-04-24.md`

--- a/model-pr-optimization-history/sglang/ernie45/README.en.md
+++ b/model-pr-optimization-history/sglang/ernie45/README.en.md
@@ -1,0 +1,42 @@
+# SGLang Ernie4.5 / Ernie4.5-VL Support and PR History
+
+This note tracks the Ernie4.5 multimodal path in SGLang at commit
+`c122d343adb969cd9bbd1af2ca86727a11be3845`.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- Ernie4.5-VL support landed as a dedicated runtime and processor, not as a
+  thin alias.
+- The most important optimization work afterward is all in the rotary path:
+  first a fused Triton kernel, then cos/sin cache reuse.
+
+## Main Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/ernie45_vl.py`
+- `sglang/python/sglang/srt/models/ernie45_moe_vl.py`
+- `sglang/python/sglang/srt/multimodal/processors/ernie45_vl.py`
+- `sglang/python/sglang/srt/layers/rotary_embedding.py`
+
+## Landed PRs
+
+- [#15679](https://github.com/sgl-project/sglang/pull/15679)
+  `Add Ernie4.5 VL model support`
+  Diff reviewed: `6` files, `2072` additions.
+  Adds the native Ernie4.5-VL runtime, MoE-VL runtime, processor, and
+  multimodal registration.
+- [#18856](https://github.com/sgl-project/sglang/pull/18856)
+  `Optimize Ernie4.5-VL rotary embedding with fused triton kernel`
+  Diff reviewed: `1` file, `268` additions, `3` deletions.
+  Adds the fused Triton Q/K rotary kernel for Ernie4.5's `(h, w, t)` layout.
+- [#19743](https://github.com/sgl-project/sglang/pull/19743)
+  `Support cos sin cache for Ernie4.5-VL`
+  Diff reviewed: `1` file, `34` additions, `12` deletions.
+  Rewrites the vision tower to reuse `get_rope(...).get_cos_sin(...)`.
+
+## Current Contract
+
+If Ernie4.5-VL regresses, check which rotary path is active before modifying the
+full model. Many correctness and performance changes in this family are local to
+vision rotary handling.

--- a/model-pr-optimization-history/sglang/ernie45/README.zh.md
+++ b/model-pr-optimization-history/sglang/ernie45/README.zh.md
@@ -1,0 +1,39 @@
+# SGLang Ernie4.5 / Ernie4.5-VL 支持与 PR 历史
+
+本文记录 SGLang 在提交 `c122d343adb969cd9bbd1af2ca86727a11be3845`
+附近的 Ernie4.5 多模态支持。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Ernie4.5-VL 不是薄别名，而是带独立 runtime 和 processor 的原生落地。
+- 后续最重要的优化工作基本都集中在 vision rotary 路径:
+  先是 fused Triton kernel，再是 cos/sin cache 复用。
+
+## 主要代码面
+
+- `sglang/python/sglang/srt/models/ernie45_vl.py`
+- `sglang/python/sglang/srt/models/ernie45_moe_vl.py`
+- `sglang/python/sglang/srt/multimodal/processors/ernie45_vl.py`
+- `sglang/python/sglang/srt/layers/rotary_embedding.py`
+
+## 已合入 PR
+
+- [#15679](https://github.com/sgl-project/sglang/pull/15679)
+  `Add Ernie4.5 VL model support`
+  已审 diff: `6` 个文件，`2072` 行新增。
+  它加入原生 Ernie4.5-VL / MoE-VL runtime、processor 和多模态注册。
+- [#18856](https://github.com/sgl-project/sglang/pull/18856)
+  `Optimize Ernie4.5-VL rotary embedding with fused triton kernel`
+  已审 diff: `1` 个文件，`268` 行新增，`3` 行删除。
+  它为 Ernie4.5 的 `(h, w, t)` 布局加入 fused Triton Q/K rotary kernel。
+- [#19743](https://github.com/sgl-project/sglang/pull/19743)
+  `Support cos sin cache for Ernie4.5-VL`
+  已审 diff: `1` 个文件，`34` 行新增，`12` 行删除。
+  它把 vision tower 改成复用 `get_rope(...).get_cos_sin(...)`。
+
+## 当前结论
+
+如果 Ernie4.5-VL 回归了，先确认当前走的是哪条 rotary 路径，再去改整套模型。
+这个家族很多 correctness / performance 变化都集中在 vision rotary 处理。

--- a/model-pr-optimization-history/sglang/gemma4/README.en.md
+++ b/model-pr-optimization-history/sglang/gemma4/README.en.md
@@ -1,0 +1,28 @@
+# SGLang Gemma 4 Support and PR History
+
+This note tracks the SGLang runtime, key PRs, and cookbook-facing touchpoints for Gemma 4.
+
+- Status: 当前 mainline 已支持
+
+## Key Conclusions
+
+- Gemma 4 is a genuinely multi-surface family: text, MoE, multimodal, tool calling, and speculative decoding all matter.
+- Fast prefill, quantized MoE, and tool-parser correctness are the main areas that changed rapidly after bring-up.
+
+## Main Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/gemma4_causal.py`
+- `sglang/python/sglang/srt/models/gemma4_mm.py`
+- `sglang/python/sglang/srt/models/gemma4_vision.py`
+- `sglang/python/sglang/srt/models/gemma4_audio.py`
+
+## Landed PRs
+
+- [#21952](https://github.com/sgl-project/sglang/pull/21952) `New Model: Gemma 4`: Initial Gemma 4 support in SGLang.
+- [#22079](https://github.com/sgl-project/sglang/pull/22079) `Gemma4 nvfp4 fix`: Fixed the NVFP4 launch path.
+- [#22408](https://github.com/sgl-project/sglang/pull/22408) `Adding Gemma 4 to Nightly CI`: Added model-family regression coverage.
+
+## Matching Skill
+
+- `skills/model-optimization/sglang/sglang-gemma4-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-gemma4-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/gemma4/README.zh.md
+++ b/model-pr-optimization-history/sglang/gemma4/README.zh.md
@@ -1,0 +1,28 @@
+# SGLang Gemma 4 支持与 PR 历史
+
+本文记录 SGLang 中与 Gemma 4 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Gemma 4 is a genuinely multi-surface family: text, MoE, multimodal, tool calling, and speculative decoding all matter.
+- Fast prefill, quantized MoE, and tool-parser correctness are the main areas that changed rapidly after bring-up.
+
+## 主要代码面
+
+- `sglang/python/sglang/srt/models/gemma4_causal.py`
+- `sglang/python/sglang/srt/models/gemma4_mm.py`
+- `sglang/python/sglang/srt/models/gemma4_vision.py`
+- `sglang/python/sglang/srt/models/gemma4_audio.py`
+
+## 已合入 PR
+
+- [#21952](https://github.com/sgl-project/sglang/pull/21952) `New Model: Gemma 4`：Initial Gemma 4 support in SGLang.
+- [#22079](https://github.com/sgl-project/sglang/pull/22079) `Gemma4 nvfp4 fix`：Fixed the NVFP4 launch path.
+- [#22408](https://github.com/sgl-project/sglang/pull/22408) `Adding Gemma 4 to Nightly CI`：Added model-family regression coverage.
+
+## 配套 skill
+
+- `skills/model-optimization/sglang/sglang-gemma4-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-gemma4-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/gpt-oss/README.en.md
+++ b/model-pr-optimization-history/sglang/gpt-oss/README.en.md
@@ -1,0 +1,28 @@
+# SGLang GPT-OSS Support and PR History
+
+This note tracks the SGLang runtime, key PRs, and cookbook-facing touchpoints for GPT-OSS.
+
+- Status: 当前 mainline 已支持
+
+## Key Conclusions
+
+- GPT-OSS is a flagship MoE family in SGLang.
+- Quantization, expert-parallel topology, and reasoning/tool parser behavior all evolved quickly and need per-PR tracking.
+
+## Main Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/gpt_oss.py`
+
+## Landed PRs
+
+- [#8843](https://github.com/sgl-project/sglang/pull/8843) `Support mxfp4 for GPT-OSS`: Added the headline quantized checkpoint path.
+- [#8944](https://github.com/sgl-project/sglang/pull/8944) `Expert Parallelism for GPT-OSS`: Scaled GPT-OSS beyond pure tensor parallel.
+- [#9043](https://github.com/sgl-project/sglang/pull/9043) `Implement Native GPT-OSS Tool Call Support`: Added native tool parser support instead of Harmony integration.
+- [#9359](https://github.com/sgl-project/sglang/pull/9359) `Support DP attention with GPT-OSS`: Enabled larger topologies via DP attention.
+- [#14920](https://github.com/sgl-project/sglang/pull/14920) `GPT-OSS Eagle v2 support`: Added speculative decoding support.
+- [#18988](https://github.com/sgl-project/sglang/pull/18988) `Support fp8 online quantization for gpt-oss bf16`: Extended quantization coverage to online FP8.
+
+## Matching Skill
+
+- `skills/model-optimization/sglang/sglang-gpt-oss-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-gpt-oss-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/gpt-oss/README.zh.md
+++ b/model-pr-optimization-history/sglang/gpt-oss/README.zh.md
@@ -1,0 +1,28 @@
+# SGLang GPT-OSS 支持与 PR 历史
+
+本文记录 SGLang 中与 GPT-OSS 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- GPT-OSS is a flagship MoE family in SGLang.
+- Quantization, expert-parallel topology, and reasoning/tool parser behavior all evolved quickly and need per-PR tracking.
+
+## 主要代码面
+
+- `sglang/python/sglang/srt/models/gpt_oss.py`
+
+## 已合入 PR
+
+- [#8843](https://github.com/sgl-project/sglang/pull/8843) `Support mxfp4 for GPT-OSS`：Added the headline quantized checkpoint path.
+- [#8944](https://github.com/sgl-project/sglang/pull/8944) `Expert Parallelism for GPT-OSS`：Scaled GPT-OSS beyond pure tensor parallel.
+- [#9043](https://github.com/sgl-project/sglang/pull/9043) `Implement Native GPT-OSS Tool Call Support`：Added native tool parser support instead of Harmony integration.
+- [#9359](https://github.com/sgl-project/sglang/pull/9359) `Support DP attention with GPT-OSS`：Enabled larger topologies via DP attention.
+- [#14920](https://github.com/sgl-project/sglang/pull/14920) `GPT-OSS Eagle v2 support`：Added speculative decoding support.
+- [#18988](https://github.com/sgl-project/sglang/pull/18988) `Support fp8 online quantization for gpt-oss bf16`：Extended quantization coverage to online FP8.
+
+## 配套 skill
+
+- `skills/model-optimization/sglang/sglang-gpt-oss-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-gpt-oss-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/intern-s1/README.en.md
+++ b/model-pr-optimization-history/sglang/intern-s1/README.en.md
@@ -1,0 +1,27 @@
+# SGLang Intern-S1 Support and PR History
+
+This note tracks the SGLang runtime, key PRs, and cookbook-facing touchpoints for Intern-S1.
+
+- Status: 当前 mainline 已支持
+
+## Key Conclusions
+
+- Intern-S1 leans heavily on shared InternVL processor code in SGLang.
+- Most regressions come from processor compatibility, parser behavior, and video-aware serving rather than the text stack alone.
+
+## Main Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/interns1.py`
+- `sglang/python/sglang/srt/models/internvl.py`
+
+## Landed PRs
+
+- [#9381](https://github.com/sgl-project/sglang/pull/9381) `InternS1 image token updates in InternVL processor`: Aligned the shared processor with Intern-S1 image semantics.
+- [#12367](https://github.com/sgl-project/sglang/pull/12367) `Fix Intern-S1 accuracy and `/generate` input_ids support`: Closed early correctness gaps.
+- [#14866](https://github.com/sgl-project/sglang/pull/14866) `Add tool calling and reasoning parser support for Intern-S1`: Added parser support that cookbook usage depends on.
+- [#17040](https://github.com/sgl-project/sglang/pull/17040) `Support InternS1 text_config in InternVL processor`: Improved sub-config compatibility in shared processors.
+
+## Matching Skill
+
+- `skills/model-optimization/sglang/sglang-intern-s1-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-intern-s1-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/intern-s1/README.zh.md
+++ b/model-pr-optimization-history/sglang/intern-s1/README.zh.md
@@ -1,0 +1,27 @@
+# SGLang Intern-S1 支持与 PR 历史
+
+本文记录 SGLang 中与 Intern-S1 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Intern-S1 leans heavily on shared InternVL processor code in SGLang.
+- Most regressions come from processor compatibility, parser behavior, and video-aware serving rather than the text stack alone.
+
+## 主要代码面
+
+- `sglang/python/sglang/srt/models/interns1.py`
+- `sglang/python/sglang/srt/models/internvl.py`
+
+## 已合入 PR
+
+- [#9381](https://github.com/sgl-project/sglang/pull/9381) `InternS1 image token updates in InternVL processor`：Aligned the shared processor with Intern-S1 image semantics.
+- [#12367](https://github.com/sgl-project/sglang/pull/12367) `Fix Intern-S1 accuracy and `/generate` input_ids support`：Closed early correctness gaps.
+- [#14866](https://github.com/sgl-project/sglang/pull/14866) `Add tool calling and reasoning parser support for Intern-S1`：Added parser support that cookbook usage depends on.
+- [#17040](https://github.com/sgl-project/sglang/pull/17040) `Support InternS1 text_config in InternVL processor`：Improved sub-config compatibility in shared processors.
+
+## 配套 skill
+
+- `skills/model-optimization/sglang/sglang-intern-s1-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-intern-s1-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/internvl35/README.en.md
+++ b/model-pr-optimization-history/sglang/internvl35/README.en.md
@@ -1,0 +1,27 @@
+# SGLang InternVL3.5 Support and PR History
+
+This note tracks the SGLang runtime, key PRs, and cookbook-facing touchpoints for InternVL3.5.
+
+- Status: 当前 mainline 已支持
+
+## Key Conclusions
+
+- InternVL3.5 is mostly a processor / encoder / video problem in SGLang.
+- Video handling, data-parallel vision execution, and backend compatibility dominate the risk surface.
+
+## Main Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/internvl.py`
+
+## Landed PRs
+
+- [#5350](https://github.com/sgl-project/sglang/pull/5350) `Support InternVL3`: Initial InternVL family support that later carried 3.5.
+- [#13640](https://github.com/sgl-project/sglang/pull/13640) `Support Piecewise CUDA Graph for InternVL`: Added graph capture support on the encoder path.
+- [#13925](https://github.com/sgl-project/sglang/pull/13925) `Support InternVL Vision Encoder Data Parallelism`: Opened the multi-GPU ViT path.
+- [#15942](https://github.com/sgl-project/sglang/pull/15942) `Support Video for InternVL3_5`: Extended support to 3.5 video use cases.
+- [#19127](https://github.com/sgl-project/sglang/pull/19127) `Support processor and embedding inputs for InternVL`: Hardened processor / embed input interoperability.
+
+## Matching Skill
+
+- `skills/model-optimization/sglang/sglang-internvl35-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-internvl35-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/internvl35/README.zh.md
+++ b/model-pr-optimization-history/sglang/internvl35/README.zh.md
@@ -1,0 +1,27 @@
+# SGLang InternVL3.5 支持与 PR 历史
+
+本文记录 SGLang 中与 InternVL3.5 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- InternVL3.5 is mostly a processor / encoder / video problem in SGLang.
+- Video handling, data-parallel vision execution, and backend compatibility dominate the risk surface.
+
+## 主要代码面
+
+- `sglang/python/sglang/srt/models/internvl.py`
+
+## 已合入 PR
+
+- [#5350](https://github.com/sgl-project/sglang/pull/5350) `Support InternVL3`：Initial InternVL family support that later carried 3.5.
+- [#13640](https://github.com/sgl-project/sglang/pull/13640) `Support Piecewise CUDA Graph for InternVL`：Added graph capture support on the encoder path.
+- [#13925](https://github.com/sgl-project/sglang/pull/13925) `Support InternVL Vision Encoder Data Parallelism`：Opened the multi-GPU ViT path.
+- [#15942](https://github.com/sgl-project/sglang/pull/15942) `Support Video for InternVL3_5`：Extended support to 3.5 video use cases.
+- [#19127](https://github.com/sgl-project/sglang/pull/19127) `Support processor and embedding inputs for InternVL`：Hardened processor / embed input interoperability.
+
+## 配套 skill
+
+- `skills/model-optimization/sglang/sglang-internvl35-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-internvl35-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/llama4/README.en.md
+++ b/model-pr-optimization-history/sglang/llama4/README.en.md
@@ -1,0 +1,28 @@
+# SGLang Llama 4 Support and PR History
+
+This note tracks the SGLang runtime, key PRs, and cookbook-facing touchpoints for Llama 4.
+
+- Status: 当前 mainline 已支持
+
+## Key Conclusions
+
+- Llama4 is mature on the SGLang side but still sensitive to quantized MoE and long-context backend selection.
+- The multimodal path adds a separate vision-rotary and processor validation surface.
+
+## Main Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/llama4.py`
+- `sglang/python/sglang/srt/models/mllama4.py`
+
+## Landed PRs
+
+- [#5092](https://github.com/sgl-project/sglang/pull/5092) `Add Llama4 support`: Initial Llama4 landing in SGLang.
+- [#5194](https://github.com/sgl-project/sglang/pull/5194) `Support Llama4 fp8 inference`: Enabled the first production quantized lane.
+- [#6162](https://github.com/sgl-project/sglang/pull/6162) `Fix Llama4 gibberish output with long context and CUDA graph`: Closed a major correctness bug.
+- [#7129](https://github.com/sgl-project/sglang/pull/7129) `Enable ModelOpt Llama4 fp8 checkpoint deployment in SGLang`: Added the ModelOpt checkpoint path.
+- [#13421](https://github.com/sgl-project/sglang/pull/13421) `Add Llama4 attention backend auto-selection`: Stabilized backend choice for real deployments.
+
+## Matching Skill
+
+- `skills/model-optimization/sglang/sglang-llama4-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-llama4-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/llama4/README.zh.md
+++ b/model-pr-optimization-history/sglang/llama4/README.zh.md
@@ -1,0 +1,28 @@
+# SGLang Llama 4 支持与 PR 历史
+
+本文记录 SGLang 中与 Llama 4 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Llama4 is mature on the SGLang side but still sensitive to quantized MoE and long-context backend selection.
+- The multimodal path adds a separate vision-rotary and processor validation surface.
+
+## 主要代码面
+
+- `sglang/python/sglang/srt/models/llama4.py`
+- `sglang/python/sglang/srt/models/mllama4.py`
+
+## 已合入 PR
+
+- [#5092](https://github.com/sgl-project/sglang/pull/5092) `Add Llama4 support`：Initial Llama4 landing in SGLang.
+- [#5194](https://github.com/sgl-project/sglang/pull/5194) `Support Llama4 fp8 inference`：Enabled the first production quantized lane.
+- [#6162](https://github.com/sgl-project/sglang/pull/6162) `Fix Llama4 gibberish output with long context and CUDA graph`：Closed a major correctness bug.
+- [#7129](https://github.com/sgl-project/sglang/pull/7129) `Enable ModelOpt Llama4 fp8 checkpoint deployment in SGLang`：Added the ModelOpt checkpoint path.
+- [#13421](https://github.com/sgl-project/sglang/pull/13421) `Add Llama4 attention backend auto-selection`：Stabilized backend choice for real deployments.
+
+## 配套 skill
+
+- `skills/model-optimization/sglang/sglang-llama4-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-llama4-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/mimo-v2-flash/README.en.md
+++ b/model-pr-optimization-history/sglang/mimo-v2-flash/README.en.md
@@ -1,0 +1,28 @@
+# SGLang MiMo-V2-Flash Support and PR History
+
+This note tracks the SGLang runtime, key PRs, and cookbook-facing touchpoints for MiMo-V2-Flash.
+
+- Status: 当前 mainline 已支持
+
+## Key Conclusions
+
+- MiMo-V2-Flash is primarily a throughput-oriented MoE serving family.
+- All-reduce fusion, overlap, and reasoning behavior matter more than generic text-only loader work.
+
+## Main Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/mimo_v2_flash.py`
+- `sglang/python/sglang/srt/models/mimo_v2_flash_nextn.py`
+
+## Landed PRs
+
+- [#15207](https://github.com/sgl-project/sglang/pull/15207) `MiMo-V2-Flash day0 support`: Initial MiMo-V2-Flash landing.
+- [#15464](https://github.com/sgl-project/sglang/pull/15464) `Optimize MiMo-V2-Flash by flashinfer fused allreduce`: Targeted decode-side communication cost.
+- [#15488](https://github.com/sgl-project/sglang/pull/15488) `Respect `--swa-full-tokens-ratio``: Fixed a concrete runtime flag integration bug.
+- [#17634](https://github.com/sgl-project/sglang/pull/17634) `Support two batch overlap`: Added overlap / throughput optimization.
+- [#21414](https://github.com/sgl-project/sglang/pull/21414) `Add mimo reasoning parser`: Completed the parser path for thinking outputs.
+
+## Matching Skill
+
+- `skills/model-optimization/sglang/sglang-mimo-v2-flash-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-mimo-v2-flash-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/mimo-v2-flash/README.zh.md
+++ b/model-pr-optimization-history/sglang/mimo-v2-flash/README.zh.md
@@ -1,0 +1,28 @@
+# SGLang MiMo-V2-Flash 支持与 PR 历史
+
+本文记录 SGLang 中与 MiMo-V2-Flash 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- MiMo-V2-Flash is primarily a throughput-oriented MoE serving family.
+- All-reduce fusion, overlap, and reasoning behavior matter more than generic text-only loader work.
+
+## 主要代码面
+
+- `sglang/python/sglang/srt/models/mimo_v2_flash.py`
+- `sglang/python/sglang/srt/models/mimo_v2_flash_nextn.py`
+
+## 已合入 PR
+
+- [#15207](https://github.com/sgl-project/sglang/pull/15207) `MiMo-V2-Flash day0 support`：Initial MiMo-V2-Flash landing.
+- [#15464](https://github.com/sgl-project/sglang/pull/15464) `Optimize MiMo-V2-Flash by flashinfer fused allreduce`：Targeted decode-side communication cost.
+- [#15488](https://github.com/sgl-project/sglang/pull/15488) `Respect `--swa-full-tokens-ratio``：Fixed a concrete runtime flag integration bug.
+- [#17634](https://github.com/sgl-project/sglang/pull/17634) `Support two batch overlap`：Added overlap / throughput optimization.
+- [#21414](https://github.com/sgl-project/sglang/pull/21414) `Add mimo reasoning parser`：Completed the parser path for thinking outputs.
+
+## 配套 skill
+
+- `skills/model-optimization/sglang/sglang-mimo-v2-flash-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-mimo-v2-flash-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/mistral-small-4/README.en.md
+++ b/model-pr-optimization-history/sglang/mistral-small-4/README.en.md
@@ -1,0 +1,30 @@
+# SGLang Mistral Small 4 Support and PR History
+
+This note tracks the SGLang runtime, key PRs, and cookbook-facing touchpoints for Mistral Small 4.
+
+- Status: 当前 mainline 已支持
+
+## Key Conclusions
+
+- Mistral Small 4 sits on top of the larger Mistral Large 3 / Ministral runtime work.
+- Startup format mismatches, multimodal projector behavior, and Eagle / MoE integration are the main risk areas.
+
+## Main Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/mistral_large_3.py`
+- `sglang/python/sglang/srt/models/mistral_large_3_eagle.py`
+- `sglang/python/sglang/srt/models/mistral.py`
+- `sglang/python/sglang/srt/models/ministral3.py`
+
+## Landed PRs
+
+- [#14213](https://github.com/sgl-project/sglang/pull/14213) `Add Mistral Large 3 support`: Historical base runtime reused by later Small 4 work.
+- [#14466](https://github.com/sgl-project/sglang/pull/14466) `Add Mistral Large 3 Eagle Support`: Enabled speculative decode on the underlying family.
+- [#15049](https://github.com/sgl-project/sglang/pull/15049) `Mistral Large 3 NVFP4 TRTLLM MoE support`: Added the first serious quantized MoE path.
+- [#20708](https://github.com/sgl-project/sglang/pull/20708) `Add Mistral Small 4 support`: Brought Mistral Small 4 / Pixtral-style runtime into mainline.
+- [#21620](https://github.com/sgl-project/sglang/pull/21620) `Mistral Small 4 fails to start due to config/weight format mismatch`: Closed a startup regression after launch.
+
+## Matching Skill
+
+- `skills/model-optimization/sglang/sglang-mistral-small-4-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-mistral-small-4-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/mistral-small-4/README.zh.md
+++ b/model-pr-optimization-history/sglang/mistral-small-4/README.zh.md
@@ -1,0 +1,30 @@
+# SGLang Mistral Small 4 支持与 PR 历史
+
+本文记录 SGLang 中与 Mistral Small 4 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Mistral Small 4 sits on top of the larger Mistral Large 3 / Ministral runtime work.
+- Startup format mismatches, multimodal projector behavior, and Eagle / MoE integration are the main risk areas.
+
+## 主要代码面
+
+- `sglang/python/sglang/srt/models/mistral_large_3.py`
+- `sglang/python/sglang/srt/models/mistral_large_3_eagle.py`
+- `sglang/python/sglang/srt/models/mistral.py`
+- `sglang/python/sglang/srt/models/ministral3.py`
+
+## 已合入 PR
+
+- [#14213](https://github.com/sgl-project/sglang/pull/14213) `Add Mistral Large 3 support`：Historical base runtime reused by later Small 4 work.
+- [#14466](https://github.com/sgl-project/sglang/pull/14466) `Add Mistral Large 3 Eagle Support`：Enabled speculative decode on the underlying family.
+- [#15049](https://github.com/sgl-project/sglang/pull/15049) `Mistral Large 3 NVFP4 TRTLLM MoE support`：Added the first serious quantized MoE path.
+- [#20708](https://github.com/sgl-project/sglang/pull/20708) `Add Mistral Small 4 support`：Brought Mistral Small 4 / Pixtral-style runtime into mainline.
+- [#21620](https://github.com/sgl-project/sglang/pull/21620) `Mistral Small 4 fails to start due to config/weight format mismatch`：Closed a startup regression after launch.
+
+## 配套 skill
+
+- `skills/model-optimization/sglang/sglang-mistral-small-4-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-mistral-small-4-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/nemotron-super/README.en.md
+++ b/model-pr-optimization-history/sglang/nemotron-super/README.en.md
@@ -1,0 +1,29 @@
+# SGLang Nemotron Super / Nano Hybrid Support and PR History
+
+This note tracks the SGLang runtime, key PRs, and cookbook-facing touchpoints for Nemotron Super / Nano Hybrid.
+
+- Status: 当前 mainline 已支持
+
+## Key Conclusions
+
+- Nemotron is a hybrid family: attention, Mamba, MoE, MTP, and VL all intersect.
+- Because of that, graph execution, cache dtype, and quantized MoE correctness are the primary risk areas.
+
+## Main Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/nemotron_h.py`
+- `sglang/python/sglang/srt/models/nemotron_h_mtp.py`
+- `sglang/python/sglang/srt/models/nano_nemotron_vl.py`
+
+## Landed PRs
+
+- [#16172](https://github.com/sgl-project/sglang/pull/16172) `NemotronH PP support`: Opened pipeline parallelism on NemotronH.
+- [#16227](https://github.com/sgl-project/sglang/pull/16227) `Add latent MoE support`: Added the hybrid latent-MoE path.
+- [#19903](https://github.com/sgl-project/sglang/pull/19903) `Enable Piecewise CUDA Graph for NemotronH Hybrid Models`: Improved hybrid serving efficiency.
+- [#20407](https://github.com/sgl-project/sglang/pull/20407) `Support Nemotron 3 Super NVFP4`: Added the key quantized Super checkpoint path.
+- [#20575](https://github.com/sgl-project/sglang/pull/20575) `Add Nemotron 3 Super CI tests for BF16 and NVFP4`: Added regression coverage for the production checkpoint variants.
+
+## Matching Skill
+
+- `skills/model-optimization/sglang/sglang-nemotron-super-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-nemotron-super-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/nemotron-super/README.zh.md
+++ b/model-pr-optimization-history/sglang/nemotron-super/README.zh.md
@@ -1,0 +1,29 @@
+# SGLang Nemotron Super / Nano Hybrid 支持与 PR 历史
+
+本文记录 SGLang 中与 Nemotron Super / Nano Hybrid 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Nemotron is a hybrid family: attention, Mamba, MoE, MTP, and VL all intersect.
+- Because of that, graph execution, cache dtype, and quantized MoE correctness are the primary risk areas.
+
+## 主要代码面
+
+- `sglang/python/sglang/srt/models/nemotron_h.py`
+- `sglang/python/sglang/srt/models/nemotron_h_mtp.py`
+- `sglang/python/sglang/srt/models/nano_nemotron_vl.py`
+
+## 已合入 PR
+
+- [#16172](https://github.com/sgl-project/sglang/pull/16172) `NemotronH PP support`：Opened pipeline parallelism on NemotronH.
+- [#16227](https://github.com/sgl-project/sglang/pull/16227) `Add latent MoE support`：Added the hybrid latent-MoE path.
+- [#19903](https://github.com/sgl-project/sglang/pull/19903) `Enable Piecewise CUDA Graph for NemotronH Hybrid Models`：Improved hybrid serving efficiency.
+- [#20407](https://github.com/sgl-project/sglang/pull/20407) `Support Nemotron 3 Super NVFP4`：Added the key quantized Super checkpoint path.
+- [#20575](https://github.com/sgl-project/sglang/pull/20575) `Add Nemotron 3 Super CI tests for BF16 and NVFP4`：Added regression coverage for the production checkpoint variants.
+
+## 配套 skill
+
+- `skills/model-optimization/sglang/sglang-nemotron-super-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-nemotron-super-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/step35/README.en.md
+++ b/model-pr-optimization-history/sglang/step35/README.en.md
@@ -1,0 +1,30 @@
+# SGLang Step3.5 / Step3-VL Support and PR History
+
+This note tracks the SGLang runtime, key PRs, and cookbook-facing touchpoints for Step3.5 / Step3-VL.
+
+- Status: 当前 mainline 已支持
+
+## Key Conclusions
+
+- Step3.5 is split between text/MTP and VL processor work.
+- All-reduce efficiency and parser behavior are the main axes to track.
+
+## Main Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/step3p5.py`
+- `sglang/python/sglang/srt/models/step3p5_mtp.py`
+- `sglang/python/sglang/srt/models/step3_vl.py`
+- `sglang/python/sglang/srt/models/step3_vl_10b.py`
+
+## Landed PRs
+
+- [#8583](https://github.com/sgl-project/sglang/pull/8583) `Support Step3V`: Initial Step3 visual model support.
+- [#8699](https://github.com/sgl-project/sglang/pull/8699) `Support DP Attention for step3_vl`: Enabled multi-GPU VL serving.
+- [#9695](https://github.com/sgl-project/sglang/pull/9695) `Add step3 tool parser`: Added tool-call parsing.
+- [#18564](https://github.com/sgl-project/sglang/pull/18564) `Implement the standard multi-layer MTP for step3p5`: Added Step3.5 draft-model support.
+- [#22773](https://github.com/sgl-project/sglang/pull/22773) `Optimize allreduce in MoE layers`: Targeted the Step3.5 MoE hot path.
+
+## Matching Skill
+
+- `skills/model-optimization/sglang/sglang-step35-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-step35-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/sglang/step35/README.zh.md
+++ b/model-pr-optimization-history/sglang/step35/README.zh.md
@@ -1,0 +1,30 @@
+# SGLang Step3.5 / Step3-VL 支持与 PR 历史
+
+本文记录 SGLang 中与 Step3.5 / Step3-VL 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Step3.5 is split between text/MTP and VL processor work.
+- All-reduce efficiency and parser behavior are the main axes to track.
+
+## 主要代码面
+
+- `sglang/python/sglang/srt/models/step3p5.py`
+- `sglang/python/sglang/srt/models/step3p5_mtp.py`
+- `sglang/python/sglang/srt/models/step3_vl.py`
+- `sglang/python/sglang/srt/models/step3_vl_10b.py`
+
+## 已合入 PR
+
+- [#8583](https://github.com/sgl-project/sglang/pull/8583) `Support Step3V`：Initial Step3 visual model support.
+- [#8699](https://github.com/sgl-project/sglang/pull/8699) `Support DP Attention for step3_vl`：Enabled multi-GPU VL serving.
+- [#9695](https://github.com/sgl-project/sglang/pull/9695) `Add step3 tool parser`：Added tool-call parsing.
+- [#18564](https://github.com/sgl-project/sglang/pull/18564) `Implement the standard multi-layer MTP for step3p5`：Added Step3.5 draft-model support.
+- [#22773](https://github.com/sgl-project/sglang/pull/22773) `Optimize allreduce in MoE layers`：Targeted the Step3.5 MoE hot path.
+
+## 配套 skill
+
+- `skills/model-optimization/sglang/sglang-step35-optimization/SKILL.md`
+- `skills/model-optimization/sglang/sglang-step35-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/README.md
+++ b/model-pr-optimization-history/vllm/README.md
@@ -1,5 +1,36 @@
 # vLLM Model PR Optimization History
 
-Reserved for future vLLM model PR histories.
+Current families:
 
-Use one directory per model family/generation, mirroring the corresponding skill under `skills/model-optimization/vllm/`.
+- `deepseek-v3-r1`
+- `deepseek-v31`
+- `deepseek-v32`
+- `deepseek-v4`
+- `glm-vlm-ocr`
+- `glm45`
+- `glm46-glm47`
+- `glm5-glm51`
+- `hunyuan3-preview`
+- `kimi`
+- `ltx23-hq`
+- `minimax`
+- `mixtral-quark-int4fp8-moe`
+- `moss-vl`
+- `qwen-image`
+- `qwen-vlm-omni-asr`
+- `qwen3-coder`
+- `qwen3-core`
+- `qwen3-next`
+- `qwen35`
+- `qwen36`
+- `z-image-turbo`
+- `ernie45`
+- `gemma4`
+- `gpt-oss`
+- `intern-s1`
+- `internvl35`
+- `llama4`
+- `mimo-v2-flash`
+- `mistral-small-4`
+- `nemotron-super`
+- `step35`

--- a/model-pr-optimization-history/vllm/deepseek-v3-r1/README.en.md
+++ b/model-pr-optimization-history/vllm/deepseek-v3-r1/README.en.md
@@ -1,0 +1,34 @@
+# vLLM DeepSeek V3 / R1 Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for DeepSeek V3 / R1.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- `DeepseekV2ForCausalLM` / `DeepseekV3ForCausalLM` remain the shared runtime for V3 and R1.
+- The highest-risk regressions cluster around packed module mapping, quantized MLA/MoE weight loading, LoRA, and MTP draft paths.
+- R1 validation should split BF16, FP8/ModelOpt, and compressed-tensors or ROCm lanes.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/deepseek_v2.py`
+- `vllm/vllm/model_executor/models/deepseek_eagle.py`
+- `vllm/vllm/model_executor/models/deepseek_eagle3.py`
+- `vllm/vllm/model_executor/models/deepseek_mtp.py`
+
+## Landed PRs
+
+- [#22352](https://github.com/vllm-project/vllm/pull/22352) `Add missing `packed_modules_mapping` to `DeepseekV2ForCausalLM``: Fixed quantized and packed-weight loading for DeepSeek V2/V3/R1 style checkpoints.
+- [#23971](https://github.com/vllm-project/vllm/pull/23971) `Add LoRA support for DeepSeek models (V2, V3, R1-0528)`: Enabled adapter injection on the DeepSeek family rather than only base dense models.
+- [#29545](https://github.com/vllm-project/vllm/pull/29545) `Fix DeepSeek R1 MTP weight loading`: Hardened R1 NextN / MTP draft loading after launch failures on draft weights.
+- [#36247](https://github.com/vllm-project/vllm/pull/36247) `Fix compressed-tensors quantization failure for DeepSeek-R1 on MI300x`: Closed a production ROCm gap for compressed-tensors DeepSeek-R1 deployment.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-deepseek-v3-r1-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-deepseek-v3-r1-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/deepseek-v3-r1/README.zh.md
+++ b/model-pr-optimization-history/vllm/deepseek-v3-r1/README.zh.md
@@ -1,0 +1,34 @@
+# vLLM DeepSeek V3 / R1 支持与 PR 历史
+
+本文记录 vLLM 中与 DeepSeek V3 / R1 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- `DeepseekV2ForCausalLM` / `DeepseekV3ForCausalLM` remain the shared runtime for V3 and R1.
+- The highest-risk regressions cluster around packed module mapping, quantized MLA/MoE weight loading, LoRA, and MTP draft paths.
+- R1 validation should split BF16, FP8/ModelOpt, and compressed-tensors or ROCm lanes.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/deepseek_v2.py`
+- `vllm/vllm/model_executor/models/deepseek_eagle.py`
+- `vllm/vllm/model_executor/models/deepseek_eagle3.py`
+- `vllm/vllm/model_executor/models/deepseek_mtp.py`
+
+## 已合入 PR
+
+- [#22352](https://github.com/vllm-project/vllm/pull/22352) `Add missing `packed_modules_mapping` to `DeepseekV2ForCausalLM``：Fixed quantized and packed-weight loading for DeepSeek V2/V3/R1 style checkpoints.
+- [#23971](https://github.com/vllm-project/vllm/pull/23971) `Add LoRA support for DeepSeek models (V2, V3, R1-0528)`：Enabled adapter injection on the DeepSeek family rather than only base dense models.
+- [#29545](https://github.com/vllm-project/vllm/pull/29545) `Fix DeepSeek R1 MTP weight loading`：Hardened R1 NextN / MTP draft loading after launch failures on draft weights.
+- [#36247](https://github.com/vllm-project/vllm/pull/36247) `Fix compressed-tensors quantization failure for DeepSeek-R1 on MI300x`：Closed a production ROCm gap for compressed-tensors DeepSeek-R1 deployment.
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-deepseek-v3-r1-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-deepseek-v3-r1-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/deepseek-v31/README.en.md
+++ b/model-pr-optimization-history/vllm/deepseek-v31/README.en.md
@@ -1,0 +1,32 @@
+# vLLM DeepSeek V3.1 Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for DeepSeek V3.1.
+
+- Status: supported on current mainline
+- This family inherits the base runtime from `deepseek-v3-r1` and only records the delta here.
+
+## Key Conclusions
+
+- V3.1 mostly reuses the base V3 runtime and adds parser plus scale-format correctness work.
+- The practical blast radius is in tool calling, DeepGEMM scale handling, and reasoning-parser behavior.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/deepseek_v2.py`
+- `vllm/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py`
+
+## Landed PRs
+
+- [#23454](https://github.com/vllm-project/vllm/pull/23454) `Support DeepSeek-V3.1 tool call`: Added the first V3.1-specific tool-call parser surface to vLLM.
+- [#23666](https://github.com/vllm-project/vllm/pull/23666) `Add Hopper DeepGEMM E8M0 for DeepSeekV3.1 scale_fmt`: Tuned the scale-format path used by DeepGEMM-based DeepSeek V3.1 kernels.
+- [#25589](https://github.com/vllm-project/vllm/pull/25589) `Add DeepSeek-V3.1 reasoning parser`: Separated V3.1 reasoning output handling from generic DeepSeek parsing.
+- [#32361](https://github.com/vllm-project/vllm/pull/32361) `Fix DeepSeek-V3.1 + DeepGEMM incompatible scale shapes`: Patched a concrete shape mismatch between newer checkpoints and DeepGEMM assumptions.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-deepseek-v31-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-deepseek-v31-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/deepseek-v31/README.zh.md
+++ b/model-pr-optimization-history/vllm/deepseek-v31/README.zh.md
@@ -1,0 +1,32 @@
+# vLLM DeepSeek V3.1 支持与 PR 历史
+
+本文记录 vLLM 中与 DeepSeek V3.1 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 已支持
+- 该家族继承 `deepseek-v3-r1` 的基础 runtime，这里只记录增量 PR。
+
+## 核心结论
+
+- V3.1 mostly reuses the base V3 runtime and adds parser plus scale-format correctness work.
+- The practical blast radius is in tool calling, DeepGEMM scale handling, and reasoning-parser behavior.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/deepseek_v2.py`
+- `vllm/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py`
+
+## 已合入 PR
+
+- [#23454](https://github.com/vllm-project/vllm/pull/23454) `Support DeepSeek-V3.1 tool call`：Added the first V3.1-specific tool-call parser surface to vLLM.
+- [#23666](https://github.com/vllm-project/vllm/pull/23666) `Add Hopper DeepGEMM E8M0 for DeepSeekV3.1 scale_fmt`：Tuned the scale-format path used by DeepGEMM-based DeepSeek V3.1 kernels.
+- [#25589](https://github.com/vllm-project/vllm/pull/25589) `Add DeepSeek-V3.1 reasoning parser`：Separated V3.1 reasoning output handling from generic DeepSeek parsing.
+- [#32361](https://github.com/vllm-project/vllm/pull/32361) `Fix DeepSeek-V3.1 + DeepGEMM incompatible scale shapes`：Patched a concrete shape mismatch between newer checkpoints and DeepGEMM assumptions.
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-deepseek-v31-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-deepseek-v31-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/deepseek-v32/README.en.md
+++ b/model-pr-optimization-history/vllm/deepseek-v32/README.en.md
@@ -1,0 +1,33 @@
+# vLLM DeepSeek V3.2 Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for DeepSeek V3.2.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- DeepSeek V3.2 is the major vLLM fork of the DeepSeek line because it adds sparse MLA and indexer logic.
+- Most regressions land in the indexer builder, tokenizer / parser, and specialized decode kernels rather than the generic V3 loader.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/deepseek_v2.py`
+- `vllm/vllm/model_executor/layers/rotary_embedding/mrope.py`
+
+## Landed PRs
+
+- [#25896](https://github.com/vllm-project/vllm/pull/25896) `Support DeepSeek-V3.2`: Landed the initial V3.2 model registration, sparse-attention runtime, and benchmark hooks.
+- [#25999](https://github.com/vllm-project/vllm/pull/25999) `Support indexer prefill chunking`: Made the V3.2 sparse indexer work with chunked prefill instead of eager-only behavior.
+- [#26670](https://github.com/vllm-project/vllm/pull/26670) `Add AMD GPU support on DeepSeek v3.2 and SparseMLA`: Opened the ROCm SparseMLA lane for V3.2 deployments.
+- [#29848](https://github.com/vllm-project/vllm/pull/29848) `Add DeepSeek-V3.2 tool parser`: Added the parser surface that cookbook-style V3.2 reasoning deployments depend on.
+- [#33090](https://github.com/vllm-project/vllm/pull/33090) `Fix DeepseekV32 `AssertionError: num_kv_heads == 1``: Removed a hard failure triggered by newer V3.2 attention shapes.
+- [#37421](https://github.com/vllm-project/vllm/pull/37421) `Persistent TopK scheduler for DeepSeek-V3.2 decode`: Modernized the decode scheduler with a CUDAGraph-safe persistent TopK kernel.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-deepseek-v32-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-deepseek-v32-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/deepseek-v32/README.zh.md
+++ b/model-pr-optimization-history/vllm/deepseek-v32/README.zh.md
@@ -1,0 +1,33 @@
+# vLLM DeepSeek V3.2 支持与 PR 历史
+
+本文记录 vLLM 中与 DeepSeek V3.2 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- DeepSeek V3.2 is the major vLLM fork of the DeepSeek line because it adds sparse MLA and indexer logic.
+- Most regressions land in the indexer builder, tokenizer / parser, and specialized decode kernels rather than the generic V3 loader.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/deepseek_v2.py`
+- `vllm/vllm/model_executor/layers/rotary_embedding/mrope.py`
+
+## 已合入 PR
+
+- [#25896](https://github.com/vllm-project/vllm/pull/25896) `Support DeepSeek-V3.2`：Landed the initial V3.2 model registration, sparse-attention runtime, and benchmark hooks.
+- [#25999](https://github.com/vllm-project/vllm/pull/25999) `Support indexer prefill chunking`：Made the V3.2 sparse indexer work with chunked prefill instead of eager-only behavior.
+- [#26670](https://github.com/vllm-project/vllm/pull/26670) `Add AMD GPU support on DeepSeek v3.2 and SparseMLA`：Opened the ROCm SparseMLA lane for V3.2 deployments.
+- [#29848](https://github.com/vllm-project/vllm/pull/29848) `Add DeepSeek-V3.2 tool parser`：Added the parser surface that cookbook-style V3.2 reasoning deployments depend on.
+- [#33090](https://github.com/vllm-project/vllm/pull/33090) `Fix DeepseekV32 `AssertionError: num_kv_heads == 1``：Removed a hard failure triggered by newer V3.2 attention shapes.
+- [#37421](https://github.com/vllm-project/vllm/pull/37421) `Persistent TopK scheduler for DeepSeek-V3.2 decode`：Modernized the decode scheduler with a CUDAGraph-safe persistent TopK kernel.
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-deepseek-v32-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-deepseek-v32-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/deepseek-v4/README.en.md
+++ b/model-pr-optimization-history/vllm/deepseek-v4/README.en.md
@@ -1,0 +1,53 @@
+# vLLM DeepSeek V4 Support and PR History
+
+This note tracks the vLLM status for DeepSeek V4 at commit
+`0f7be0f2f76814f80f9091220a5fbbb53912ad00`.
+
+- Status: not supported on current mainline; only open PR evidence exists
+
+## Key Conclusions
+
+- Current mainline still does not register `DeepseekV4ForCausalLM` in
+  `vllm/model_executor/models/registry.py`.
+- The real bring-up work is concentrated in open PR `#40760`, which spans the
+  model, MTP draft path, tokenizer, renderer, parser, tests, and spec-decode
+  glue.
+- Two additional open PRs are already relevant even before merge:
+  `#40811` for BF16 persistent top-k and `#40806` for DSML streaming safety.
+
+## Main Runtime Surfaces
+
+- Current-main check point: `vllm/vllm/model_executor/models/registry.py`
+- Open-radar files:
+  `vllm/vllm/model_executor/models/deepseek_v4.py`,
+  `vllm/vllm/model_executor/models/deepseek_v4_mtp.py`,
+  `vllm/vllm/tokenizers/deepseek_v4.py`,
+  `vllm/vllm/renderers/deepseek_v4.py`,
+  `vllm/vllm/tool_parsers/deepseekv4_tool_parser.py`,
+  `vllm/vllm/v1/spec_decode/eagle.py`,
+  `vllm/csrc/persistent_topk.cuh`
+
+## Open PR Radar
+
+- [#40760](https://github.com/vllm-project/vllm/pull/40760)
+  `[New Model] Support DeepseekV4`
+  Diff reviewed: `156` files, `16193` additions, `760` deletions.
+  The PR adds the proposed model alias, V4 MTP class, tokenizer, renderer,
+  parser, config mapping, and speculative-decode wiring.
+- [#40811](https://github.com/vllm-project/vllm/pull/40811)
+  `[Perf][Kernel] BF16 input support for persistent topK - DeepSeekV4`
+  Diff reviewed: `3` files, `886` additions, `330` deletions.
+  The patch teaches the sparse top-k kernel to handle BF16 ordered keys and adds
+  BF16 kernel tests.
+- [#40806](https://github.com/vllm-project/vllm/pull/40806)
+  `[Bugfix] Fix the DSML token leakage in DSV4/3.2`
+  Diff reviewed: `2` files, `30` additions, `1` deletion.
+  The parser now buffers partial DSML sentinels instead of leaking them as plain
+  text during chunked streaming.
+
+## Current Contract
+
+Do not claim DeepSeek V4 support in vLLM until the model alias appears on
+mainline and the tokenizer/parser path merges with it. If these PRs merge,
+validate model load, tool calling, speculative decoding, and BF16 sparse top-k
+as one connected stack.

--- a/model-pr-optimization-history/vllm/deepseek-v4/README.zh.md
+++ b/model-pr-optimization-history/vllm/deepseek-v4/README.zh.md
@@ -1,0 +1,52 @@
+# vLLM DeepSeek V4 支持与 PR 历史
+
+本文记录 vLLM 在提交 `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+附近对 DeepSeek V4 的真实状态。
+
+- 状态: 当前 mainline 尚未支持，只有 open PR 证据
+
+## 核心结论
+
+- 当前 mainline 的 `vllm/model_executor/models/registry.py` 里还没有
+  `DeepseekV4ForCausalLM`。
+- 真正的 bring-up 工作集中在 open PR `#40760`，它不是只加 alias，而是
+  一次性改了模型实现、MTP、tokenizer、renderer、tool parser、测试和
+  spec-decode 配套。
+- 另外两个 open PR 也已经构成 DeepSeek V4 证据链的一部分:
+  `#40811` 负责 BF16 persistent top-k，
+  `#40806` 负责 DSML 流式解析不泄漏 sentinel。
+
+## 主要代码面
+
+- 当前 mainline 检查点: `vllm/vllm/model_executor/models/registry.py`
+- open-radar 代码面:
+  `vllm/vllm/model_executor/models/deepseek_v4.py`,
+  `vllm/vllm/model_executor/models/deepseek_v4_mtp.py`,
+  `vllm/vllm/tokenizers/deepseek_v4.py`,
+  `vllm/vllm/renderers/deepseek_v4.py`,
+  `vllm/vllm/tool_parsers/deepseekv4_tool_parser.py`,
+  `vllm/vllm/v1/spec_decode/eagle.py`,
+  `vllm/csrc/persistent_topk.cuh`
+
+## Open PR 雷达
+
+- [#40760](https://github.com/vllm-project/vllm/pull/40760)
+  `[New Model] Support DeepseekV4`
+  已审 diff: `156` 个文件，`16193` 行新增，`760` 行删除。
+  这组改动提出了 DeepSeek V4 主模型、MTP 草稿模型、tokenizer、renderer、
+  parser、config 映射和 speculative decode 连接层。
+- [#40811](https://github.com/vllm-project/vllm/pull/40811)
+  `[Perf][Kernel] BF16 input support for persistent topK - DeepSeekV4`
+  已审 diff: `3` 个文件，`886` 行新增，`330` 行删除。
+  它把稀疏 top-k kernel 从默认 FP32 排序逻辑扩展到 BF16，并补了 BF16
+  kernel 测试。
+- [#40806](https://github.com/vllm-project/vllm/pull/40806)
+  `[Bugfix] Fix the DSML token leakage in DSV4/3.2`
+  已审 diff: `2` 个文件，`30` 行新增，`1` 行删除。
+  它修掉了流式输出里半截 DSML sentinel 被当作普通文本吐出的 parser 问题。
+
+## 当前结论
+
+在 model alias 真正进入 mainline 之前，不要把 DeepSeek V4 写成 vLLM
+已支持。等这些 PR 合入后，要把模型加载、tool calling、spec decode 和
+BF16 sparse top-k 作为一整条链路一起回归。

--- a/model-pr-optimization-history/vllm/ernie45/README.en.md
+++ b/model-pr-optimization-history/vllm/ernie45/README.en.md
@@ -1,0 +1,29 @@
+# vLLM Ernie4.5 / Ernie4.5-VL Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and cookbook-facing touchpoints for Ernie4.5 / Ernie4.5-VL.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- Ernie4.5 spans dense, MoE, and VL paths in vLLM.
+- The highest-risk work items are shared-expert behavior, VL rotary/timestamp logic, and long-input stability.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/ernie45.py`
+- `vllm/vllm/model_executor/models/ernie45_moe.py`
+- `vllm/vllm/model_executor/models/ernie45_vl.py`
+
+## Landed PRs
+
+- [#20220](https://github.com/vllm-project/vllm/pull/20220) `Add Ernie4.5 and Ernie4.5MoE Model Support`: Landed text and MoE support.
+- [#21717](https://github.com/vllm-project/vllm/pull/21717) `Fix Ernie4_5_MoeForCausalLM shared experts`: Fixed shared-expert correctness.
+- [#22514](https://github.com/vllm-project/vllm/pull/22514) `Add Ernie4.5 VL Model Support`: Added the multimodal Ernie4.5-VL lane.
+- [#24074](https://github.com/vllm-project/vllm/pull/24074) `Fix Ernie4.5-VL hanging on long inputs`: Closed a production long-input stall.
+- [#31274](https://github.com/vllm-project/vllm/pull/31274) `Support video metadata for timestamp rendering`: Improved VL video output fidelity.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-ernie45-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-ernie45-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/ernie45/README.zh.md
+++ b/model-pr-optimization-history/vllm/ernie45/README.zh.md
@@ -1,0 +1,29 @@
+# vLLM Ernie4.5 / Ernie4.5-VL 支持与 PR 历史
+
+本文记录 vLLM 中与 Ernie4.5 / Ernie4.5-VL 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Ernie4.5 spans dense, MoE, and VL paths in vLLM.
+- The highest-risk work items are shared-expert behavior, VL rotary/timestamp logic, and long-input stability.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/ernie45.py`
+- `vllm/vllm/model_executor/models/ernie45_moe.py`
+- `vllm/vllm/model_executor/models/ernie45_vl.py`
+
+## 已合入 PR
+
+- [#20220](https://github.com/vllm-project/vllm/pull/20220) `Add Ernie4.5 and Ernie4.5MoE Model Support`：Landed text and MoE support.
+- [#21717](https://github.com/vllm-project/vllm/pull/21717) `Fix Ernie4_5_MoeForCausalLM shared experts`：Fixed shared-expert correctness.
+- [#22514](https://github.com/vllm-project/vllm/pull/22514) `Add Ernie4.5 VL Model Support`：Added the multimodal Ernie4.5-VL lane.
+- [#24074](https://github.com/vllm-project/vllm/pull/24074) `Fix Ernie4.5-VL hanging on long inputs`：Closed a production long-input stall.
+- [#31274](https://github.com/vllm-project/vllm/pull/31274) `Support video metadata for timestamp rendering`：Improved VL video output fidelity.
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-ernie45-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-ernie45-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/gemma4/README.en.md
+++ b/model-pr-optimization-history/vllm/gemma4/README.en.md
@@ -1,0 +1,28 @@
+# vLLM Gemma 4 Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and cookbook-facing touchpoints for Gemma 4.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- Gemma 4 is a genuinely multi-surface family: text, MoE, multimodal, tool calling, and speculative decoding all matter.
+- Fast prefill, quantized MoE, and tool-parser correctness are the main areas that changed rapidly after bring-up.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/gemma4.py`
+- `vllm/vllm/model_executor/models/gemma4_mm.py`
+
+## Landed PRs
+
+- [#38826](https://github.com/vllm-project/vllm/pull/38826) `Implement Google Gemma 4 architecture support`: Initial Gemma 4 text/MoE/multimodal landing.
+- [#38879](https://github.com/vllm-project/vllm/pull/38879) `Enable Fast Prefill Optimization`: Added YOCO KV-sharing based fast prefill for Gemma4.
+- [#39045](https://github.com/vllm-project/vllm/pull/39045) `Support quantized MoE`: Extended Gemma4 to quantized MoE checkpoints.
+- [#38844](https://github.com/vllm-project/vllm/pull/38844) `Enable Gemma4ForCausalLM to load LoRA adapters correctly`: Fixed adapter naming/load behavior.
+- [#39450](https://github.com/vllm-project/vllm/pull/39450) `Add Gemma4 Eagle3 support`: Enabled speculative decode for Gemma4.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-gemma4-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-gemma4-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/gemma4/README.zh.md
+++ b/model-pr-optimization-history/vllm/gemma4/README.zh.md
@@ -1,0 +1,28 @@
+# vLLM Gemma 4 支持与 PR 历史
+
+本文记录 vLLM 中与 Gemma 4 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Gemma 4 is a genuinely multi-surface family: text, MoE, multimodal, tool calling, and speculative decoding all matter.
+- Fast prefill, quantized MoE, and tool-parser correctness are the main areas that changed rapidly after bring-up.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/gemma4.py`
+- `vllm/vllm/model_executor/models/gemma4_mm.py`
+
+## 已合入 PR
+
+- [#38826](https://github.com/vllm-project/vllm/pull/38826) `Implement Google Gemma 4 architecture support`：Initial Gemma 4 text/MoE/multimodal landing.
+- [#38879](https://github.com/vllm-project/vllm/pull/38879) `Enable Fast Prefill Optimization`：Added YOCO KV-sharing based fast prefill for Gemma4.
+- [#39045](https://github.com/vllm-project/vllm/pull/39045) `Support quantized MoE`：Extended Gemma4 to quantized MoE checkpoints.
+- [#38844](https://github.com/vllm-project/vllm/pull/38844) `Enable Gemma4ForCausalLM to load LoRA adapters correctly`：Fixed adapter naming/load behavior.
+- [#39450](https://github.com/vllm-project/vllm/pull/39450) `Add Gemma4 Eagle3 support`：Enabled speculative decode for Gemma4.
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-gemma4-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-gemma4-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/glm-vlm-ocr/README.en.md
+++ b/model-pr-optimization-history/vllm/glm-vlm-ocr/README.en.md
@@ -1,0 +1,34 @@
+# vLLM GLM VLM / OCR Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for GLM VLM / OCR.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- GLM visual/OCR support in vLLM spans classic GLM4V, newer GLM4.1V, and GLM-OCR-specific processor paths.
+- The main failures are processor-schema drift, MRoPE/video position handling, and OCR-specific weight or patch-merger mismatches.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/glm4v.py`
+- `vllm/vllm/model_executor/models/glm4_1v.py`
+- `vllm/vllm/model_executor/models/glm_ocr.py`
+
+## Landed PRs
+
+- [#9242](https://github.com/vllm-project/vllm/pull/9242) `Add GLM-4v support`: Landed the original GLM4V multimodal model path.
+- [#19331](https://github.com/vllm-project/vllm/pull/19331) `Add GLM4.1V model`: Extended the family to the newer GLM4.1V checkpoint layout and vision stack.
+- [#27860](https://github.com/vllm-project/vllm/pull/27860) `Fix broken MRoPE for GLM-4.1V/GLM-4.5V`: Closed a positional-embedding bug with large practical accuracy impact on vision inputs.
+- [#33005](https://github.com/vllm-project/vllm/pull/33005) `GLM-OCR with MTP Support`: Added OCR-specific draft / MTP support rather than text-only OCR loading.
+- [#33350](https://github.com/vllm-project/vllm/pull/33350) `Fix broken GLM-OCR initialization`: Fixed startup failures in the GLM-OCR path after the first bring-up.
+- [#37962](https://github.com/vllm-project/vllm/pull/37962) `GLM OCR Patch Merger context_dim`: Updated the patch-merger contract for newer OCR checkpoints.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-glm-vlm-ocr-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-glm-vlm-ocr-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/glm-vlm-ocr/README.zh.md
+++ b/model-pr-optimization-history/vllm/glm-vlm-ocr/README.zh.md
@@ -1,0 +1,34 @@
+# vLLM GLM VLM / OCR 支持与 PR 历史
+
+本文记录 vLLM 中与 GLM VLM / OCR 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- GLM visual/OCR support in vLLM spans classic GLM4V, newer GLM4.1V, and GLM-OCR-specific processor paths.
+- The main failures are processor-schema drift, MRoPE/video position handling, and OCR-specific weight or patch-merger mismatches.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/glm4v.py`
+- `vllm/vllm/model_executor/models/glm4_1v.py`
+- `vllm/vllm/model_executor/models/glm_ocr.py`
+
+## 已合入 PR
+
+- [#9242](https://github.com/vllm-project/vllm/pull/9242) `Add GLM-4v support`：Landed the original GLM4V multimodal model path.
+- [#19331](https://github.com/vllm-project/vllm/pull/19331) `Add GLM4.1V model`：Extended the family to the newer GLM4.1V checkpoint layout and vision stack.
+- [#27860](https://github.com/vllm-project/vllm/pull/27860) `Fix broken MRoPE for GLM-4.1V/GLM-4.5V`：Closed a positional-embedding bug with large practical accuracy impact on vision inputs.
+- [#33005](https://github.com/vllm-project/vllm/pull/33005) `GLM-OCR with MTP Support`：Added OCR-specific draft / MTP support rather than text-only OCR loading.
+- [#33350](https://github.com/vllm-project/vllm/pull/33350) `Fix broken GLM-OCR initialization`：Fixed startup failures in the GLM-OCR path after the first bring-up.
+- [#37962](https://github.com/vllm-project/vllm/pull/37962) `GLM OCR Patch Merger context_dim`：Updated the patch-merger contract for newer OCR checkpoints.
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-glm-vlm-ocr-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-glm-vlm-ocr-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/glm45/README.en.md
+++ b/model-pr-optimization-history/vllm/glm45/README.en.md
@@ -1,0 +1,33 @@
+# vLLM GLM-4.5 / 4.5V Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for GLM-4.5 / 4.5V.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- The GLM-4.5 lane is where vLLM reorganized the GLM family around text, MoE, and vision variants.
+- Most regressions are in MoE gate behavior, tie-word-embedding policy, and vendor-specific fused MoE tuning.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/glm4.py`
+- `vllm/vllm/model_executor/models/glm4_moe.py`
+- `vllm/vllm/model_executor/models/glm4v.py`
+
+## Landed PRs
+
+- [#22171](https://github.com/vllm-project/vllm/pull/22171) `Modify the organization of GLM series`: Reworked the family layout so 4.5-era models reused a cleaner GLM structure.
+- [#22460](https://github.com/vllm-project/vllm/pull/22460) `not tie_word_embeddings for glm-4.5 and glm-4.5v`: Aligned the loader with the real 4.5 checkpoint contract instead of forcing tied embeddings.
+- [#22832](https://github.com/vllm-project/vllm/pull/22832) `Modify the gate implementation of glm4_moe`: Changed the GLM4.5 MoE gating path used by text and VL variants.
+- [#23695](https://github.com/vllm-project/vllm/pull/23695) `Add triton fused moe config for GLM-4.5-Air-FP8 on B200`: Added a production kernel-tuning lane for the 4.5 Air FP8 deployment path.
+- [#24589](https://github.com/vllm-project/vllm/pull/24589) `Add documentation for GLM-4.5 series tool-calling and reasoning parser`: Codified the parser choices needed to serve 4.5 reasoning / tool checkpoints correctly.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-glm45-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-glm45-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/glm45/README.zh.md
+++ b/model-pr-optimization-history/vllm/glm45/README.zh.md
@@ -1,0 +1,33 @@
+# vLLM GLM-4.5 / 4.5V 支持与 PR 历史
+
+本文记录 vLLM 中与 GLM-4.5 / 4.5V 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- The GLM-4.5 lane is where vLLM reorganized the GLM family around text, MoE, and vision variants.
+- Most regressions are in MoE gate behavior, tie-word-embedding policy, and vendor-specific fused MoE tuning.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/glm4.py`
+- `vllm/vllm/model_executor/models/glm4_moe.py`
+- `vllm/vllm/model_executor/models/glm4v.py`
+
+## 已合入 PR
+
+- [#22171](https://github.com/vllm-project/vllm/pull/22171) `Modify the organization of GLM series`：Reworked the family layout so 4.5-era models reused a cleaner GLM structure.
+- [#22460](https://github.com/vllm-project/vllm/pull/22460) `not tie_word_embeddings for glm-4.5 and glm-4.5v`：Aligned the loader with the real 4.5 checkpoint contract instead of forcing tied embeddings.
+- [#22832](https://github.com/vllm-project/vllm/pull/22832) `Modify the gate implementation of glm4_moe`：Changed the GLM4.5 MoE gating path used by text and VL variants.
+- [#23695](https://github.com/vllm-project/vllm/pull/23695) `Add triton fused moe config for GLM-4.5-Air-FP8 on B200`：Added a production kernel-tuning lane for the 4.5 Air FP8 deployment path.
+- [#24589](https://github.com/vllm-project/vllm/pull/24589) `Add documentation for GLM-4.5 series tool-calling and reasoning parser`：Codified the parser choices needed to serve 4.5 reasoning / tool checkpoints correctly.
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-glm45-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-glm45-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/glm46-glm47/README.en.md
+++ b/model-pr-optimization-history/vllm/glm46-glm47/README.en.md
@@ -1,0 +1,33 @@
+# vLLM GLM-4.6 / 4.7 Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for GLM-4.6 / 4.7.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- The 4.6/4.7 generation mainly extends the 4.5 base with new tuning tables, parser behavior, and Lite variants.
+- AWQ / Marlin compatibility and content-normalization in tool parsing are the recurring pitfalls.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/glm4.py`
+- `vllm/vllm/model_executor/models/glm4_moe.py`
+- `vllm/vllm/model_executor/models/glm4v.py`
+
+## Landed PRs
+
+- [#26818](https://github.com/vllm-project/vllm/pull/26818) `Add MoE tunings for GLM 4.6-FP8 and GLM 4.5 Air on B200`: Added fused-MoE tuning configs for the new Blackwell deployment lane.
+- [#30210](https://github.com/vllm-project/vllm/pull/30210) `Fix glm46 awq marlin moe compatibility`: Closed an incompatibility between GLM-4.6 AWQ checkpoints and Marlin MoE assumptions.
+- [#30876](https://github.com/vllm-project/vllm/pull/30876) `GLM-4.7 Tool Parser and Doc Update`: Brought parser behavior and docs up to date for 4.7 / 4.7-Flash.
+- [#31386](https://github.com/vllm-project/vllm/pull/31386) `GLM Model support for GLM-Lite`: Extended the same runtime family to the Lite checkpoint line.
+- [#37386](https://github.com/vllm-project/vllm/pull/37386) `Improve tool call parsing and content normalization for glm47`: Fixed concrete parsing errors that surfaced in newer GLM-4.7 outputs.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-glm46-glm47-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-glm46-glm47-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/glm46-glm47/README.zh.md
+++ b/model-pr-optimization-history/vllm/glm46-glm47/README.zh.md
@@ -1,0 +1,33 @@
+# vLLM GLM-4.6 / 4.7 支持与 PR 历史
+
+本文记录 vLLM 中与 GLM-4.6 / 4.7 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- The 4.6/4.7 generation mainly extends the 4.5 base with new tuning tables, parser behavior, and Lite variants.
+- AWQ / Marlin compatibility and content-normalization in tool parsing are the recurring pitfalls.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/glm4.py`
+- `vllm/vllm/model_executor/models/glm4_moe.py`
+- `vllm/vllm/model_executor/models/glm4v.py`
+
+## 已合入 PR
+
+- [#26818](https://github.com/vllm-project/vllm/pull/26818) `Add MoE tunings for GLM 4.6-FP8 and GLM 4.5 Air on B200`：Added fused-MoE tuning configs for the new Blackwell deployment lane.
+- [#30210](https://github.com/vllm-project/vllm/pull/30210) `Fix glm46 awq marlin moe compatibility`：Closed an incompatibility between GLM-4.6 AWQ checkpoints and Marlin MoE assumptions.
+- [#30876](https://github.com/vllm-project/vllm/pull/30876) `GLM-4.7 Tool Parser and Doc Update`：Brought parser behavior and docs up to date for 4.7 / 4.7-Flash.
+- [#31386](https://github.com/vllm-project/vllm/pull/31386) `GLM Model support for GLM-Lite`：Extended the same runtime family to the Lite checkpoint line.
+- [#37386](https://github.com/vllm-project/vllm/pull/37386) `Improve tool call parsing and content normalization for glm47`：Fixed concrete parsing errors that surfaced in newer GLM-4.7 outputs.
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-glm46-glm47-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-glm46-glm47-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/glm5-glm51/README.en.md
+++ b/model-pr-optimization-history/vllm/glm5-glm51/README.en.md
@@ -1,0 +1,40 @@
+# vLLM GLM-5 / 5.1 Support and PR History
+
+This note tracks the landed GLM-5 / 5.1 path in vLLM at commit
+`0f7be0f2f76814f80f9091220a5fbbb53912ad00`.
+
+- Status: partially supported on current mainline
+
+## Key Conclusions
+
+- GLM-5 support is currently an adaptation layer on top of the DeepSeek-V2/V3
+  runtime, not an independent `glm5.py` implementation.
+- The two key landed steps are:
+  `#34124` for architecture/config adaptation and `#34385` for MTP accuracy.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/deepseek_v2.py`
+- `vllm/vllm/model_executor/models/registry.py`
+- `vllm/vllm/config/speculative.py`
+- `vllm/vllm/transformers_utils/model_arch_config_convertor.py`
+- `vllm/vllm/v1/spec_decode/eagle.py`
+
+## Landed PRs
+
+- [#34124](https://github.com/vllm-project/vllm/pull/34124)
+  `GLM adaptation`
+  Diff reviewed: `7` files, `13` additions, `3` deletions.
+  Adds `GlmMoeDsaForCausalLM` as a DeepSeek-V2-derived alias, extends
+  speculative config conversion, and respects `indexer_rope_interleave`.
+- [#34385](https://github.com/vllm-project/vllm/pull/34385)
+  `Fix MTP accuracy for GLM-5`
+  Diff reviewed: `1` file, `18` additions.
+  Shares the target `lm_head` into MTP `shared_head.head` so GLM-5 draft logits
+  stop producing NaNs or uninitialized outputs.
+
+## Current Contract
+
+If GLM-5 breaks, inspect the DeepSeek-based MLA/MoE runtime and speculative
+decode stack first. Do not assume the older `glm4*` files are the source of
+truth for GLM-5 behavior.

--- a/model-pr-optimization-history/vllm/glm5-glm51/README.zh.md
+++ b/model-pr-optimization-history/vllm/glm5-glm51/README.zh.md
@@ -1,0 +1,40 @@
+# vLLM GLM-5 / 5.1 支持与 PR 历史
+
+本文记录 vLLM 在提交 `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+附近对 GLM-5 / 5.1 的已落地支持。
+
+- 状态: 当前 mainline 仅部分支持
+
+## 核心结论
+
+- GLM-5 现在不是独立的 `glm5.py` 实现，而是通过 DeepSeek-V2/V3 的
+  MLA/MoE 运行时做适配。
+- 当前最关键的两步是:
+  `#34124` 负责架构和配置适配，
+  `#34385` 负责修正 MTP 草稿模型的 logits 正确性。
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/deepseek_v2.py`
+- `vllm/vllm/model_executor/models/registry.py`
+- `vllm/vllm/config/speculative.py`
+- `vllm/vllm/transformers_utils/model_arch_config_convertor.py`
+- `vllm/vllm/v1/spec_decode/eagle.py`
+
+## 已合入 PR
+
+- [#34124](https://github.com/vllm-project/vllm/pull/34124)
+  `GLM adaptation`
+  已审 diff: `7` 个文件，`13` 行新增，`3` 行删除。
+  它把 `GlmMoeDsaForCausalLM` 接到 DeepSeek-V2 运行时上，并补了
+  speculative config 与 `indexer_rope_interleave` 适配。
+- [#34385](https://github.com/vllm-project/vllm/pull/34385)
+  `Fix MTP accuracy for GLM-5`
+  已审 diff: `1` 个文件，`18` 行新增。
+  它把目标模型 `lm_head` 显式共享给每个 MTP layer 的
+  `shared_head.head`，否则 GLM-5 draft logits 会出现 NaN 或未初始化输出。
+
+## 当前结论
+
+遇到 GLM-5 问题时，优先检查 DeepSeek 复用路径和 speculative decode 基础
+设施，而不是先去看旧的 `glm4*` 文件。

--- a/model-pr-optimization-history/vllm/gpt-oss/README.en.md
+++ b/model-pr-optimization-history/vllm/gpt-oss/README.en.md
@@ -1,0 +1,27 @@
+# vLLM GPT-OSS Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and cookbook-facing touchpoints for GPT-OSS.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- GPT-OSS is a flagship MoE family in vLLM.
+- Quantization, expert-parallel topology, and reasoning/tool parser behavior all evolved quickly and need per-PR tracking.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/gpt_oss.py`
+
+## Landed PRs
+
+- [#22327](https://github.com/vllm-project/vllm/pull/22327) `Add GPT-OSS model code and config`: Initial GPT-OSS landing in vLLM.
+- [#23819](https://github.com/vllm-project/vllm/pull/23819) `Support DP+EP for GPT-OSS with FlashInfer trtllm-gen MoE`: Opened large-scale GPT-OSS serving topologies.
+- [#25246](https://github.com/vllm-project/vllm/pull/25246) `Enable Eagle3 speculative decoding for GPT-OSS model`: Added draft-model acceleration.
+- [#25515](https://github.com/vllm-project/vllm/pull/25515) `Structure_Tag support for gpt-oss tool-call in cot`: Improved tool calling in reasoning-mode outputs.
+- [#30647](https://github.com/vllm-project/vllm/pull/30647) `Eliminate padding and slicing op for GPT-OSS with Flashinfer MXFP4 MXFP8 MoE`: Targeted the hot MXFP4/MXFP8 path for throughput.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-gpt-oss-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-gpt-oss-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/gpt-oss/README.zh.md
+++ b/model-pr-optimization-history/vllm/gpt-oss/README.zh.md
@@ -1,0 +1,27 @@
+# vLLM GPT-OSS 支持与 PR 历史
+
+本文记录 vLLM 中与 GPT-OSS 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- GPT-OSS is a flagship MoE family in vLLM.
+- Quantization, expert-parallel topology, and reasoning/tool parser behavior all evolved quickly and need per-PR tracking.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/gpt_oss.py`
+
+## 已合入 PR
+
+- [#22327](https://github.com/vllm-project/vllm/pull/22327) `Add GPT-OSS model code and config`：Initial GPT-OSS landing in vLLM.
+- [#23819](https://github.com/vllm-project/vllm/pull/23819) `Support DP+EP for GPT-OSS with FlashInfer trtllm-gen MoE`：Opened large-scale GPT-OSS serving topologies.
+- [#25246](https://github.com/vllm-project/vllm/pull/25246) `Enable Eagle3 speculative decoding for GPT-OSS model`：Added draft-model acceleration.
+- [#25515](https://github.com/vllm-project/vllm/pull/25515) `Structure_Tag support for gpt-oss tool-call in cot`：Improved tool calling in reasoning-mode outputs.
+- [#30647](https://github.com/vllm-project/vllm/pull/30647) `Eliminate padding and slicing op for GPT-OSS with Flashinfer MXFP4 MXFP8 MoE`：Targeted the hot MXFP4/MXFP8 path for throughput.
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-gpt-oss-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-gpt-oss-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/hunyuan3-preview/README.en.md
+++ b/model-pr-optimization-history/vllm/hunyuan3-preview/README.en.md
@@ -1,0 +1,30 @@
+# vLLM Hunyuan 3 Preview Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for Hunyuan 3 Preview.
+
+- Status: partially supported or only adjacent architectures landed on current mainline
+
+## Key Conclusions
+
+- vLLM does not currently expose a dedicated Hunyuan 3 Preview model alias.
+- The closest landed evidence is the Hunyuan dense, Hunyuan OCR, and HunyuanVL / Eagle work already in tree.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/hunyuan_v1.py`
+- `vllm/vllm/model_executor/models/hunyuan_vision.py`
+
+## Landed PRs
+
+- [#21368](https://github.com/vllm-project/vllm/pull/21368) `Add Hunyuan V1 Dense Model support`: Brought the dense Hunyuan line into vLLM mainline.
+- [#29327](https://github.com/vllm-project/vllm/pull/29327) `Add HunyuanOCR support`: Extended the family to OCR workloads instead of text-only generation.
+- [#33035](https://github.com/vllm-project/vllm/pull/33035) `Eagle3 support for HunyuanVL & Hunyuan`: Added speculative decoding support on top of the Hunyuan family.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-hunyuan3-preview-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-hunyuan3-preview-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/hunyuan3-preview/README.zh.md
+++ b/model-pr-optimization-history/vllm/hunyuan3-preview/README.zh.md
@@ -1,0 +1,30 @@
+# vLLM Hunyuan 3 Preview 支持与 PR 历史
+
+本文记录 vLLM 中与 Hunyuan 3 Preview 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 仅部分支持，或只有相邻架构已落地
+
+## 核心结论
+
+- vLLM does not currently expose a dedicated Hunyuan 3 Preview model alias.
+- The closest landed evidence is the Hunyuan dense, Hunyuan OCR, and HunyuanVL / Eagle work already in tree.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/hunyuan_v1.py`
+- `vllm/vllm/model_executor/models/hunyuan_vision.py`
+
+## 已合入 PR
+
+- [#21368](https://github.com/vllm-project/vllm/pull/21368) `Add Hunyuan V1 Dense Model support`：Brought the dense Hunyuan line into vLLM mainline.
+- [#29327](https://github.com/vllm-project/vllm/pull/29327) `Add HunyuanOCR support`：Extended the family to OCR workloads instead of text-only generation.
+- [#33035](https://github.com/vllm-project/vllm/pull/33035) `Eagle3 support for HunyuanVL & Hunyuan`：Added speculative decoding support on top of the Hunyuan family.
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-hunyuan3-preview-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-hunyuan3-preview-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/intern-s1/README.en.md
+++ b/model-pr-optimization-history/vllm/intern-s1/README.en.md
@@ -1,0 +1,27 @@
+# vLLM Intern-S1 Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and cookbook-facing touchpoints for Intern-S1.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- Intern-S1 leans heavily on shared InternVL processor code in vLLM.
+- Most regressions come from processor compatibility and video-aware serving rather than the text stack alone.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/interns1.py`
+- `vllm/vllm/model_executor/models/interns1_pro.py`
+
+## Landed PRs
+
+- [#21628](https://github.com/vllm-project/vllm/pull/21628) `Support Intern-S1`: Initial Intern-S1 support in vLLM.
+- [#21671](https://github.com/vllm-project/vllm/pull/21671) `Add video support for Intern-S1`: Extended the family beyond static images.
+- [#22417](https://github.com/vllm-project/vllm/pull/22417) `Fix wrong method name in Intern-S1 image processor`: Patched a processor bug after bring-up.
+- [#33636](https://github.com/vllm-project/vllm/pull/33636) `Intern-S1-Pro`: Added the Pro generation / alias path.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-intern-s1-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-intern-s1-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/intern-s1/README.zh.md
+++ b/model-pr-optimization-history/vllm/intern-s1/README.zh.md
@@ -1,0 +1,27 @@
+# vLLM Intern-S1 支持与 PR 历史
+
+本文记录 vLLM 中与 Intern-S1 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Intern-S1 leans heavily on shared InternVL processor code in vLLM.
+- Most regressions come from processor compatibility and video-aware serving rather than the text stack alone.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/interns1.py`
+- `vllm/vllm/model_executor/models/interns1_pro.py`
+
+## 已合入 PR
+
+- [#21628](https://github.com/vllm-project/vllm/pull/21628) `Support Intern-S1`：Initial Intern-S1 support in vLLM.
+- [#21671](https://github.com/vllm-project/vllm/pull/21671) `Add video support for Intern-S1`：Extended the family beyond static images.
+- [#22417](https://github.com/vllm-project/vllm/pull/22417) `Fix wrong method name in Intern-S1 image processor`：Patched a processor bug after bring-up.
+- [#33636](https://github.com/vllm-project/vllm/pull/33636) `Intern-S1-Pro`：Added the Pro generation / alias path.
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-intern-s1-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-intern-s1-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/internvl35/README.en.md
+++ b/model-pr-optimization-history/vllm/internvl35/README.en.md
@@ -1,0 +1,27 @@
+# vLLM InternVL3.5 Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and cookbook-facing touchpoints for InternVL3.5.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- InternVL3.5 is mostly a processor / encoder / video problem in vLLM.
+- Video handling, native HF loading, and backend compatibility dominate the risk surface.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/internvl.py`
+
+## Landed PRs
+
+- [#6514](https://github.com/vllm-project/vllm/pull/6514) `Initialize support for InternVL2 series models`: Historical base for current InternVL runtime code.
+- [#18499](https://github.com/vllm-project/vllm/pull/18499) `Initialize video input support for InternVL models`: Added video processing to the family.
+- [#23658](https://github.com/vllm-project/vllm/pull/23658) `Enable video support for InternVL3.5 models`: Carried video support into the 3.5 checkpoints.
+- [#23742](https://github.com/vllm-project/vllm/pull/23742) `Enable native HF format InternVL support`: Removed reliance on ad hoc checkpoint rewrites.
+- [#38049](https://github.com/vllm-project/vllm/pull/38049) `Add torch.compile support for InternVL vision encoder`: Modernized the encoder execution path.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-internvl35-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-internvl35-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/internvl35/README.zh.md
+++ b/model-pr-optimization-history/vllm/internvl35/README.zh.md
@@ -1,0 +1,27 @@
+# vLLM InternVL3.5 支持与 PR 历史
+
+本文记录 vLLM 中与 InternVL3.5 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- InternVL3.5 is mostly a processor / encoder / video problem in vLLM.
+- Video handling, native HF loading, and backend compatibility dominate the risk surface.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/internvl.py`
+
+## 已合入 PR
+
+- [#6514](https://github.com/vllm-project/vllm/pull/6514) `Initialize support for InternVL2 series models`：Historical base for current InternVL runtime code.
+- [#18499](https://github.com/vllm-project/vllm/pull/18499) `Initialize video input support for InternVL models`：Added video processing to the family.
+- [#23658](https://github.com/vllm-project/vllm/pull/23658) `Enable video support for InternVL3.5 models`：Carried video support into the 3.5 checkpoints.
+- [#23742](https://github.com/vllm-project/vllm/pull/23742) `Enable native HF format InternVL support`：Removed reliance on ad hoc checkpoint rewrites.
+- [#38049](https://github.com/vllm-project/vllm/pull/38049) `Add torch.compile support for InternVL vision encoder`：Modernized the encoder execution path.
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-internvl35-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-internvl35-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/kimi/README.en.md
+++ b/model-pr-optimization-history/vllm/kimi/README.en.md
@@ -1,0 +1,35 @@
+# vLLM Kimi K2 / K2.5 / Linear / Audio / VL Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for Kimi K2 / K2.5 / Linear / Audio / VL.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- The Kimi family in vLLM spans vision, linear-attention, K2.5, and audio checkpoints.
+- The most fragile areas are MLA plus FP8/NVFP4 loading, processor evolution, and parser alias compatibility between K2 and K2.5.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/kimi_vl.py`
+- `vllm/vllm/model_executor/models/kimi_linear.py`
+- `vllm/vllm/model_executor/models/kimi_k25.py`
+- `vllm/vllm/model_executor/models/kimi_audio.py`
+
+## Landed PRs
+
+- [#16387](https://github.com/vllm-project/vllm/pull/16387) `Add Kimi-VL model support`: Landed the original Kimi-VL multimodal runtime.
+- [#27809](https://github.com/vllm-project/vllm/pull/27809) `Introduce Kimi Linear to vLLM`: Added the linear-attention Kimi family instead of only the VL path.
+- [#33131](https://github.com/vllm-project/vllm/pull/33131) `Kimi-K2.5`: Brought the K2.5 generation into mainline.
+- [#33876](https://github.com/vllm-project/vllm/pull/33876) `Fix Kimi-K2.5 NVFP4 checkpoints weight loading`: Closed a concrete launch blocker for quantized K2.5 checkpoints.
+- [#36127](https://github.com/vllm-project/vllm/pull/36127) `Add support for moonshotai/Kimi-Audio-7B-Instruct`: Extended the family to audio-conditioned serving.
+- [#37438](https://github.com/vllm-project/vllm/pull/37438) `Add Kimi-K2.5 reasoning/tool parser aliases`: Aligned parser aliases and tool-call IDs with the newer model outputs.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-kimi-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-kimi-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/kimi/README.zh.md
+++ b/model-pr-optimization-history/vllm/kimi/README.zh.md
@@ -1,0 +1,35 @@
+# vLLM Kimi K2 / K2.5 / Linear / Audio / VL 支持与 PR 历史
+
+本文记录 vLLM 中与 Kimi K2 / K2.5 / Linear / Audio / VL 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- The Kimi family in vLLM spans vision, linear-attention, K2.5, and audio checkpoints.
+- The most fragile areas are MLA plus FP8/NVFP4 loading, processor evolution, and parser alias compatibility between K2 and K2.5.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/kimi_vl.py`
+- `vllm/vllm/model_executor/models/kimi_linear.py`
+- `vllm/vllm/model_executor/models/kimi_k25.py`
+- `vllm/vllm/model_executor/models/kimi_audio.py`
+
+## 已合入 PR
+
+- [#16387](https://github.com/vllm-project/vllm/pull/16387) `Add Kimi-VL model support`：Landed the original Kimi-VL multimodal runtime.
+- [#27809](https://github.com/vllm-project/vllm/pull/27809) `Introduce Kimi Linear to vLLM`：Added the linear-attention Kimi family instead of only the VL path.
+- [#33131](https://github.com/vllm-project/vllm/pull/33131) `Kimi-K2.5`：Brought the K2.5 generation into mainline.
+- [#33876](https://github.com/vllm-project/vllm/pull/33876) `Fix Kimi-K2.5 NVFP4 checkpoints weight loading`：Closed a concrete launch blocker for quantized K2.5 checkpoints.
+- [#36127](https://github.com/vllm-project/vllm/pull/36127) `Add support for moonshotai/Kimi-Audio-7B-Instruct`：Extended the family to audio-conditioned serving.
+- [#37438](https://github.com/vllm-project/vllm/pull/37438) `Add Kimi-K2.5 reasoning/tool parser aliases`：Aligned parser aliases and tool-call IDs with the newer model outputs.
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-kimi-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-kimi-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/llama4/README.en.md
+++ b/model-pr-optimization-history/vllm/llama4/README.en.md
@@ -1,0 +1,29 @@
+# vLLM Llama 4 Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and cookbook-facing touchpoints for Llama 4.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- Llama4 is mature on the vLLM side but still sensitive to quantized MoE and long-context backend selection.
+- The multimodal path adds a separate vision-rotary and processor validation surface.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/llama4.py`
+- `vllm/vllm/model_executor/models/mllama4.py`
+- `vllm/vllm/model_executor/models/llama4_eagle.py`
+
+## Landed PRs
+
+- [#16104](https://github.com/vllm-project/vllm/pull/16104) `Support Llama4 in vLLM`: Initial Llama4 landing.
+- [#20419](https://github.com/vllm-project/vllm/pull/20419) `Enable ModelOpt Llama4 fp8 checkpoint deployment`: Added ModelOpt FP8 coverage.
+- [#20591](https://github.com/vllm-project/vllm/pull/20591) `Llama4 EAGLE Support`: Opened speculative decoding for Llama4.
+- [#22511](https://github.com/vllm-project/vllm/pull/22511) `Fix Llama4 FlashInfer FP4 MoE issues`: Stabilized the FP4 MoE path.
+- [#25889](https://github.com/vllm-project/vllm/pull/25889) `Fix misplaced dtype cast in Llama4VisionRotaryEmbedding`: Patched a multimodal rotary bug.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-llama4-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-llama4-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/llama4/README.zh.md
+++ b/model-pr-optimization-history/vllm/llama4/README.zh.md
@@ -1,0 +1,29 @@
+# vLLM Llama 4 支持与 PR 历史
+
+本文记录 vLLM 中与 Llama 4 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Llama4 is mature on the vLLM side but still sensitive to quantized MoE and long-context backend selection.
+- The multimodal path adds a separate vision-rotary and processor validation surface.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/llama4.py`
+- `vllm/vllm/model_executor/models/mllama4.py`
+- `vllm/vllm/model_executor/models/llama4_eagle.py`
+
+## 已合入 PR
+
+- [#16104](https://github.com/vllm-project/vllm/pull/16104) `Support Llama4 in vLLM`：Initial Llama4 landing.
+- [#20419](https://github.com/vllm-project/vllm/pull/20419) `Enable ModelOpt Llama4 fp8 checkpoint deployment`：Added ModelOpt FP8 coverage.
+- [#20591](https://github.com/vllm-project/vllm/pull/20591) `Llama4 EAGLE Support`：Opened speculative decoding for Llama4.
+- [#22511](https://github.com/vllm-project/vllm/pull/22511) `Fix Llama4 FlashInfer FP4 MoE issues`：Stabilized the FP4 MoE path.
+- [#25889](https://github.com/vllm-project/vllm/pull/25889) `Fix misplaced dtype cast in Llama4VisionRotaryEmbedding`：Patched a multimodal rotary bug.
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-llama4-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-llama4-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/ltx23-hq/README.en.md
+++ b/model-pr-optimization-history/vllm/ltx23-hq/README.en.md
@@ -1,0 +1,27 @@
+# vLLM LTX 2.3 HQ Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for LTX 2.3 HQ.
+
+- Status: not supported on current mainline
+
+## Key Conclusions
+
+- Current vLLM mainline does not ship a dedicated LTX diffusion/video generation runtime.
+- Treat this dossier as an explicit unsupported marker, not as hidden partial support.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## Landed PRs
+
+- No landed PR is recorded in this dossier yet.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-ltx23-hq-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-ltx23-hq-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/ltx23-hq/README.zh.md
+++ b/model-pr-optimization-history/vllm/ltx23-hq/README.zh.md
@@ -1,0 +1,27 @@
+# vLLM LTX 2.3 HQ 支持与 PR 历史
+
+本文记录 vLLM 中与 LTX 2.3 HQ 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 不支持
+
+## 核心结论
+
+- Current vLLM mainline does not ship a dedicated LTX diffusion/video generation runtime.
+- Treat this dossier as an explicit unsupported marker, not as hidden partial support.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## 已合入 PR
+
+- 当前 dossier 中没有已记录的 merged PR。
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-ltx23-hq-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-ltx23-hq-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/mimo-v2-flash/README.en.md
+++ b/model-pr-optimization-history/vllm/mimo-v2-flash/README.en.md
@@ -1,0 +1,27 @@
+# vLLM MiMo-V2-Flash Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and cookbook-facing touchpoints for MiMo-V2-Flash.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- MiMo-V2-Flash is a throughput-oriented MoE serving family in vLLM.
+- MTP correctness and the split between older MiMo checkpoints and V2-Flash are the key maintenance points.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/mimo_v2_flash.py`
+- `vllm/vllm/model_executor/models/mimo.py`
+- `vllm/vllm/model_executor/models/mimo_mtp.py`
+
+## Landed PRs
+
+- [#17433](https://github.com/vllm-project/vllm/pull/17433) `Support MiMo-7B inference with MTP`: Historical base for the MiMo family.
+- [#25136](https://github.com/vllm-project/vllm/pull/25136) `Fix MTP inference path for MiMo-7B model`: Closed a concrete draft-path bug.
+- [#30836](https://github.com/vllm-project/vllm/pull/30836) `Add MiMo-V2-Flash support`: Landed the dedicated V2-Flash runtime.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-mimo-v2-flash-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-mimo-v2-flash-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/mimo-v2-flash/README.zh.md
+++ b/model-pr-optimization-history/vllm/mimo-v2-flash/README.zh.md
@@ -1,0 +1,27 @@
+# vLLM MiMo-V2-Flash 支持与 PR 历史
+
+本文记录 vLLM 中与 MiMo-V2-Flash 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- MiMo-V2-Flash is a throughput-oriented MoE serving family in vLLM.
+- MTP correctness and the split between older MiMo checkpoints and V2-Flash are the key maintenance points.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/mimo_v2_flash.py`
+- `vllm/vllm/model_executor/models/mimo.py`
+- `vllm/vllm/model_executor/models/mimo_mtp.py`
+
+## 已合入 PR
+
+- [#17433](https://github.com/vllm-project/vllm/pull/17433) `Support MiMo-7B inference with MTP`：Historical base for the MiMo family.
+- [#25136](https://github.com/vllm-project/vllm/pull/25136) `Fix MTP inference path for MiMo-7B model`：Closed a concrete draft-path bug.
+- [#30836](https://github.com/vllm-project/vllm/pull/30836) `Add MiMo-V2-Flash support`：Landed the dedicated V2-Flash runtime.
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-mimo-v2-flash-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-mimo-v2-flash-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/minimax/README.en.md
+++ b/model-pr-optimization-history/vllm/minimax/README.en.md
@@ -1,0 +1,34 @@
+# vLLM MiniMax M1 / M2 / VL Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for MiniMax M1 / M2 / VL.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- MiniMax support evolved from the text-01 path into M1/M2 and VL variants.
+- Today the key production surfaces are linear-attention correctness, VL processor behavior, LoRA, and Eagle3 on M2.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/minimax_text_01.py`
+- `vllm/vllm/model_executor/models/minimax_m2.py`
+- `vllm/vllm/model_executor/models/minimax_vl_01.py`
+
+## Landed PRs
+
+- [#13454](https://github.com/vllm-project/vllm/pull/13454) `Support MiniMaxText01 model inference`: Landed the original MiniMax text runtime.
+- [#16328](https://github.com/vllm-project/vllm/pull/16328) `support MiniMax-VL-01 model`: Added the multimodal MiniMax-VL path.
+- [#19677](https://github.com/vllm-project/vllm/pull/19677) `Add support for MiniMaxM1ForCausalLM`: Connected the M1 checkpoint alias to the shared MiniMax runtime.
+- [#27535](https://github.com/vllm-project/vllm/pull/27535) `Support MiniMax-M2 Model`: Brought the M2 generation into mainline.
+- [#32763](https://github.com/vllm-project/vllm/pull/32763) `Complete LoRA support for MiniMaxM2`: Finished missing adapter wiring in the M2 family.
+- [#37512](https://github.com/vllm-project/vllm/pull/37512) `MiniMax-M2: add Eagle3 speculative decoding support`: Enabled the draft-model acceleration path for MiniMax M2.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-minimax-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-minimax-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/minimax/README.zh.md
+++ b/model-pr-optimization-history/vllm/minimax/README.zh.md
@@ -1,0 +1,34 @@
+# vLLM MiniMax M1 / M2 / VL 支持与 PR 历史
+
+本文记录 vLLM 中与 MiniMax M1 / M2 / VL 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- MiniMax support evolved from the text-01 path into M1/M2 and VL variants.
+- Today the key production surfaces are linear-attention correctness, VL processor behavior, LoRA, and Eagle3 on M2.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/minimax_text_01.py`
+- `vllm/vllm/model_executor/models/minimax_m2.py`
+- `vllm/vllm/model_executor/models/minimax_vl_01.py`
+
+## 已合入 PR
+
+- [#13454](https://github.com/vllm-project/vllm/pull/13454) `Support MiniMaxText01 model inference`：Landed the original MiniMax text runtime.
+- [#16328](https://github.com/vllm-project/vllm/pull/16328) `support MiniMax-VL-01 model`：Added the multimodal MiniMax-VL path.
+- [#19677](https://github.com/vllm-project/vllm/pull/19677) `Add support for MiniMaxM1ForCausalLM`：Connected the M1 checkpoint alias to the shared MiniMax runtime.
+- [#27535](https://github.com/vllm-project/vllm/pull/27535) `Support MiniMax-M2 Model`：Brought the M2 generation into mainline.
+- [#32763](https://github.com/vllm-project/vllm/pull/32763) `Complete LoRA support for MiniMaxM2`：Finished missing adapter wiring in the M2 family.
+- [#37512](https://github.com/vllm-project/vllm/pull/37512) `MiniMax-M2: add Eagle3 speculative decoding support`：Enabled the draft-model acceleration path for MiniMax M2.
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-minimax-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-minimax-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/mistral-small-4/README.en.md
+++ b/model-pr-optimization-history/vllm/mistral-small-4/README.en.md
@@ -1,0 +1,26 @@
+# vLLM Mistral Small 4 Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and cookbook-facing touchpoints for Mistral Small 4.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- Mistral Small 4 sits on top of the larger Mistral Large 3 / Ministral runtime work.
+- MoE execution and multimodal projector behavior are the main risk areas.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/mistral_large_3.py`
+- `vllm/vllm/model_executor/models/mistral_large_3_eagle.py`
+- `vllm/vllm/model_executor/models/mistral3.py`
+
+## Landed PRs
+
+- [#29757](https://github.com/vllm-project/vllm/pull/29757) `Add Mistral Large 3 and Ministral 3`: Landed the runtime family that Mistral Small 4 deployments build on in vLLM.
+- [#33174](https://github.com/vllm-project/vllm/pull/33174) `Add support for Mistral Large 3 inference with Flashinfer MoE`: Improved the practical MoE serving path for the same family.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-mistral-small-4-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-mistral-small-4-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/mistral-small-4/README.zh.md
+++ b/model-pr-optimization-history/vllm/mistral-small-4/README.zh.md
@@ -1,0 +1,26 @@
+# vLLM Mistral Small 4 支持与 PR 历史
+
+本文记录 vLLM 中与 Mistral Small 4 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Mistral Small 4 sits on top of the larger Mistral Large 3 / Ministral runtime work.
+- MoE execution and multimodal projector behavior are the main risk areas.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/mistral_large_3.py`
+- `vllm/vllm/model_executor/models/mistral_large_3_eagle.py`
+- `vllm/vllm/model_executor/models/mistral3.py`
+
+## 已合入 PR
+
+- [#29757](https://github.com/vllm-project/vllm/pull/29757) `Add Mistral Large 3 and Ministral 3`：Landed the runtime family that Mistral Small 4 deployments build on in vLLM.
+- [#33174](https://github.com/vllm-project/vllm/pull/33174) `Add support for Mistral Large 3 inference with Flashinfer MoE`：Improved the practical MoE serving path for the same family.
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-mistral-small-4-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-mistral-small-4-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/mixtral-quark-int4fp8-moe/README.en.md
+++ b/model-pr-optimization-history/vllm/mixtral-quark-int4fp8-moe/README.en.md
@@ -1,0 +1,33 @@
+# vLLM Mixtral Quark / INT4-FP8 MoE Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for Mixtral Quark / INT4-FP8 MoE.
+
+- Status: partially supported or only adjacent architectures landed on current mainline
+
+## Key Conclusions
+
+- vLLM has rich Mixtral MoE support, but not every Quark-branded checkpoint path is called out by name.
+- The closest production evidence is the Mixtral fused-MoE, FP8, ModelOpt, and EPLB work already merged.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/mixtral.py`
+- `vllm/vllm/model_executor/layers/fused_moe/layer.py`
+
+## Landed PRs
+
+- [#2011](https://github.com/vllm-project/vllm/pull/2011) `Mixtral 8x7B support`: Initial Mixtral model-family support.
+- [#2090](https://github.com/vllm-project/vllm/pull/2090) `Optimize Mixtral with expert parallelism`: Added early expert-parallel scaling instead of pure TP execution.
+- [#2542](https://github.com/vllm-project/vllm/pull/2542) `Fused MOE for Mixtral`: Brought fused-MoE kernels into the Mixtral serving path.
+- [#4527](https://github.com/vllm-project/vllm/pull/4527) `Support MoE FP8 checkpoints for Mixtral`: Added the first serious FP8 checkpoint path for Mixtral MoE.
+- [#15961](https://github.com/vllm-project/vllm/pull/15961) `Support ModelOpt quantization of Mixtral model`: Extended the family to NVIDIA ModelOpt quantization flows.
+- [#22842](https://github.com/vllm-project/vllm/pull/22842) `Support EPLB for Mixtral Model`: Added expert-parallel load balancing to the Mixtral family.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-mixtral-quark-int4fp8-moe-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-mixtral-quark-int4fp8-moe-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/mixtral-quark-int4fp8-moe/README.zh.md
+++ b/model-pr-optimization-history/vllm/mixtral-quark-int4fp8-moe/README.zh.md
@@ -1,0 +1,33 @@
+# vLLM Mixtral Quark / INT4-FP8 MoE 支持与 PR 历史
+
+本文记录 vLLM 中与 Mixtral Quark / INT4-FP8 MoE 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 仅部分支持，或只有相邻架构已落地
+
+## 核心结论
+
+- vLLM has rich Mixtral MoE support, but not every Quark-branded checkpoint path is called out by name.
+- The closest production evidence is the Mixtral fused-MoE, FP8, ModelOpt, and EPLB work already merged.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/mixtral.py`
+- `vllm/vllm/model_executor/layers/fused_moe/layer.py`
+
+## 已合入 PR
+
+- [#2011](https://github.com/vllm-project/vllm/pull/2011) `Mixtral 8x7B support`：Initial Mixtral model-family support.
+- [#2090](https://github.com/vllm-project/vllm/pull/2090) `Optimize Mixtral with expert parallelism`：Added early expert-parallel scaling instead of pure TP execution.
+- [#2542](https://github.com/vllm-project/vllm/pull/2542) `Fused MOE for Mixtral`：Brought fused-MoE kernels into the Mixtral serving path.
+- [#4527](https://github.com/vllm-project/vllm/pull/4527) `Support MoE FP8 checkpoints for Mixtral`：Added the first serious FP8 checkpoint path for Mixtral MoE.
+- [#15961](https://github.com/vllm-project/vllm/pull/15961) `Support ModelOpt quantization of Mixtral model`：Extended the family to NVIDIA ModelOpt quantization flows.
+- [#22842](https://github.com/vllm-project/vllm/pull/22842) `Support EPLB for Mixtral Model`：Added expert-parallel load balancing to the Mixtral family.
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-mixtral-quark-int4fp8-moe-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-mixtral-quark-int4fp8-moe-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/moss-vl/README.en.md
+++ b/model-pr-optimization-history/vllm/moss-vl/README.en.md
@@ -1,0 +1,27 @@
+# vLLM MOSS-VL Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for MOSS-VL.
+
+- Status: not supported on current mainline
+
+## Key Conclusions
+
+- No `moss` or `moss_vl` model module is present in current vLLM mainline.
+- Keep the family explicitly marked unsupported until that changes.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## Landed PRs
+
+- No landed PR is recorded in this dossier yet.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-moss-vl-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-moss-vl-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/moss-vl/README.zh.md
+++ b/model-pr-optimization-history/vllm/moss-vl/README.zh.md
@@ -1,0 +1,27 @@
+# vLLM MOSS-VL 支持与 PR 历史
+
+本文记录 vLLM 中与 MOSS-VL 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 不支持
+
+## 核心结论
+
+- No `moss` or `moss_vl` model module is present in current vLLM mainline.
+- Keep the family explicitly marked unsupported until that changes.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## 已合入 PR
+
+- 当前 dossier 中没有已记录的 merged PR。
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-moss-vl-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-moss-vl-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/nemotron-super/README.en.md
+++ b/model-pr-optimization-history/vllm/nemotron-super/README.en.md
@@ -1,0 +1,30 @@
+# vLLM Nemotron Super / Nano Hybrid Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and cookbook-facing touchpoints for Nemotron Super / Nano Hybrid.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- Nemotron is a hybrid family: attention, Mamba, MoE, MTP, and VL all intersect.
+- Because of that, graph execution, cache dtype, and quantized MoE correctness are the primary risk areas.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/nemotron_h.py`
+- `vllm/vllm/model_executor/models/nemotron_h_mtp.py`
+- `vllm/vllm/model_executor/models/nano_nemotron_vl.py`
+- `vllm/vllm/model_executor/models/nemotron_vl.py`
+
+## Landed PRs
+
+- [#18863](https://github.com/vllm-project/vllm/pull/18863) `NemotronH support`: Initial NemotronH landing in vLLM.
+- [#25863](https://github.com/vllm-project/vllm/pull/25863) `Add MoE support for NemotronH`: Extended the hybrid family to routed experts.
+- [#33726](https://github.com/vllm-project/vllm/pull/33726) `Nemotron-H MTP and Mamba Speculative Decoding Support`: Opened the MTP / spec-decode path.
+- [#36803](https://github.com/vllm-project/vllm/pull/36803) `E2E Nemotron-3-Super tests`: Added direct Super-family regression coverage.
+- [#37803](https://github.com/vllm-project/vllm/pull/37803) `Enable NemotronHPuzzle + NemotronHMTP`: Expanded hybrid and MTP coverage for the family.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-nemotron-super-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-nemotron-super-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/nemotron-super/README.zh.md
+++ b/model-pr-optimization-history/vllm/nemotron-super/README.zh.md
@@ -1,0 +1,30 @@
+# vLLM Nemotron Super / Nano Hybrid 支持与 PR 历史
+
+本文记录 vLLM 中与 Nemotron Super / Nano Hybrid 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Nemotron is a hybrid family: attention, Mamba, MoE, MTP, and VL all intersect.
+- Because of that, graph execution, cache dtype, and quantized MoE correctness are the primary risk areas.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/nemotron_h.py`
+- `vllm/vllm/model_executor/models/nemotron_h_mtp.py`
+- `vllm/vllm/model_executor/models/nano_nemotron_vl.py`
+- `vllm/vllm/model_executor/models/nemotron_vl.py`
+
+## 已合入 PR
+
+- [#18863](https://github.com/vllm-project/vllm/pull/18863) `NemotronH support`：Initial NemotronH landing in vLLM.
+- [#25863](https://github.com/vllm-project/vllm/pull/25863) `Add MoE support for NemotronH`：Extended the hybrid family to routed experts.
+- [#33726](https://github.com/vllm-project/vllm/pull/33726) `Nemotron-H MTP and Mamba Speculative Decoding Support`：Opened the MTP / spec-decode path.
+- [#36803](https://github.com/vllm-project/vllm/pull/36803) `E2E Nemotron-3-Super tests`：Added direct Super-family regression coverage.
+- [#37803](https://github.com/vllm-project/vllm/pull/37803) `Enable NemotronHPuzzle + NemotronHMTP`：Expanded hybrid and MTP coverage for the family.
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-nemotron-super-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-nemotron-super-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/qwen-image/README.en.md
+++ b/model-pr-optimization-history/vllm/qwen-image/README.en.md
@@ -1,0 +1,27 @@
+# vLLM Qwen-Image Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for Qwen-Image.
+
+- Status: not supported on current mainline
+
+## Key Conclusions
+
+- vLLM current mainline does not ship a Qwen-Image diffusion model runtime.
+- The family should stay marked unsupported rather than being backfilled from Qwen text/VL support.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## Landed PRs
+
+- No landed PR is recorded in this dossier yet.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-qwen-image-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-qwen-image-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/qwen-image/README.zh.md
+++ b/model-pr-optimization-history/vllm/qwen-image/README.zh.md
@@ -1,0 +1,27 @@
+# vLLM Qwen-Image 支持与 PR 历史
+
+本文记录 vLLM 中与 Qwen-Image 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 不支持
+
+## 核心结论
+
+- vLLM current mainline does not ship a Qwen-Image diffusion model runtime.
+- The family should stay marked unsupported rather than being backfilled from Qwen text/VL support.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## 已合入 PR
+
+- 当前 dossier 中没有已记录的 merged PR。
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-qwen-image-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-qwen-image-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/qwen-vlm-omni-asr/README.en.md
+++ b/model-pr-optimization-history/vllm/qwen-vlm-omni-asr/README.en.md
@@ -1,0 +1,60 @@
+# vLLM Qwen2.5-VL / Qwen3-VL / Qwen3-Omni / Qwen3-ASR Support and PR History
+
+This note tracks the multimodal Qwen family in vLLM at commit
+`0f7be0f2f76814f80f9091220a5fbbb53912ad00`.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- The family now spans Qwen2.5-VL, Qwen3-VL, Qwen3-VL-MoE, Qwen3-Omni thinker,
+  Qwen3-ASR, and realtime Qwen3-ASR.
+- The main risk areas are:
+  processor placeholder expansion, video timestamps, interleaved MRoPE,
+  `use_audio_in_video`, audio feature-length accounting, and realtime prompt
+  expansion.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/qwen2_5_vl.py`
+- `vllm/vllm/model_executor/models/qwen3_vl.py`
+- `vllm/vllm/model_executor/models/qwen3_vl_moe.py`
+- `vllm/vllm/model_executor/models/qwen3_omni_moe_thinker.py`
+- `vllm/vllm/model_executor/models/qwen3_asr.py`
+- `vllm/vllm/model_executor/models/qwen3_asr_realtime.py`
+- `vllm/vllm/model_executor/layers/rotary_embedding/mrope.py`
+
+## Landed PRs
+
+- [#13155](https://github.com/vllm-project/vllm/pull/13155)
+  `Qwen2.5-VL Optimization`
+  Diff reviewed: `2` files, `47` additions, `51` deletions.
+  Optimizes the Qwen2.5-VL vision attention fallback and switches to shared
+  `RMSNorm`.
+- [#24727](https://github.com/vllm-project/vllm/pull/24727)
+  `Support Qwen3-VL Model Series`
+  Diff reviewed: `13` files, `2084` additions, `17` deletions.
+  Lands native Qwen3-VL / Qwen3-VL-MoE plus video placeholders and processing.
+- [#25055](https://github.com/vllm-project/vllm/pull/25055)
+  `Add Triton kernel for Qwen3-VL interleaved MRoPE`
+  Diff reviewed: `2` files, `88` additions, `46` deletions.
+  Adds interleaved MRoPE support and test coverage for Qwen3-VL.
+- [#25550](https://github.com/vllm-project/vllm/pull/25550)
+  `Add Qwen3-Omni moe thinker`
+  Diff reviewed: `6` files, `1795` additions, `36` deletions.
+  Adds the thinker runtime and special `use_audio_in_video` placeholder logic.
+- [#33312](https://github.com/vllm-project/vllm/pull/33312)
+  `Qwen3-ASR`
+  Diff reviewed: `9` files, `1269` additions.
+  Adds Qwen3-ASR configs, processor, model, and transcription path.
+- [#34613](https://github.com/vllm-project/vllm/pull/34613)
+  `Add Qwen3-ASR realtime streaming support`
+  Diff reviewed: `5` files, `256` additions, `1` deletion.
+  Adds a dedicated realtime subclass, audio buffer, and prompt expansion logic.
+
+## Current Contract
+
+When this family breaks, look at the exact modality path first:
+Qwen2.5-VL attention fallback, Qwen3-VL video prompt replacement, Qwen3-Omni
+audio-in-video bookkeeping, or Qwen3-ASR prompt/audio length logic. These are
+the real fault lines.

--- a/model-pr-optimization-history/vllm/qwen-vlm-omni-asr/README.zh.md
+++ b/model-pr-optimization-history/vllm/qwen-vlm-omni-asr/README.zh.md
@@ -1,0 +1,58 @@
+# vLLM Qwen2.5-VL / Qwen3-VL / Qwen3-Omni / Qwen3-ASR 支持与 PR 历史
+
+本文记录 vLLM 在提交 `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+附近的多模态 Qwen 家族支持情况。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- 这条家族线已经覆盖 Qwen2.5-VL、Qwen3-VL、Qwen3-VL-MoE、
+  Qwen3-Omni thinker、Qwen3-ASR，以及 realtime Qwen3-ASR。
+- 真正高风险的地方主要在:
+  placeholder 展开、视频时间戳、interleaved MRoPE、
+  `use_audio_in_video`、音频特征长度换算，以及 realtime prompt 扩展。
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/qwen2_5_vl.py`
+- `vllm/vllm/model_executor/models/qwen3_vl.py`
+- `vllm/vllm/model_executor/models/qwen3_vl_moe.py`
+- `vllm/vllm/model_executor/models/qwen3_omni_moe_thinker.py`
+- `vllm/vllm/model_executor/models/qwen3_asr.py`
+- `vllm/vllm/model_executor/models/qwen3_asr_realtime.py`
+- `vllm/vllm/model_executor/layers/rotary_embedding/mrope.py`
+
+## 已合入 PR
+
+- [#13155](https://github.com/vllm-project/vllm/pull/13155)
+  `Qwen2.5-VL Optimization`
+  已审 diff: `2` 个文件，`47` 行新增，`51` 行删除。
+  主要优化 Qwen2.5-VL 的视觉注意力 fallback 路径，并切到共享 `RMSNorm`。
+- [#24727](https://github.com/vllm-project/vllm/pull/24727)
+  `Support Qwen3-VL Model Series`
+  已审 diff: `13` 个文件，`2084` 行新增，`17` 行删除。
+  这是 Qwen3-VL / Qwen3-VL-MoE 的主落地 PR，并补了视频 placeholder 和处理链。
+- [#25055](https://github.com/vllm-project/vllm/pull/25055)
+  `Add Triton kernel for Qwen3-VL interleaved MRoPE`
+  已审 diff: `2` 个文件，`88` 行新增，`46` 行删除。
+  它让 Qwen3-VL 的 interleaved MRoPE 真正成为受测的主路径。
+- [#25550](https://github.com/vllm-project/vllm/pull/25550)
+  `Add Qwen3-Omni moe thinker`
+  已审 diff: `6` 个文件，`1795` 行新增，`36` 行删除。
+  它加入 thinker 运行时，并单独处理 `use_audio_in_video` 的 placeholder 记账。
+- [#33312](https://github.com/vllm-project/vllm/pull/33312)
+  `Qwen3-ASR`
+  已审 diff: `9` 个文件，`1269` 行新增。
+  它补了 Qwen3-ASR 的 config、processor、模型和 transcription 路径。
+- [#34613](https://github.com/vllm-project/vllm/pull/34613)
+  `Add Qwen3-ASR realtime streaming support`
+  已审 diff: `5` 个文件，`256` 行新增，`1` 行删除。
+  它加入 realtime 子类、音频 buffer 和 prompt 扩展逻辑。
+
+## 当前结论
+
+这条家族线出问题时，不要笼统地说“多模态坏了”。要先定位是
+Qwen2.5-VL attention fallback、Qwen3-VL 视频 prompt replacement、
+Qwen3-Omni 的 audio-in-video 记账，还是 Qwen3-ASR 的
+prompt / audio length 逻辑出错。

--- a/model-pr-optimization-history/vllm/qwen3-coder/README.en.md
+++ b/model-pr-optimization-history/vllm/qwen3-coder/README.en.md
@@ -1,0 +1,32 @@
+# vLLM Qwen3 Coder Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for Qwen3 Coder.
+
+- Status: supported on current mainline
+- This family inherits the base runtime from `qwen3-core` and only records the delta here.
+
+## Key Conclusions
+
+- Qwen3 Coder inherits the base Qwen3 runtime and adds coder-specific tool parsing.
+- The main regressions are in JSON-schema edge cases, anyOf / oneOf handling, and Responses API tools.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/qwen3.py`
+- `vllm/vllm/entrypoints/openai/tool_parsers/`
+
+## Landed PRs
+
+- [#21396](https://github.com/vllm-project/vllm/pull/21396) `Add Qwen3CoderToolParser`: Created the dedicated coder-tool parser instead of reusing a generic Qwen parser.
+- [#36032](https://github.com/vllm-project/vllm/pull/36032) `Fix anyOf double encoded parameters`: Fixed a concrete schema serialization bug in coder tool calls.
+- [#37831](https://github.com/vllm-project/vllm/pull/37831) `Fix anyOf/oneOf type resolution for nullable params`: Improved nullable parameter handling in complex schemas.
+- [#38848](https://github.com/vllm-project/vllm/pull/38848) `Fix Qwen3 tool parser for Responses API tools`: Aligned the tool parser with the Responses API tool surface.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-qwen3-coder-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-qwen3-coder-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/qwen3-coder/README.zh.md
+++ b/model-pr-optimization-history/vllm/qwen3-coder/README.zh.md
@@ -1,0 +1,32 @@
+# vLLM Qwen3 Coder 支持与 PR 历史
+
+本文记录 vLLM 中与 Qwen3 Coder 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 已支持
+- 该家族继承 `qwen3-core` 的基础 runtime，这里只记录增量 PR。
+
+## 核心结论
+
+- Qwen3 Coder inherits the base Qwen3 runtime and adds coder-specific tool parsing.
+- The main regressions are in JSON-schema edge cases, anyOf / oneOf handling, and Responses API tools.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/qwen3.py`
+- `vllm/vllm/entrypoints/openai/tool_parsers/`
+
+## 已合入 PR
+
+- [#21396](https://github.com/vllm-project/vllm/pull/21396) `Add Qwen3CoderToolParser`：Created the dedicated coder-tool parser instead of reusing a generic Qwen parser.
+- [#36032](https://github.com/vllm-project/vllm/pull/36032) `Fix anyOf double encoded parameters`：Fixed a concrete schema serialization bug in coder tool calls.
+- [#37831](https://github.com/vllm-project/vllm/pull/37831) `Fix anyOf/oneOf type resolution for nullable params`：Improved nullable parameter handling in complex schemas.
+- [#38848](https://github.com/vllm-project/vllm/pull/38848) `Fix Qwen3 tool parser for Responses API tools`：Aligned the tool parser with the Responses API tool surface.
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-qwen3-coder-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-qwen3-coder-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/qwen3-core/README.en.md
+++ b/model-pr-optimization-history/vllm/qwen3-core/README.en.md
@@ -1,0 +1,35 @@
+# vLLM Qwen3 Core Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for Qwen3 Core.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- Qwen3 and Qwen3MoE are first-class mainline runtimes in vLLM.
+- The highest-risk regressions show up in quantized MoE weight loading, packed-module mappings, and embedding / reranker special cases.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/qwen3.py`
+- `vllm/vllm/model_executor/models/qwen3_moe.py`
+- `vllm/vllm/model_executor/models/voyage.py`
+
+## Landed PRs
+
+- [#15289](https://github.com/vllm-project/vllm/pull/15289) `Add Qwen3 and Qwen3MoE`: Initial Qwen3 dense and MoE support landed here.
+- [#19260](https://github.com/vllm-project/vllm/pull/19260) `Support Qwen3 Embedding & Reranker`: Extended the family to bidirectional embedding / reranker models.
+- [#19598](https://github.com/vllm-project/vllm/pull/19598) `Skip loading extra parameters for modelopt Qwen3 MoE model`: Fixed a concrete ModelOpt launch failure on Qwen3 MoE.
+- [#22017](https://github.com/vllm-project/vllm/pull/22017) `KeyError for Qwen3-MoE with GPTQ on ROCm`: Closed a GPTQ loading failure in the Qwen3 MoE path.
+- [#22785](https://github.com/vllm-project/vllm/pull/22785) `Fix GGUF loader for Qwen3 MoE`: Made the Qwen3 MoE loader accept GGUF weights again.
+- [#23490](https://github.com/vllm-project/vllm/pull/23490) `Fix Qwen3 MoE GPTQ inference`: Patched runtime correctness after GPTQ startup succeeded.
+- [#26485](https://github.com/vllm-project/vllm/pull/26485) `Add EAGLE-3 Speculative Decoding Support for Qwen3 MoE`: Enabled the draft-model path on top of the base Qwen3 MoE runtime.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-qwen3-core-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-qwen3-core-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/qwen3-core/README.zh.md
+++ b/model-pr-optimization-history/vllm/qwen3-core/README.zh.md
@@ -1,0 +1,35 @@
+# vLLM Qwen3 Core 支持与 PR 历史
+
+本文记录 vLLM 中与 Qwen3 Core 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Qwen3 and Qwen3MoE are first-class mainline runtimes in vLLM.
+- The highest-risk regressions show up in quantized MoE weight loading, packed-module mappings, and embedding / reranker special cases.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/qwen3.py`
+- `vllm/vllm/model_executor/models/qwen3_moe.py`
+- `vllm/vllm/model_executor/models/voyage.py`
+
+## 已合入 PR
+
+- [#15289](https://github.com/vllm-project/vllm/pull/15289) `Add Qwen3 and Qwen3MoE`：Initial Qwen3 dense and MoE support landed here.
+- [#19260](https://github.com/vllm-project/vllm/pull/19260) `Support Qwen3 Embedding & Reranker`：Extended the family to bidirectional embedding / reranker models.
+- [#19598](https://github.com/vllm-project/vllm/pull/19598) `Skip loading extra parameters for modelopt Qwen3 MoE model`：Fixed a concrete ModelOpt launch failure on Qwen3 MoE.
+- [#22017](https://github.com/vllm-project/vllm/pull/22017) `KeyError for Qwen3-MoE with GPTQ on ROCm`：Closed a GPTQ loading failure in the Qwen3 MoE path.
+- [#22785](https://github.com/vllm-project/vllm/pull/22785) `Fix GGUF loader for Qwen3 MoE`：Made the Qwen3 MoE loader accept GGUF weights again.
+- [#23490](https://github.com/vllm-project/vllm/pull/23490) `Fix Qwen3 MoE GPTQ inference`：Patched runtime correctness after GPTQ startup succeeded.
+- [#26485](https://github.com/vllm-project/vllm/pull/26485) `Add EAGLE-3 Speculative Decoding Support for Qwen3 MoE`：Enabled the draft-model path on top of the base Qwen3 MoE runtime.
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-qwen3-core-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-qwen3-core-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/qwen3-next/README.en.md
+++ b/model-pr-optimization-history/vllm/qwen3-next/README.en.md
@@ -1,0 +1,33 @@
+# vLLM Qwen3-Next Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for Qwen3-Next.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- Qwen3-Next is its own runtime family because of Gated DeltaNet attention and its MTP path.
+- The practical risks are PP, MTP varlen handling, quantized shared-expert naming, and GDN-specific CUDA graph bugs.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/qwen3_next.py`
+- `vllm/vllm/model_executor/models/qwen3_next_mtp.py`
+
+## Landed PRs
+
+- [#24709](https://github.com/vllm-project/vllm/pull/24709) `Fix Qwen3-Next PP`: Corrected pipeline-parallel execution on Qwen3-Next.
+- [#24957](https://github.com/vllm-project/vllm/pull/24957) `Fix the varlen issue in qwen3-next MTP implementation`: Removed a concrete MTP correctness bug on variable-length batches.
+- [#24960](https://github.com/vllm-project/vllm/pull/24960) `Add prefixes to shared_expert in qwen3-next`: Fixed ignored-parameter and quantized weight loading for shared experts.
+- [#25743](https://github.com/vllm-project/vllm/pull/25743) `Fix cuda graph capture bug in GDN metadata and a stride bug`: Stabilized GDN execution under CUDA graphs.
+- [#31722](https://github.com/vllm-project/vllm/pull/31722) `Speed-up of GDN attention decode part`: Improved decode throughput on the GDN attention path.
+- [#33657](https://github.com/vllm-project/vllm/pull/33657) `Initial support for GDN attention on Qwen3-next/Qwen3.5 (XPU)`: Extended the family beyond CUDA with XPU GDN coverage.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-qwen3-next-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-qwen3-next-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/qwen3-next/README.zh.md
+++ b/model-pr-optimization-history/vllm/qwen3-next/README.zh.md
@@ -1,0 +1,33 @@
+# vLLM Qwen3-Next 支持与 PR 历史
+
+本文记录 vLLM 中与 Qwen3-Next 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Qwen3-Next is its own runtime family because of Gated DeltaNet attention and its MTP path.
+- The practical risks are PP, MTP varlen handling, quantized shared-expert naming, and GDN-specific CUDA graph bugs.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/qwen3_next.py`
+- `vllm/vllm/model_executor/models/qwen3_next_mtp.py`
+
+## 已合入 PR
+
+- [#24709](https://github.com/vllm-project/vllm/pull/24709) `Fix Qwen3-Next PP`：Corrected pipeline-parallel execution on Qwen3-Next.
+- [#24957](https://github.com/vllm-project/vllm/pull/24957) `Fix the varlen issue in qwen3-next MTP implementation`：Removed a concrete MTP correctness bug on variable-length batches.
+- [#24960](https://github.com/vllm-project/vllm/pull/24960) `Add prefixes to shared_expert in qwen3-next`：Fixed ignored-parameter and quantized weight loading for shared experts.
+- [#25743](https://github.com/vllm-project/vllm/pull/25743) `Fix cuda graph capture bug in GDN metadata and a stride bug`：Stabilized GDN execution under CUDA graphs.
+- [#31722](https://github.com/vllm-project/vllm/pull/31722) `Speed-up of GDN attention decode part`：Improved decode throughput on the GDN attention path.
+- [#33657](https://github.com/vllm-project/vllm/pull/33657) `Initial support for GDN attention on Qwen3-next/Qwen3.5 (XPU)`：Extended the family beyond CUDA with XPU GDN coverage.
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-qwen3-next-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-qwen3-next-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/qwen35/README.en.md
+++ b/model-pr-optimization-history/vllm/qwen35/README.en.md
@@ -1,0 +1,33 @@
+# vLLM Qwen3.5 Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for Qwen3.5.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- Qwen3.5 builds on the Qwen3-Next era work but has its own model registration and quantization details.
+- The hot spots are GDN fusion, FP8/NVFP4 loading, LoRA target naming, and MoE EP precision.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/qwen3_5.py`
+- `vllm/vllm/model_executor/models/qwen3_5_mtp.py`
+
+## Landed PRs
+
+- [#34110](https://github.com/vllm-project/vllm/pull/34110) `Adding Support for Qwen3.5 Models`: Landed the Qwen3.5 runtime family.
+- [#34697](https://github.com/vllm-project/vllm/pull/34697) `Redo Qwen3.5/Qwen3-Next GDN projector fusion`: Reworked an earlier fusion that had to be reverted.
+- [#35289](https://github.com/vllm-project/vllm/pull/35289) `Fix Qwen3.5 FP8 quantization tuple shard_id weight loading`: Closed a concrete FP8 weight-loading failure.
+- [#36658](https://github.com/vllm-project/vllm/pull/36658) `Add Eagle3 support for Qwen3.5`: Enabled the draft-model fast path.
+- [#37975](https://github.com/vllm-project/vllm/pull/37975) `Extract GatedDeltaNetAttention into shared layer for Qwen3Next and Qwen3.5`: Reduced duplicated GDN logic across related families.
+- [#39181](https://github.com/vllm-project/vllm/pull/39181) `Fix EP precision for Qwen3.5, Qwen3-Next`: Patched a serving-precision bug under expert parallelism.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-qwen35-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-qwen35-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/qwen35/README.zh.md
+++ b/model-pr-optimization-history/vllm/qwen35/README.zh.md
@@ -1,0 +1,33 @@
+# vLLM Qwen3.5 支持与 PR 历史
+
+本文记录 vLLM 中与 Qwen3.5 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Qwen3.5 builds on the Qwen3-Next era work but has its own model registration and quantization details.
+- The hot spots are GDN fusion, FP8/NVFP4 loading, LoRA target naming, and MoE EP precision.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/qwen3_5.py`
+- `vllm/vllm/model_executor/models/qwen3_5_mtp.py`
+
+## 已合入 PR
+
+- [#34110](https://github.com/vllm-project/vllm/pull/34110) `Adding Support for Qwen3.5 Models`：Landed the Qwen3.5 runtime family.
+- [#34697](https://github.com/vllm-project/vllm/pull/34697) `Redo Qwen3.5/Qwen3-Next GDN projector fusion`：Reworked an earlier fusion that had to be reverted.
+- [#35289](https://github.com/vllm-project/vllm/pull/35289) `Fix Qwen3.5 FP8 quantization tuple shard_id weight loading`：Closed a concrete FP8 weight-loading failure.
+- [#36658](https://github.com/vllm-project/vllm/pull/36658) `Add Eagle3 support for Qwen3.5`：Enabled the draft-model fast path.
+- [#37975](https://github.com/vllm-project/vllm/pull/37975) `Extract GatedDeltaNetAttention into shared layer for Qwen3Next and Qwen3.5`：Reduced duplicated GDN logic across related families.
+- [#39181](https://github.com/vllm-project/vllm/pull/39181) `Fix EP precision for Qwen3.5, Qwen3-Next`：Patched a serving-precision bug under expert parallelism.
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-qwen35-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-qwen35-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/qwen36/README.en.md
+++ b/model-pr-optimization-history/vllm/qwen36/README.en.md
@@ -1,0 +1,27 @@
+# vLLM Qwen3.6 Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for Qwen3.6.
+
+- Status: not supported on current mainline
+
+## Key Conclusions
+
+- Qwen3.6 should not be treated as automatically covered just because Qwen3 / Qwen3.5 are supported.
+- At the current checked commit, there is no dedicated `Qwen3.6` model module or registry alias.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## Landed PRs
+
+- No landed PR is recorded in this dossier yet.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-qwen36-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-qwen36-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/qwen36/README.zh.md
+++ b/model-pr-optimization-history/vllm/qwen36/README.zh.md
@@ -1,0 +1,27 @@
+# vLLM Qwen3.6 支持与 PR 历史
+
+本文记录 vLLM 中与 Qwen3.6 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 不支持
+
+## 核心结论
+
+- Qwen3.6 should not be treated as automatically covered just because Qwen3 / Qwen3.5 are supported.
+- At the current checked commit, there is no dedicated `Qwen3.6` model module or registry alias.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## 已合入 PR
+
+- 当前 dossier 中没有已记录的 merged PR。
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-qwen36-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-qwen36-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/step35/README.en.md
+++ b/model-pr-optimization-history/vllm/step35/README.en.md
@@ -1,0 +1,28 @@
+# vLLM Step3.5 / Step3-VL Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and cookbook-facing touchpoints for Step3.5 / Step3-VL.
+
+- Status: supported on current mainline
+
+## Key Conclusions
+
+- Step3.5 is split between text/MTP and VL processor work.
+- NVFP4 and processor behavior are the main axes to track on the vLLM side.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/step3p5.py`
+- `vllm/vllm/model_executor/models/step3p5_mtp.py`
+- `vllm/vllm/model_executor/models/step3_vl.py`
+- `vllm/vllm/model_executor/models/step3_text.py`
+
+## Landed PRs
+
+- [#33755](https://github.com/vllm-project/vllm/pull/33755) `Enable Step3p5ForCausalLM testing`: Stabilized the core Step3.5 text runtime.
+- [#34478](https://github.com/vllm-project/vllm/pull/34478) `Add NVFP4 quantization support for Step3.5-Flash`: Opened the practical quantized deployment path.
+- [#37579](https://github.com/vllm-project/vllm/pull/37579) `Refactor Step3-VL processor to HF style`: Modernized the Step3-VL processor contract.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-step35-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-step35-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/step35/README.zh.md
+++ b/model-pr-optimization-history/vllm/step35/README.zh.md
@@ -1,0 +1,28 @@
+# vLLM Step3.5 / Step3-VL 支持与 PR 历史
+
+本文记录 vLLM 中与 Step3.5 / Step3-VL 相关的模型支持、关键 PR、以及 cookbook 对应的落点。
+
+- 状态: 当前 mainline 已支持
+
+## 核心结论
+
+- Step3.5 is split between text/MTP and VL processor work.
+- NVFP4 and processor behavior are the main axes to track on the vLLM side.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/step3p5.py`
+- `vllm/vllm/model_executor/models/step3p5_mtp.py`
+- `vllm/vllm/model_executor/models/step3_vl.py`
+- `vllm/vllm/model_executor/models/step3_text.py`
+
+## 已合入 PR
+
+- [#33755](https://github.com/vllm-project/vllm/pull/33755) `Enable Step3p5ForCausalLM testing`：Stabilized the core Step3.5 text runtime.
+- [#34478](https://github.com/vllm-project/vllm/pull/34478) `Add NVFP4 quantization support for Step3.5-Flash`：Opened the practical quantized deployment path.
+- [#37579](https://github.com/vllm-project/vllm/pull/37579) `Refactor Step3-VL processor to HF style`：Modernized the Step3-VL processor contract.
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-step35-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-step35-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/z-image-turbo/README.en.md
+++ b/model-pr-optimization-history/vllm/z-image-turbo/README.en.md
@@ -1,0 +1,27 @@
+# vLLM Z-Image-Turbo Support and PR History
+
+This note tracks the vLLM runtime, key PRs, and remaining risk areas for Z-Image-Turbo.
+
+- Status: not supported on current mainline
+
+## Key Conclusions
+
+- vLLM current mainline does not ship a Z-Image diffusion runtime.
+- Keep the family explicitly unsupported instead of inferring support from generic multimodal work.
+
+## Main Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## Landed PRs
+
+- No landed PR is recorded in this dossier yet.
+
+## Open PR Radar
+
+- No pinned open PR here; re-run PR search before claiming new support.
+
+## Matching Skill
+
+- `skills/model-optimization/vllm/vllm-z-image-turbo-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-z-image-turbo-optimization/references/pr-history.md`

--- a/model-pr-optimization-history/vllm/z-image-turbo/README.zh.md
+++ b/model-pr-optimization-history/vllm/z-image-turbo/README.zh.md
@@ -1,0 +1,27 @@
+# vLLM Z-Image-Turbo 支持与 PR 历史
+
+本文记录 vLLM 中与 Z-Image-Turbo 相关的模型支持、关键 PR、以及仍需持续跟踪的风险点。
+
+- 状态: 当前 mainline 不支持
+
+## 核心结论
+
+- vLLM current mainline does not ship a Z-Image diffusion runtime.
+- Keep the family explicitly unsupported instead of inferring support from generic multimodal work.
+
+## 主要代码面
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## 已合入 PR
+
+- 当前 dossier 中没有已记录的 merged PR。
+
+## Open PR 雷达
+
+- 暂无固定 open PR；需要在声称新支持前重新搜索。
+
+## 配套 skill
+
+- `skills/model-optimization/vllm/vllm-z-image-turbo-optimization/SKILL.md`
+- `skills/model-optimization/vllm/vllm-z-image-turbo-optimization/references/pr-history.md`

--- a/skills/model-optimization/README.md
+++ b/skills/model-optimization/README.md
@@ -4,6 +4,6 @@ This directory stores model-family optimization skills by serving framework.
 
 - `model-pr-diff-dossier/`: shared production standard for manual, diff-backed model PR histories across SGLang, vLLM, and future serving frameworks.
 - `sglang/`: SGLang model optimization skills.
-- `vllm/`: reserved for future vLLM model optimization skills.
+- `vllm/`: vLLM model optimization skills.
 
 Every model optimization skill that cites PR history must follow the same rule: read the source diff for each PR and document motivation, implementation, key code excerpt, and validation/risk.

--- a/skills/model-optimization/sglang/README.md
+++ b/skills/model-optimization/sglang/README.md
@@ -1,30 +1,36 @@
 # SGLang Model Optimization Skills
 
-SGLang model optimization skills live here, grouped by model family and generation. The skill name in each `SKILL.md` front matter remains stable even though the directory is framework-scoped.
-
-The shared production standard is `../model-pr-diff-dossier`: every model PR history must be based on per-PR source-diff reading and must include motivation, implementation detail, key code excerpt, and validation/risk.
-
 Current SGLang model skills:
 
 - `sglang-deepseek-v3-r1-optimization`
 - `sglang-deepseek-v31-optimization`
 - `sglang-deepseek-v32-optimization`
 - `sglang-deepseek-v4-optimization`
+- `sglang-glm-vlm-ocr-optimization`
+- `sglang-glm45-optimization`
+- `sglang-glm46-glm47-optimization`
+- `sglang-glm5-glm51-optimization`
 - `sglang-hunyuan3-preview-optimization`
-- `sglang-kimi-k2-k25-optimization`
+- `sglang-kimi-optimization`
 - `sglang-ltx23-hq-optimization`
-- `sglang-minimax-m2-series-optimization`
+- `sglang-minimax-optimization`
 - `sglang-mixtral-quark-int4fp8-moe-optimization`
 - `sglang-moss-vl-optimization`
+- `sglang-qwen-image-optimization`
+- `sglang-qwen-vlm-omni-asr-optimization`
+- `sglang-qwen3-coder-optimization`
 - `sglang-qwen3-core-optimization`
 - `sglang-qwen3-next-optimization`
 - `sglang-qwen35-optimization`
 - `sglang-qwen36-optimization`
-- `sglang-qwen3-coder-optimization`
-- `sglang-qwen-vlm-omni-asr-optimization`
-- `sglang-qwen-image-optimization`
 - `sglang-z-image-turbo-optimization`
-- `sglang-glm45-optimization`
-- `sglang-glm46-glm47-optimization`
-- `sglang-glm5-glm51-optimization`
-- `sglang-glm-vlm-ocr-optimization`
+- `sglang-ernie45-optimization`
+- `sglang-gemma4-optimization`
+- `sglang-gpt-oss-optimization`
+- `sglang-intern-s1-optimization`
+- `sglang-internvl35-optimization`
+- `sglang-llama4-optimization`
+- `sglang-mimo-v2-flash-optimization`
+- `sglang-mistral-small-4-optimization`
+- `sglang-nemotron-super-optimization`
+- `sglang-step35-optimization`

--- a/skills/model-optimization/sglang/sglang-ernie45-optimization/SKILL.md
+++ b/skills/model-optimization/sglang/sglang-ernie45-optimization/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: sglang-ernie45-optimization
+description: PR-backed optimization manual for Ernie4.5 / Ernie4.5-VL in SGLang. Use when Codex needs to audit, debug, extend, or document the SGLang Ernie4.5 multimodal runtime, especially the initial VL landing, fused Triton rotary path, and later cos/sin cache rewrite for Ernie4.5-VL.
+---
+
+# SGLang Ernie4.5 / Ernie4.5-VL Optimization
+
+## Overview
+
+Ernie4.5 is already supported on the checked SGLang mainline. The high-signal
+changes for this family are the initial VL bring-up, then two successive rotary
+embedding optimizations for the vision tower.
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors:
+  `model-pr-optimization-history/sglang/ernie45/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the bar.
+For Ernie4.5-VL, name the exact rotary path being changed:
+original rotary embedding, fused Triton rope, or cached cos/sin route.
+
+## Runtime Surfaces
+
+- `sglang/python/sglang/srt/configs/model_config.py`
+- `sglang/python/sglang/srt/models/ernie45_vl.py`
+- `sglang/python/sglang/srt/models/ernie45_moe_vl.py`
+- `sglang/python/sglang/srt/multimodal/processors/ernie45_vl.py`
+- `sglang/python/sglang/srt/layers/rotary_embedding.py`
+
+## Current Main Summary
+
+- `#15679` lands the Ernie4.5-VL and Ernie4.5-MoE-VL runtime plus the multimodal
+  processor and model-config registration.
+- `#18856` adds a fused Triton Q/K rope kernel tailored to Ernie4.5-VL's
+  `(h, w, t)` layout.
+- `#19743` rewrites the vision tower to use `get_rope(...).get_cos_sin(...)`
+  instead of recomputing rotary embeddings for every call.
+
+## Key Landed PRs
+
+- [#15679](https://github.com/sgl-project/sglang/pull/15679) `Add Ernie4.5 VL model support`
+- [#18856](https://github.com/sgl-project/sglang/pull/18856) `Optimize Ernie4.5-VL rotary embedding with fused triton kernel`
+- [#19743](https://github.com/sgl-project/sglang/pull/19743) `Support cos sin cache for Ernie4.5-VL`
+
+## Validation Lanes
+
+- Ernie4.5-VL startup and processor/token expansion.
+- Vision-tower rotary correctness under both the fused kernel and cached cos/sin
+  path.
+- Long-input and multi-image / video cases that stress `grid_thw` and rotary
+  indexing.
+
+## References
+
+- `references/pr-history.md`: diff-reviewed Ernie4.5 cards.

--- a/skills/model-optimization/sglang/sglang-ernie45-optimization/references/pr-history.md
+++ b/skills/model-optimization/sglang/sglang-ernie45-optimization/references/pr-history.md
@@ -1,0 +1,124 @@
+# SGLang Ernie4.5 / Ernie4.5-VL PR History
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Scope: Ernie4.5-VL landing and rotary hot-path optimization
+
+## Landed PRs
+
+### PR #15679 - Add Ernie4.5 VL model support
+
+- Link: https://github.com/sgl-project/sglang/pull/15679
+- State: merged
+- Diff coverage: full diff reviewed, `6` files, `2072` additions
+- Motivation:
+  - SGLang needed native Ernie4.5-VL and Ernie4.5-MoE-VL support rather than
+    routing the family through an adjacent vision-language model.
+- Key implementation:
+  - Registers `Ernie4_5_VLMoeForConditionalGeneration` as multimodal.
+  - Adds `ernie45_vl.py`, `ernie45_moe_vl.py`, and the matching multimodal
+    processor.
+  - Builds a dedicated vision stack with `VisionAttention`,
+    variable-resolution resampling, and Ernie4.5-specific multimodal embedding
+    plumbing.
+- Key code excerpts:
+
+```diff
++    "Ernie4_5_VLMoeForConditionalGeneration",
+```
+
+```diff
++from sglang.srt.models.ernie45_moe_vl import Ernie4_5_VLMoeModel
++from sglang.srt.utils.hf_transformers_utils import get_processor
+...
++class Ernie4_5_VisionBlock(nn.Module):
++    self.attn = VisionAttention(... use_qkv_parallel=True, flatten_batch=True, ...)
+```
+
+- Reviewed files:
+  - config: `python/sglang/srt/configs/model_config.py`
+  - runtime: `python/sglang/srt/models/ernie45_vl.py`,
+    `python/sglang/srt/models/ernie45_moe_vl.py`
+  - processor:
+    `python/sglang/srt/multimodal/processors/ernie45_vl.py`
+- Validation implications:
+  - Ernie4.5-VL bugs can come from the processor or the vision resampler, not
+    only from the text model.
+
+### PR #18856 - Optimize Ernie4.5-VL rotary embedding with fused triton kernel
+
+- Link: https://github.com/sgl-project/sglang/pull/18856
+- State: merged
+- Diff coverage: full diff reviewed, `1` file, `268` additions, `3` deletions
+- Motivation:
+  - The original Ernie4.5-VL rotary path was expensive for the vision tower and
+    repeatedly transformed Q/K in a generic way instead of fusing the layout.
+- Key implementation:
+  - Adds `_triton_ernie45_rope_qk_fused` and
+    `triton_ernie45_rope_fused_inplace(...)`.
+  - Encodes Ernie4.5's `(h, w, t)` layout selection directly in the kernel.
+  - Extends `Ernie4_5_VLRotaryEmbedding` around the fused path.
+- Key code excerpts:
+
+```diff
++@triton.jit
++def _triton_ernie45_rope_qk_fused(
++    q_ptr,
++    k_ptr,
++    cos_sin_cache_ptr,
++    positions_ptr,  # [3, num_tokens]  (t/h/w)
++    ...
++):
+```
+
+```diff
++    section_h, section_w, section_t = mrope_section
++    assert section_h == section_w, "Ernie4.5 layout assumes section_h == section_w"
+```
+
+- Reviewed files:
+  - runtime/kernel wrapper: `python/sglang/srt/layers/rotary_embedding.py`
+- Validation implications:
+  - If Ernie4.5-VL outputs drift only after rotary or Triton changes, inspect
+    the fused rope path before changing higher-level model code.
+
+### PR #19743 - Support cos sin cache for Ernie4.5-VL
+
+- Link: https://github.com/sgl-project/sglang/pull/19743
+- State: merged
+- Diff coverage: full diff reviewed, `1` file, `34` additions, `12` deletions
+- Motivation:
+  - After the fused rotary kernel landed, the remaining waste was repeated
+    rotary cache computation in the Ernie4.5-VL vision tower.
+- Key implementation:
+  - Replaces the custom rotary object with `get_rope(...)`.
+  - Fetches `cos` and `sin` via `get_cos_sin(max_grid_size)`.
+  - Threads `rotary_pos_emb_cos` and `rotary_pos_emb_sin` through the vision
+    blocks instead of passing a prebuilt combined embedding tensor.
+- Key code excerpts:
+
+```diff
++from sglang.srt.layers.rotary_embedding import get_rope
+...
++        self.rotary_pos_emb = get_rope(
++            head_size=head_dim,
++            rotary_dim=head_dim // 2,
++            max_position=8192,
++            base=10000.0,
++            is_neox_style=True,
++        )
+```
+
+```diff
++        cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)
++        cos_combined = cos[pos_ids].flatten(1)
++        sin_combined = sin[pos_ids].flatten(1)
+```
+
+- Reviewed files:
+  - runtime: `python/sglang/srt/models/ernie45_vl.py`
+- Validation implications:
+  - If Ernie4.5-VL regresses after rope cache refactors, verify the
+    `grid_thw -> pos_ids -> cos/sin` mapping, not only the attention call site.

--- a/skills/model-optimization/sglang/sglang-gemma4-optimization/SKILL.md
+++ b/skills/model-optimization/sglang/sglang-gemma4-optimization/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: sglang-gemma4-optimization
+description: PR-backed optimization manual for Gemma 4 in SGLang. Use when Codex needs to audit, debug, extend, or document Gemma 4 text, MoE, multimodal, reasoning, tool use, and quantized MoE serving.
+---
+
+# SGLang Gemma 4 Optimization
+
+## Overview
+
+This skill covers Gemma 4 text, MoE, multimodal, reasoning, tool use, and quantized MoE serving.
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/sglang/gemma4/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/gemma4_causal.py`
+- `sglang/python/sglang/srt/models/gemma4_mm.py`
+- `sglang/python/sglang/srt/models/gemma4_vision.py`
+- `sglang/python/sglang/srt/models/gemma4_audio.py`
+
+## Current Main Summary
+
+- Gemma 4 is a genuinely multi-surface family: text, MoE, multimodal, tool calling, and speculative decoding all matter.
+- Fast prefill, quantized MoE, and tool-parser correctness are the main areas that changed rapidly after bring-up.
+
+## Key Landed PRs
+
+- [#21952](https://github.com/sgl-project/sglang/pull/21952) `New Model: Gemma 4`: Initial Gemma 4 support in SGLang.
+- [#22079](https://github.com/sgl-project/sglang/pull/22079) `Gemma4 nvfp4 fix`: Fixed the NVFP4 launch path.
+- [#22408](https://github.com/sgl-project/sglang/pull/22408) `Adding Gemma 4 to Nightly CI`: Added model-family regression coverage.
+
+## Validation Lanes
+
+- Startup on the cookbook checkpoint or example route.
+- Re-run the parser, quantization, or multimodal lane that matches this family.
+- Re-check registered or manual tests after touching loader or processor code.

--- a/skills/model-optimization/sglang/sglang-gemma4-optimization/references/pr-history.md
+++ b/skills/model-optimization/sglang/sglang-gemma4-optimization/references/pr-history.md
@@ -1,0 +1,30 @@
+# SGLang Gemma 4 PR History
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Scope: Gemma 4 text, MoE, multimodal, reasoning, tool use, and quantized MoE serving.
+
+## Landed PRs
+
+### PR #21952 - New Model: Gemma 4
+
+- Link: https://github.com/sgl-project/sglang/pull/21952
+- Why it mattered: Initial Gemma 4 support in SGLang.
+- Runtime path: sglang/python/sglang/srt/models/gemma4_causal.py, sglang/python/sglang/srt/models/gemma4_mm.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #22079 - Gemma4 nvfp4 fix
+
+- Link: https://github.com/sgl-project/sglang/pull/22079
+- Why it mattered: Fixed the NVFP4 launch path.
+- Runtime path: sglang/python/sglang/srt/models/gemma4_causal.py, sglang/python/sglang/srt/models/gemma4_mm.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #22408 - Adding Gemma 4 to Nightly CI
+
+- Link: https://github.com/sgl-project/sglang/pull/22408
+- Why it mattered: Added model-family regression coverage.
+- Runtime path: sglang/python/sglang/srt/models/gemma4_causal.py, sglang/python/sglang/srt/models/gemma4_mm.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/sglang/sglang-gpt-oss-optimization/SKILL.md
+++ b/skills/model-optimization/sglang/sglang-gpt-oss-optimization/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: sglang-gpt-oss-optimization
+description: PR-backed optimization manual for GPT-OSS in SGLang. Use when Codex needs to audit, debug, extend, or document OpenAI GPT-OSS MoE, MXFP4/FP8 quantization, DP/EP, reasoning parser, tool calling, and Eagle/spec decode.
+---
+
+# SGLang GPT-OSS Optimization
+
+## Overview
+
+This skill covers OpenAI GPT-OSS MoE, MXFP4/FP8 quantization, DP/EP, reasoning parser, tool calling, and Eagle/spec decode.
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/sglang/gpt-oss/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/gpt_oss.py`
+
+## Current Main Summary
+
+- GPT-OSS is a flagship MoE family in SGLang.
+- Quantization, expert-parallel topology, and reasoning/tool parser behavior all evolved quickly and need per-PR tracking.
+
+## Key Landed PRs
+
+- [#8843](https://github.com/sgl-project/sglang/pull/8843) `Support mxfp4 for GPT-OSS`: Added the headline quantized checkpoint path.
+- [#8944](https://github.com/sgl-project/sglang/pull/8944) `Expert Parallelism for GPT-OSS`: Scaled GPT-OSS beyond pure tensor parallel.
+- [#9043](https://github.com/sgl-project/sglang/pull/9043) `Implement Native GPT-OSS Tool Call Support`: Added native tool parser support instead of Harmony integration.
+- [#9359](https://github.com/sgl-project/sglang/pull/9359) `Support DP attention with GPT-OSS`: Enabled larger topologies via DP attention.
+- [#14920](https://github.com/sgl-project/sglang/pull/14920) `GPT-OSS Eagle v2 support`: Added speculative decoding support.
+- [#18988](https://github.com/sgl-project/sglang/pull/18988) `Support fp8 online quantization for gpt-oss bf16`: Extended quantization coverage to online FP8.
+
+## Validation Lanes
+
+- Startup on the cookbook checkpoint or example route.
+- Re-run the parser, quantization, or multimodal lane that matches this family.
+- Re-check registered or manual tests after touching loader or processor code.

--- a/skills/model-optimization/sglang/sglang-gpt-oss-optimization/references/pr-history.md
+++ b/skills/model-optimization/sglang/sglang-gpt-oss-optimization/references/pr-history.md
@@ -1,0 +1,51 @@
+# SGLang GPT-OSS PR History
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Scope: OpenAI GPT-OSS MoE, MXFP4/FP8 quantization, DP/EP, reasoning parser, tool calling, and Eagle/spec decode.
+
+## Landed PRs
+
+### PR #8843 - Support mxfp4 for GPT-OSS
+
+- Link: https://github.com/sgl-project/sglang/pull/8843
+- Why it mattered: Added the headline quantized checkpoint path.
+- Runtime path: sglang/python/sglang/srt/models/gpt_oss.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #8944 - Expert Parallelism for GPT-OSS
+
+- Link: https://github.com/sgl-project/sglang/pull/8944
+- Why it mattered: Scaled GPT-OSS beyond pure tensor parallel.
+- Runtime path: sglang/python/sglang/srt/models/gpt_oss.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #9043 - Implement Native GPT-OSS Tool Call Support
+
+- Link: https://github.com/sgl-project/sglang/pull/9043
+- Why it mattered: Added native tool parser support instead of Harmony integration.
+- Runtime path: sglang/python/sglang/srt/models/gpt_oss.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #9359 - Support DP attention with GPT-OSS
+
+- Link: https://github.com/sgl-project/sglang/pull/9359
+- Why it mattered: Enabled larger topologies via DP attention.
+- Runtime path: sglang/python/sglang/srt/models/gpt_oss.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #14920 - GPT-OSS Eagle v2 support
+
+- Link: https://github.com/sgl-project/sglang/pull/14920
+- Why it mattered: Added speculative decoding support.
+- Runtime path: sglang/python/sglang/srt/models/gpt_oss.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #18988 - Support fp8 online quantization for gpt-oss bf16
+
+- Link: https://github.com/sgl-project/sglang/pull/18988
+- Why it mattered: Extended quantization coverage to online FP8.
+- Runtime path: sglang/python/sglang/srt/models/gpt_oss.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/sglang/sglang-intern-s1-optimization/SKILL.md
+++ b/skills/model-optimization/sglang/sglang-intern-s1-optimization/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: sglang-intern-s1-optimization
+description: PR-backed optimization manual for Intern-S1 in SGLang. Use when Codex needs to audit, debug, extend, or document Intern-S1 language and video-aware serving, processor integration, and tool/reasoning parser behavior.
+---
+
+# SGLang Intern-S1 Optimization
+
+## Overview
+
+This skill covers Intern-S1 language and video-aware serving, processor integration, and tool/reasoning parser behavior.
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/sglang/intern-s1/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/interns1.py`
+- `sglang/python/sglang/srt/models/internvl.py`
+
+## Current Main Summary
+
+- Intern-S1 leans heavily on shared InternVL processor code in SGLang.
+- Most regressions come from processor compatibility, parser behavior, and video-aware serving rather than the text stack alone.
+
+## Key Landed PRs
+
+- [#9381](https://github.com/sgl-project/sglang/pull/9381) `InternS1 image token updates in InternVL processor`: Aligned the shared processor with Intern-S1 image semantics.
+- [#12367](https://github.com/sgl-project/sglang/pull/12367) `Fix Intern-S1 accuracy and `/generate` input_ids support`: Closed early correctness gaps.
+- [#14866](https://github.com/sgl-project/sglang/pull/14866) `Add tool calling and reasoning parser support for Intern-S1`: Added parser support that cookbook usage depends on.
+- [#17040](https://github.com/sgl-project/sglang/pull/17040) `Support InternS1 text_config in InternVL processor`: Improved sub-config compatibility in shared processors.
+
+## Validation Lanes
+
+- Startup on the cookbook checkpoint or example route.
+- Re-run the parser, quantization, or multimodal lane that matches this family.
+- Re-check registered or manual tests after touching loader or processor code.

--- a/skills/model-optimization/sglang/sglang-intern-s1-optimization/references/pr-history.md
+++ b/skills/model-optimization/sglang/sglang-intern-s1-optimization/references/pr-history.md
@@ -1,0 +1,37 @@
+# SGLang Intern-S1 PR History
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Scope: Intern-S1 language and video-aware serving, processor integration, and tool/reasoning parser behavior.
+
+## Landed PRs
+
+### PR #9381 - InternS1 image token updates in InternVL processor
+
+- Link: https://github.com/sgl-project/sglang/pull/9381
+- Why it mattered: Aligned the shared processor with Intern-S1 image semantics.
+- Runtime path: sglang/python/sglang/srt/models/interns1.py, sglang/python/sglang/srt/models/internvl.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #12367 - Fix Intern-S1 accuracy and `/generate` input_ids support
+
+- Link: https://github.com/sgl-project/sglang/pull/12367
+- Why it mattered: Closed early correctness gaps.
+- Runtime path: sglang/python/sglang/srt/models/interns1.py, sglang/python/sglang/srt/models/internvl.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #14866 - Add tool calling and reasoning parser support for Intern-S1
+
+- Link: https://github.com/sgl-project/sglang/pull/14866
+- Why it mattered: Added parser support that cookbook usage depends on.
+- Runtime path: sglang/python/sglang/srt/models/interns1.py, sglang/python/sglang/srt/models/internvl.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #17040 - Support InternS1 text_config in InternVL processor
+
+- Link: https://github.com/sgl-project/sglang/pull/17040
+- Why it mattered: Improved sub-config compatibility in shared processors.
+- Runtime path: sglang/python/sglang/srt/models/interns1.py, sglang/python/sglang/srt/models/internvl.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/sglang/sglang-internvl35-optimization/SKILL.md
+++ b/skills/model-optimization/sglang/sglang-internvl35-optimization/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: sglang-internvl35-optimization
+description: PR-backed optimization manual for InternVL3.5 in SGLang. Use when Codex needs to audit, debug, extend, or document InternVL3.5 multimodal processor, video support, ViT DP / CUDA graph, and non-CUDA backend compatibility.
+---
+
+# SGLang InternVL3.5 Optimization
+
+## Overview
+
+This skill covers InternVL3.5 multimodal processor, video support, ViT DP / CUDA graph, and non-CUDA backend compatibility.
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/sglang/internvl35/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/internvl.py`
+
+## Current Main Summary
+
+- InternVL3.5 is mostly a processor / encoder / video problem in SGLang.
+- Video handling, data-parallel vision execution, and backend compatibility dominate the risk surface.
+
+## Key Landed PRs
+
+- [#5350](https://github.com/sgl-project/sglang/pull/5350) `Support InternVL3`: Initial InternVL family support that later carried 3.5.
+- [#13640](https://github.com/sgl-project/sglang/pull/13640) `Support Piecewise CUDA Graph for InternVL`: Added graph capture support on the encoder path.
+- [#13925](https://github.com/sgl-project/sglang/pull/13925) `Support InternVL Vision Encoder Data Parallelism`: Opened the multi-GPU ViT path.
+- [#15942](https://github.com/sgl-project/sglang/pull/15942) `Support Video for InternVL3_5`: Extended support to 3.5 video use cases.
+- [#19127](https://github.com/sgl-project/sglang/pull/19127) `Support processor and embedding inputs for InternVL`: Hardened processor / embed input interoperability.
+
+## Validation Lanes
+
+- Startup on the cookbook checkpoint or example route.
+- Re-run the parser, quantization, or multimodal lane that matches this family.
+- Re-check registered or manual tests after touching loader or processor code.

--- a/skills/model-optimization/sglang/sglang-internvl35-optimization/references/pr-history.md
+++ b/skills/model-optimization/sglang/sglang-internvl35-optimization/references/pr-history.md
@@ -1,0 +1,44 @@
+# SGLang InternVL3.5 PR History
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Scope: InternVL3.5 multimodal processor, video support, ViT DP / CUDA graph, and non-CUDA backend compatibility.
+
+## Landed PRs
+
+### PR #5350 - Support InternVL3
+
+- Link: https://github.com/sgl-project/sglang/pull/5350
+- Why it mattered: Initial InternVL family support that later carried 3.5.
+- Runtime path: sglang/python/sglang/srt/models/internvl.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #13640 - Support Piecewise CUDA Graph for InternVL
+
+- Link: https://github.com/sgl-project/sglang/pull/13640
+- Why it mattered: Added graph capture support on the encoder path.
+- Runtime path: sglang/python/sglang/srt/models/internvl.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #13925 - Support InternVL Vision Encoder Data Parallelism
+
+- Link: https://github.com/sgl-project/sglang/pull/13925
+- Why it mattered: Opened the multi-GPU ViT path.
+- Runtime path: sglang/python/sglang/srt/models/internvl.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #15942 - Support Video for InternVL3_5
+
+- Link: https://github.com/sgl-project/sglang/pull/15942
+- Why it mattered: Extended support to 3.5 video use cases.
+- Runtime path: sglang/python/sglang/srt/models/internvl.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #19127 - Support processor and embedding inputs for InternVL
+
+- Link: https://github.com/sgl-project/sglang/pull/19127
+- Why it mattered: Hardened processor / embed input interoperability.
+- Runtime path: sglang/python/sglang/srt/models/internvl.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/sglang/sglang-llama4-optimization/SKILL.md
+++ b/skills/model-optimization/sglang/sglang-llama4-optimization/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: sglang-llama4-optimization
+description: PR-backed optimization manual for Llama 4 in SGLang. Use when Codex needs to audit, debug, extend, or document Llama4 text and multimodal runtime, FP8/FP4 quantization, router behavior, long-context attention, and Eagle support.
+---
+
+# SGLang Llama 4 Optimization
+
+## Overview
+
+This skill covers Llama4 text and multimodal runtime, FP8/FP4 quantization, router behavior, long-context attention, and Eagle support.
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/sglang/llama4/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/llama4.py`
+- `sglang/python/sglang/srt/models/mllama4.py`
+
+## Current Main Summary
+
+- Llama4 is mature on the SGLang side but still sensitive to quantized MoE and long-context backend selection.
+- The multimodal path adds a separate vision-rotary and processor validation surface.
+
+## Key Landed PRs
+
+- [#5092](https://github.com/sgl-project/sglang/pull/5092) `Add Llama4 support`: Initial Llama4 landing in SGLang.
+- [#5194](https://github.com/sgl-project/sglang/pull/5194) `Support Llama4 fp8 inference`: Enabled the first production quantized lane.
+- [#6162](https://github.com/sgl-project/sglang/pull/6162) `Fix Llama4 gibberish output with long context and CUDA graph`: Closed a major correctness bug.
+- [#7129](https://github.com/sgl-project/sglang/pull/7129) `Enable ModelOpt Llama4 fp8 checkpoint deployment in SGLang`: Added the ModelOpt checkpoint path.
+- [#13421](https://github.com/sgl-project/sglang/pull/13421) `Add Llama4 attention backend auto-selection`: Stabilized backend choice for real deployments.
+
+## Validation Lanes
+
+- Startup on the cookbook checkpoint or example route.
+- Re-run the parser, quantization, or multimodal lane that matches this family.
+- Re-check registered or manual tests after touching loader or processor code.

--- a/skills/model-optimization/sglang/sglang-llama4-optimization/references/pr-history.md
+++ b/skills/model-optimization/sglang/sglang-llama4-optimization/references/pr-history.md
@@ -1,0 +1,44 @@
+# SGLang Llama 4 PR History
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Scope: Llama4 text and multimodal runtime, FP8/FP4 quantization, router behavior, long-context attention, and Eagle support.
+
+## Landed PRs
+
+### PR #5092 - Add Llama4 support
+
+- Link: https://github.com/sgl-project/sglang/pull/5092
+- Why it mattered: Initial Llama4 landing in SGLang.
+- Runtime path: sglang/python/sglang/srt/models/llama4.py, sglang/python/sglang/srt/models/mllama4.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #5194 - Support Llama4 fp8 inference
+
+- Link: https://github.com/sgl-project/sglang/pull/5194
+- Why it mattered: Enabled the first production quantized lane.
+- Runtime path: sglang/python/sglang/srt/models/llama4.py, sglang/python/sglang/srt/models/mllama4.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #6162 - Fix Llama4 gibberish output with long context and CUDA graph
+
+- Link: https://github.com/sgl-project/sglang/pull/6162
+- Why it mattered: Closed a major correctness bug.
+- Runtime path: sglang/python/sglang/srt/models/llama4.py, sglang/python/sglang/srt/models/mllama4.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #7129 - Enable ModelOpt Llama4 fp8 checkpoint deployment in SGLang
+
+- Link: https://github.com/sgl-project/sglang/pull/7129
+- Why it mattered: Added the ModelOpt checkpoint path.
+- Runtime path: sglang/python/sglang/srt/models/llama4.py, sglang/python/sglang/srt/models/mllama4.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #13421 - Add Llama4 attention backend auto-selection
+
+- Link: https://github.com/sgl-project/sglang/pull/13421
+- Why it mattered: Stabilized backend choice for real deployments.
+- Runtime path: sglang/python/sglang/srt/models/llama4.py, sglang/python/sglang/srt/models/mllama4.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/sglang/sglang-mimo-v2-flash-optimization/SKILL.md
+++ b/skills/model-optimization/sglang/sglang-mimo-v2-flash-optimization/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: sglang-mimo-v2-flash-optimization
+description: PR-backed optimization manual for MiMo-V2-Flash in SGLang. Use when Codex needs to audit, debug, extend, or document MiMo-V2-Flash inference-centric MoE runtime, flashinfer fused all-reduce, overlap, and reasoning parser behavior.
+---
+
+# SGLang MiMo-V2-Flash Optimization
+
+## Overview
+
+This skill covers MiMo-V2-Flash inference-centric MoE runtime, flashinfer fused all-reduce, overlap, and reasoning parser behavior.
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/sglang/mimo-v2-flash/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/mimo_v2_flash.py`
+- `sglang/python/sglang/srt/models/mimo_v2_flash_nextn.py`
+
+## Current Main Summary
+
+- MiMo-V2-Flash is primarily a throughput-oriented MoE serving family.
+- All-reduce fusion, overlap, and reasoning behavior matter more than generic text-only loader work.
+
+## Key Landed PRs
+
+- [#15207](https://github.com/sgl-project/sglang/pull/15207) `MiMo-V2-Flash day0 support`: Initial MiMo-V2-Flash landing.
+- [#15464](https://github.com/sgl-project/sglang/pull/15464) `Optimize MiMo-V2-Flash by flashinfer fused allreduce`: Targeted decode-side communication cost.
+- [#15488](https://github.com/sgl-project/sglang/pull/15488) `Respect `--swa-full-tokens-ratio``: Fixed a concrete runtime flag integration bug.
+- [#17634](https://github.com/sgl-project/sglang/pull/17634) `Support two batch overlap`: Added overlap / throughput optimization.
+- [#21414](https://github.com/sgl-project/sglang/pull/21414) `Add mimo reasoning parser`: Completed the parser path for thinking outputs.
+
+## Validation Lanes
+
+- Startup on the cookbook checkpoint or example route.
+- Re-run the parser, quantization, or multimodal lane that matches this family.
+- Re-check registered or manual tests after touching loader or processor code.

--- a/skills/model-optimization/sglang/sglang-mimo-v2-flash-optimization/references/pr-history.md
+++ b/skills/model-optimization/sglang/sglang-mimo-v2-flash-optimization/references/pr-history.md
@@ -1,0 +1,44 @@
+# SGLang MiMo-V2-Flash PR History
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Scope: MiMo-V2-Flash inference-centric MoE runtime, flashinfer fused all-reduce, overlap, and reasoning parser behavior.
+
+## Landed PRs
+
+### PR #15207 - MiMo-V2-Flash day0 support
+
+- Link: https://github.com/sgl-project/sglang/pull/15207
+- Why it mattered: Initial MiMo-V2-Flash landing.
+- Runtime path: sglang/python/sglang/srt/models/mimo_v2_flash.py, sglang/python/sglang/srt/models/mimo_v2_flash_nextn.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #15464 - Optimize MiMo-V2-Flash by flashinfer fused allreduce
+
+- Link: https://github.com/sgl-project/sglang/pull/15464
+- Why it mattered: Targeted decode-side communication cost.
+- Runtime path: sglang/python/sglang/srt/models/mimo_v2_flash.py, sglang/python/sglang/srt/models/mimo_v2_flash_nextn.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #15488 - Respect `--swa-full-tokens-ratio`
+
+- Link: https://github.com/sgl-project/sglang/pull/15488
+- Why it mattered: Fixed a concrete runtime flag integration bug.
+- Runtime path: sglang/python/sglang/srt/models/mimo_v2_flash.py, sglang/python/sglang/srt/models/mimo_v2_flash_nextn.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #17634 - Support two batch overlap
+
+- Link: https://github.com/sgl-project/sglang/pull/17634
+- Why it mattered: Added overlap / throughput optimization.
+- Runtime path: sglang/python/sglang/srt/models/mimo_v2_flash.py, sglang/python/sglang/srt/models/mimo_v2_flash_nextn.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #21414 - Add mimo reasoning parser
+
+- Link: https://github.com/sgl-project/sglang/pull/21414
+- Why it mattered: Completed the parser path for thinking outputs.
+- Runtime path: sglang/python/sglang/srt/models/mimo_v2_flash.py, sglang/python/sglang/srt/models/mimo_v2_flash_nextn.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/sglang/sglang-mistral-small-4-optimization/SKILL.md
+++ b/skills/model-optimization/sglang/sglang-mistral-small-4-optimization/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: sglang-mistral-small-4-optimization
+description: PR-backed optimization manual for Mistral Small 4 in SGLang. Use when Codex needs to audit, debug, extend, or document Mistral Small 4, Leanstral, and closely related Mistral Large 3 / Ministral serving behavior, including multimodal and EAGLE paths.
+---
+
+# SGLang Mistral Small 4 Optimization
+
+## Overview
+
+This skill covers Mistral Small 4, Leanstral, and closely related Mistral Large 3 / Ministral serving behavior, including multimodal and EAGLE paths.
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/sglang/mistral-small-4/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/mistral_large_3.py`
+- `sglang/python/sglang/srt/models/mistral_large_3_eagle.py`
+- `sglang/python/sglang/srt/models/mistral.py`
+- `sglang/python/sglang/srt/models/ministral3.py`
+
+## Current Main Summary
+
+- Mistral Small 4 sits on top of the larger Mistral Large 3 / Ministral runtime work.
+- Startup format mismatches, multimodal projector behavior, and Eagle / MoE integration are the main risk areas.
+
+## Key Landed PRs
+
+- [#14213](https://github.com/sgl-project/sglang/pull/14213) `Add Mistral Large 3 support`: Historical base runtime reused by later Small 4 work.
+- [#14466](https://github.com/sgl-project/sglang/pull/14466) `Add Mistral Large 3 Eagle Support`: Enabled speculative decode on the underlying family.
+- [#15049](https://github.com/sgl-project/sglang/pull/15049) `Mistral Large 3 NVFP4 TRTLLM MoE support`: Added the first serious quantized MoE path.
+- [#20708](https://github.com/sgl-project/sglang/pull/20708) `Add Mistral Small 4 support`: Brought Mistral Small 4 / Pixtral-style runtime into mainline.
+- [#21620](https://github.com/sgl-project/sglang/pull/21620) `Mistral Small 4 fails to start due to config/weight format mismatch`: Closed a startup regression after launch.
+
+## Validation Lanes
+
+- Startup on the cookbook checkpoint or example route.
+- Re-run the parser, quantization, or multimodal lane that matches this family.
+- Re-check registered or manual tests after touching loader or processor code.

--- a/skills/model-optimization/sglang/sglang-mistral-small-4-optimization/references/pr-history.md
+++ b/skills/model-optimization/sglang/sglang-mistral-small-4-optimization/references/pr-history.md
@@ -1,0 +1,44 @@
+# SGLang Mistral Small 4 PR History
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Scope: Mistral Small 4, Leanstral, and closely related Mistral Large 3 / Ministral serving behavior, including multimodal and EAGLE paths.
+
+## Landed PRs
+
+### PR #14213 - Add Mistral Large 3 support
+
+- Link: https://github.com/sgl-project/sglang/pull/14213
+- Why it mattered: Historical base runtime reused by later Small 4 work.
+- Runtime path: sglang/python/sglang/srt/models/mistral_large_3.py, sglang/python/sglang/srt/models/mistral_large_3_eagle.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #14466 - Add Mistral Large 3 Eagle Support
+
+- Link: https://github.com/sgl-project/sglang/pull/14466
+- Why it mattered: Enabled speculative decode on the underlying family.
+- Runtime path: sglang/python/sglang/srt/models/mistral_large_3.py, sglang/python/sglang/srt/models/mistral_large_3_eagle.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #15049 - Mistral Large 3 NVFP4 TRTLLM MoE support
+
+- Link: https://github.com/sgl-project/sglang/pull/15049
+- Why it mattered: Added the first serious quantized MoE path.
+- Runtime path: sglang/python/sglang/srt/models/mistral_large_3.py, sglang/python/sglang/srt/models/mistral_large_3_eagle.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #20708 - Add Mistral Small 4 support
+
+- Link: https://github.com/sgl-project/sglang/pull/20708
+- Why it mattered: Brought Mistral Small 4 / Pixtral-style runtime into mainline.
+- Runtime path: sglang/python/sglang/srt/models/mistral_large_3.py, sglang/python/sglang/srt/models/mistral_large_3_eagle.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #21620 - Mistral Small 4 fails to start due to config/weight format mismatch
+
+- Link: https://github.com/sgl-project/sglang/pull/21620
+- Why it mattered: Closed a startup regression after launch.
+- Runtime path: sglang/python/sglang/srt/models/mistral_large_3.py, sglang/python/sglang/srt/models/mistral_large_3_eagle.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/sglang/sglang-nemotron-super-optimization/SKILL.md
+++ b/skills/model-optimization/sglang/sglang-nemotron-super-optimization/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: sglang-nemotron-super-optimization
+description: PR-backed optimization manual for Nemotron Super / Nano Hybrid in SGLang. Use when Codex needs to audit, debug, extend, or document NemotronH, Nemotron 3 Super, Nemotron Nano hybrid Mamba+Attention+MoE, MTP, NVFP4, and VL adjacencies.
+---
+
+# SGLang Nemotron Super / Nano Hybrid Optimization
+
+## Overview
+
+This skill covers NemotronH, Nemotron 3 Super, Nemotron Nano hybrid Mamba+Attention+MoE, MTP, NVFP4, and VL adjacencies.
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/sglang/nemotron-super/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/nemotron_h.py`
+- `sglang/python/sglang/srt/models/nemotron_h_mtp.py`
+- `sglang/python/sglang/srt/models/nano_nemotron_vl.py`
+
+## Current Main Summary
+
+- Nemotron is a hybrid family: attention, Mamba, MoE, MTP, and VL all intersect.
+- Because of that, graph execution, cache dtype, and quantized MoE correctness are the primary risk areas.
+
+## Key Landed PRs
+
+- [#16172](https://github.com/sgl-project/sglang/pull/16172) `NemotronH PP support`: Opened pipeline parallelism on NemotronH.
+- [#16227](https://github.com/sgl-project/sglang/pull/16227) `Add latent MoE support`: Added the hybrid latent-MoE path.
+- [#19903](https://github.com/sgl-project/sglang/pull/19903) `Enable Piecewise CUDA Graph for NemotronH Hybrid Models`: Improved hybrid serving efficiency.
+- [#20407](https://github.com/sgl-project/sglang/pull/20407) `Support Nemotron 3 Super NVFP4`: Added the key quantized Super checkpoint path.
+- [#20575](https://github.com/sgl-project/sglang/pull/20575) `Add Nemotron 3 Super CI tests for BF16 and NVFP4`: Added regression coverage for the production checkpoint variants.
+
+## Validation Lanes
+
+- Startup on the cookbook checkpoint or example route.
+- Re-run the parser, quantization, or multimodal lane that matches this family.
+- Re-check registered or manual tests after touching loader or processor code.

--- a/skills/model-optimization/sglang/sglang-nemotron-super-optimization/references/pr-history.md
+++ b/skills/model-optimization/sglang/sglang-nemotron-super-optimization/references/pr-history.md
@@ -1,0 +1,44 @@
+# SGLang Nemotron Super / Nano Hybrid PR History
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Scope: NemotronH, Nemotron 3 Super, Nemotron Nano hybrid Mamba+Attention+MoE, MTP, NVFP4, and VL adjacencies.
+
+## Landed PRs
+
+### PR #16172 - NemotronH PP support
+
+- Link: https://github.com/sgl-project/sglang/pull/16172
+- Why it mattered: Opened pipeline parallelism on NemotronH.
+- Runtime path: sglang/python/sglang/srt/models/nemotron_h.py, sglang/python/sglang/srt/models/nemotron_h_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #16227 - Add latent MoE support
+
+- Link: https://github.com/sgl-project/sglang/pull/16227
+- Why it mattered: Added the hybrid latent-MoE path.
+- Runtime path: sglang/python/sglang/srt/models/nemotron_h.py, sglang/python/sglang/srt/models/nemotron_h_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #19903 - Enable Piecewise CUDA Graph for NemotronH Hybrid Models
+
+- Link: https://github.com/sgl-project/sglang/pull/19903
+- Why it mattered: Improved hybrid serving efficiency.
+- Runtime path: sglang/python/sglang/srt/models/nemotron_h.py, sglang/python/sglang/srt/models/nemotron_h_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #20407 - Support Nemotron 3 Super NVFP4
+
+- Link: https://github.com/sgl-project/sglang/pull/20407
+- Why it mattered: Added the key quantized Super checkpoint path.
+- Runtime path: sglang/python/sglang/srt/models/nemotron_h.py, sglang/python/sglang/srt/models/nemotron_h_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #20575 - Add Nemotron 3 Super CI tests for BF16 and NVFP4
+
+- Link: https://github.com/sgl-project/sglang/pull/20575
+- Why it mattered: Added regression coverage for the production checkpoint variants.
+- Runtime path: sglang/python/sglang/srt/models/nemotron_h.py, sglang/python/sglang/srt/models/nemotron_h_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/sglang/sglang-step35-optimization/SKILL.md
+++ b/skills/model-optimization/sglang/sglang-step35-optimization/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: sglang-step35-optimization
+description: PR-backed optimization manual for Step3.5 / Step3-VL in SGLang. Use when Codex needs to audit, debug, extend, or document Step3.5-Flash and Step3-VL-10B serving, MTP, MoE all-reduce, tool/reasoning parser, and processor evolution.
+---
+
+# SGLang Step3.5 / Step3-VL Optimization
+
+## Overview
+
+This skill covers Step3.5-Flash and Step3-VL-10B serving, MTP, MoE all-reduce, tool/reasoning parser, and processor evolution.
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/sglang/step35/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `sglang/python/sglang/srt/models/step3p5.py`
+- `sglang/python/sglang/srt/models/step3p5_mtp.py`
+- `sglang/python/sglang/srt/models/step3_vl.py`
+- `sglang/python/sglang/srt/models/step3_vl_10b.py`
+
+## Current Main Summary
+
+- Step3.5 is split between text/MTP and VL processor work.
+- All-reduce efficiency and parser behavior are the main axes to track.
+
+## Key Landed PRs
+
+- [#8583](https://github.com/sgl-project/sglang/pull/8583) `Support Step3V`: Initial Step3 visual model support.
+- [#8699](https://github.com/sgl-project/sglang/pull/8699) `Support DP Attention for step3_vl`: Enabled multi-GPU VL serving.
+- [#9695](https://github.com/sgl-project/sglang/pull/9695) `Add step3 tool parser`: Added tool-call parsing.
+- [#18564](https://github.com/sgl-project/sglang/pull/18564) `Implement the standard multi-layer MTP for step3p5`: Added Step3.5 draft-model support.
+- [#22773](https://github.com/sgl-project/sglang/pull/22773) `Optimize allreduce in MoE layers`: Targeted the Step3.5 MoE hot path.
+
+## Validation Lanes
+
+- Startup on the cookbook checkpoint or example route.
+- Re-run the parser, quantization, or multimodal lane that matches this family.
+- Re-check registered or manual tests after touching loader or processor code.

--- a/skills/model-optimization/sglang/sglang-step35-optimization/references/pr-history.md
+++ b/skills/model-optimization/sglang/sglang-step35-optimization/references/pr-history.md
@@ -1,0 +1,44 @@
+# SGLang Step3.5 / Step3-VL PR History
+
+Evidence snapshot:
+
+- SGLang mainline checked around `c122d343adb969cd9bbd1af2ca86727a11be3845`
+- sgl-cookbook checked around `e88b0fd8ac5b1caa6eb42766035029220053369b`
+- Scope: Step3.5-Flash and Step3-VL-10B serving, MTP, MoE all-reduce, tool/reasoning parser, and processor evolution.
+
+## Landed PRs
+
+### PR #8583 - Support Step3V
+
+- Link: https://github.com/sgl-project/sglang/pull/8583
+- Why it mattered: Initial Step3 visual model support.
+- Runtime path: sglang/python/sglang/srt/models/step3p5.py, sglang/python/sglang/srt/models/step3p5_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #8699 - Support DP Attention for step3_vl
+
+- Link: https://github.com/sgl-project/sglang/pull/8699
+- Why it mattered: Enabled multi-GPU VL serving.
+- Runtime path: sglang/python/sglang/srt/models/step3p5.py, sglang/python/sglang/srt/models/step3p5_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #9695 - Add step3 tool parser
+
+- Link: https://github.com/sgl-project/sglang/pull/9695
+- Why it mattered: Added tool-call parsing.
+- Runtime path: sglang/python/sglang/srt/models/step3p5.py, sglang/python/sglang/srt/models/step3p5_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #18564 - Implement the standard multi-layer MTP for step3p5
+
+- Link: https://github.com/sgl-project/sglang/pull/18564
+- Why it mattered: Added Step3.5 draft-model support.
+- Runtime path: sglang/python/sglang/srt/models/step3p5.py, sglang/python/sglang/srt/models/step3p5_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #22773 - Optimize allreduce in MoE layers
+
+- Link: https://github.com/sgl-project/sglang/pull/22773
+- Why it mattered: Targeted the Step3.5 MoE hot path.
+- Runtime path: sglang/python/sglang/srt/models/step3p5.py, sglang/python/sglang/srt/models/step3p5_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/vllm/README.md
+++ b/skills/model-optimization/vllm/README.md
@@ -1,13 +1,36 @@
 # vLLM Model Optimization Skills
 
-Reserved for future vLLM model optimization skills.
+Current vLLM model skills:
 
-Use the same layout as `../sglang/`:
-
-- one skill directory per model family/generation,
-- `SKILL.md`,
-- `references/pr-history.md`,
-- `references/playbook.md`,
-- optional `agents/openai.yaml`.
-
-Each vLLM model PR history should follow the repository-wide PR-diff dossier standard: read the code diff for every PR and write motivation, implementation detail, key code excerpt, and validation/risk.
+- `vllm-deepseek-v3-r1-optimization`
+- `vllm-deepseek-v31-optimization`
+- `vllm-deepseek-v32-optimization`
+- `vllm-deepseek-v4-optimization`
+- `vllm-glm-vlm-ocr-optimization`
+- `vllm-glm45-optimization`
+- `vllm-glm46-glm47-optimization`
+- `vllm-glm5-glm51-optimization`
+- `vllm-hunyuan3-preview-optimization`
+- `vllm-kimi-optimization`
+- `vllm-ltx23-hq-optimization`
+- `vllm-minimax-optimization`
+- `vllm-mixtral-quark-int4fp8-moe-optimization`
+- `vllm-moss-vl-optimization`
+- `vllm-qwen-image-optimization`
+- `vllm-qwen-vlm-omni-asr-optimization`
+- `vllm-qwen3-coder-optimization`
+- `vllm-qwen3-core-optimization`
+- `vllm-qwen3-next-optimization`
+- `vllm-qwen35-optimization`
+- `vllm-qwen36-optimization`
+- `vllm-z-image-turbo-optimization`
+- `vllm-ernie45-optimization`
+- `vllm-gemma4-optimization`
+- `vllm-gpt-oss-optimization`
+- `vllm-intern-s1-optimization`
+- `vllm-internvl35-optimization`
+- `vllm-llama4-optimization`
+- `vllm-mimo-v2-flash-optimization`
+- `vllm-mistral-small-4-optimization`
+- `vllm-nemotron-super-optimization`
+- `vllm-step35-optimization`

--- a/skills/model-optimization/vllm/vllm-deepseek-v3-r1-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-deepseek-v3-r1-optimization/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: vllm-deepseek-v3-r1-optimization
+description: PR-backed optimization manual for DeepSeek V3 / R1 in vLLM. Use when Codex needs to audit, debug, extend, or document DeepSeek V3 and DeepSeek R1 MLA, MoE, packed-module loading, LoRA, MTP/Eagle, and quantized ROCm/CUDA validation paths.
+---
+
+# vLLM DeepSeek V3 / R1 Optimization
+
+## Overview
+
+This skill covers DeepSeek V3 and DeepSeek R1 MLA, MoE, packed-module loading, LoRA, MTP/Eagle, and quantized ROCm/CUDA validation paths.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/deepseek-v3-r1/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/deepseek_v2.py`
+- `vllm/vllm/model_executor/models/deepseek_eagle.py`
+- `vllm/vllm/model_executor/models/deepseek_eagle3.py`
+- `vllm/vllm/model_executor/models/deepseek_mtp.py`
+
+## Current Main Summary
+
+- `DeepseekV2ForCausalLM` / `DeepseekV3ForCausalLM` remain the shared runtime for V3 and R1.
+- The highest-risk regressions cluster around packed module mapping, quantized MLA/MoE weight loading, LoRA, and MTP draft paths.
+- R1 validation should split BF16, FP8/ModelOpt, and compressed-tensors or ROCm lanes.
+
+## Key Landed PRs
+
+- [#22352](https://github.com/vllm-project/vllm/pull/22352) `Add missing `packed_modules_mapping` to `DeepseekV2ForCausalLM``: Fixed quantized and packed-weight loading for DeepSeek V2/V3/R1 style checkpoints.
+- [#23971](https://github.com/vllm-project/vllm/pull/23971) `Add LoRA support for DeepSeek models (V2, V3, R1-0528)`: Enabled adapter injection on the DeepSeek family rather than only base dense models.
+- [#29545](https://github.com/vllm-project/vllm/pull/29545) `Fix DeepSeek R1 MTP weight loading`: Hardened R1 NextN / MTP draft loading after launch failures on draft weights.
+- [#36247](https://github.com/vllm-project/vllm/pull/36247) `Fix compressed-tensors quantization failure for DeepSeek-R1 on MI300x`: Closed a production ROCm gap for compressed-tensors DeepSeek-R1 deployment.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- BF16 DeepSeek-V3 / R1 serve plus generation sanity.
+- FP8 or compressed-tensors startup on Hopper/Blackwell and MI300X.
+- MTP / Eagle draft-model acceptance tests.
+- LoRA adapter load and unload on the same checkpoint.

--- a/skills/model-optimization/vllm/vllm-deepseek-v3-r1-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-deepseek-v3-r1-optimization/references/pr-history.md
@@ -1,0 +1,42 @@
+# vLLM DeepSeek V3 / R1 PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Scope: DeepSeek V3 and DeepSeek R1 MLA, MoE, packed-module loading, LoRA, MTP/Eagle, and quantized ROCm/CUDA validation paths.
+
+
+## Landed PRs
+
+### PR #22352 - Add missing `packed_modules_mapping` to `DeepseekV2ForCausalLM`
+
+- Link: https://github.com/vllm-project/vllm/pull/22352
+- Why it mattered: Fixed quantized and packed-weight loading for DeepSeek V2/V3/R1 style checkpoints.
+- Runtime path: vllm/vllm/model_executor/models/deepseek_v2.py, vllm/vllm/model_executor/models/deepseek_eagle.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #23971 - Add LoRA support for DeepSeek models (V2, V3, R1-0528)
+
+- Link: https://github.com/vllm-project/vllm/pull/23971
+- Why it mattered: Enabled adapter injection on the DeepSeek family rather than only base dense models.
+- Runtime path: vllm/vllm/model_executor/models/deepseek_v2.py, vllm/vllm/model_executor/models/deepseek_eagle.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #29545 - Fix DeepSeek R1 MTP weight loading
+
+- Link: https://github.com/vllm-project/vllm/pull/29545
+- Why it mattered: Hardened R1 NextN / MTP draft loading after launch failures on draft weights.
+- Runtime path: vllm/vllm/model_executor/models/deepseek_v2.py, vllm/vllm/model_executor/models/deepseek_eagle.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #36247 - Fix compressed-tensors quantization failure for DeepSeek-R1 on MI300x
+
+- Link: https://github.com/vllm-project/vllm/pull/36247
+- Why it mattered: Closed a production ROCm gap for compressed-tensors DeepSeek-R1 deployment.
+- Runtime path: vllm/vllm/model_executor/models/deepseek_v2.py, vllm/vllm/model_executor/models/deepseek_eagle.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-deepseek-v31-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-deepseek-v31-optimization/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: vllm-deepseek-v31-optimization
+description: PR-backed optimization manual for DeepSeek V3.1 in vLLM. Use when Codex needs to audit, debug, extend, or document DeepSeek V3.1 parser, scale-format, DeepGEMM, and reasoning-tooling deltas layered on top of the base DeepSeek V3 runtime.
+---
+
+# vLLM DeepSeek V3.1 Optimization
+
+## Overview
+
+This skill covers DeepSeek V3.1 parser, scale-format, DeepGEMM, and reasoning-tooling deltas layered on top of the base DeepSeek V3 runtime.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Family baseline: read `deepseek-v3-r1` first; this dossier only records the delta for `deepseek-v31`.
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/deepseek-v31/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/deepseek_v2.py`
+- `vllm/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py`
+
+## Current Main Summary
+
+- V3.1 mostly reuses the base V3 runtime and adds parser plus scale-format correctness work.
+- The practical blast radius is in tool calling, DeepGEMM scale handling, and reasoning-parser behavior.
+
+## Key Landed PRs
+
+- [#23454](https://github.com/vllm-project/vllm/pull/23454) `Support DeepSeek-V3.1 tool call`: Added the first V3.1-specific tool-call parser surface to vLLM.
+- [#23666](https://github.com/vllm-project/vllm/pull/23666) `Add Hopper DeepGEMM E8M0 for DeepSeekV3.1 scale_fmt`: Tuned the scale-format path used by DeepGEMM-based DeepSeek V3.1 kernels.
+- [#25589](https://github.com/vllm-project/vllm/pull/25589) `Add DeepSeek-V3.1 reasoning parser`: Separated V3.1 reasoning output handling from generic DeepSeek parsing.
+- [#32361](https://github.com/vllm-project/vllm/pull/32361) `Fix DeepSeek-V3.1 + DeepGEMM incompatible scale shapes`: Patched a concrete shape mismatch between newer checkpoints and DeepGEMM assumptions.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- Tool-call extraction on non-streaming and streaming outputs.
+- DeepGEMM-backed launch with V3.1 scale-format checkpoints.
+- Reasoning parser output separation under long responses.

--- a/skills/model-optimization/vllm/vllm-deepseek-v31-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-deepseek-v31-optimization/references/pr-history.md
@@ -1,0 +1,43 @@
+# vLLM DeepSeek V3.1 PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Scope: DeepSeek V3.1 parser, scale-format, DeepGEMM, and reasoning-tooling deltas layered on top of the base DeepSeek V3 runtime.
+
+This family inherits the base runtime context from `deepseek-v3-r1`; this file records only the delta that is specific to `deepseek-v31`.
+
+## Landed PRs
+
+### PR #23454 - Support DeepSeek-V3.1 tool call
+
+- Link: https://github.com/vllm-project/vllm/pull/23454
+- Why it mattered: Added the first V3.1-specific tool-call parser surface to vLLM.
+- Runtime path: vllm/vllm/model_executor/models/deepseek_v2.py, vllm/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #23666 - Add Hopper DeepGEMM E8M0 for DeepSeekV3.1 scale_fmt
+
+- Link: https://github.com/vllm-project/vllm/pull/23666
+- Why it mattered: Tuned the scale-format path used by DeepGEMM-based DeepSeek V3.1 kernels.
+- Runtime path: vllm/vllm/model_executor/models/deepseek_v2.py, vllm/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #25589 - Add DeepSeek-V3.1 reasoning parser
+
+- Link: https://github.com/vllm-project/vllm/pull/25589
+- Why it mattered: Separated V3.1 reasoning output handling from generic DeepSeek parsing.
+- Runtime path: vllm/vllm/model_executor/models/deepseek_v2.py, vllm/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #32361 - Fix DeepSeek-V3.1 + DeepGEMM incompatible scale shapes
+
+- Link: https://github.com/vllm-project/vllm/pull/32361
+- Why it mattered: Patched a concrete shape mismatch between newer checkpoints and DeepGEMM assumptions.
+- Runtime path: vllm/vllm/model_executor/models/deepseek_v2.py, vllm/vllm/model_executor/layers/quantization/utils/flashinfer_utils.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-deepseek-v32-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-deepseek-v32-optimization/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: vllm-deepseek-v32-optimization
+description: PR-backed optimization manual for DeepSeek V3.2 in vLLM. Use when Codex needs to audit, debug, extend, or document DeepSeek V3.2 sparse-MLA / DSA runtime, indexer, tool parser, MTP fallback, and long-context decode kernels in vLLM.
+---
+
+# vLLM DeepSeek V3.2 Optimization
+
+## Overview
+
+This skill covers DeepSeek V3.2 sparse-MLA / DSA runtime, indexer, tool parser, MTP fallback, and long-context decode kernels in vLLM.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/deepseek-v32/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/deepseek_v2.py`
+- `vllm/vllm/model_executor/layers/rotary_embedding/mrope.py`
+
+## Current Main Summary
+
+- DeepSeek V3.2 is the major vLLM fork of the DeepSeek line because it adds sparse MLA and indexer logic.
+- Most regressions land in the indexer builder, tokenizer / parser, and specialized decode kernels rather than the generic V3 loader.
+
+## Key Landed PRs
+
+- [#25896](https://github.com/vllm-project/vllm/pull/25896) `Support DeepSeek-V3.2`: Landed the initial V3.2 model registration, sparse-attention runtime, and benchmark hooks.
+- [#25999](https://github.com/vllm-project/vllm/pull/25999) `Support indexer prefill chunking`: Made the V3.2 sparse indexer work with chunked prefill instead of eager-only behavior.
+- [#26670](https://github.com/vllm-project/vllm/pull/26670) `Add AMD GPU support on DeepSeek v3.2 and SparseMLA`: Opened the ROCm SparseMLA lane for V3.2 deployments.
+- [#29848](https://github.com/vllm-project/vllm/pull/29848) `Add DeepSeek-V3.2 tool parser`: Added the parser surface that cookbook-style V3.2 reasoning deployments depend on.
+- [#33090](https://github.com/vllm-project/vllm/pull/33090) `Fix DeepseekV32 `AssertionError: num_kv_heads == 1``: Removed a hard failure triggered by newer V3.2 attention shapes.
+- [#37421](https://github.com/vllm-project/vllm/pull/37421) `Persistent TopK scheduler for DeepSeek-V3.2 decode`: Modernized the decode scheduler with a CUDAGraph-safe persistent TopK kernel.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- SparseMLA prefill plus decode on CUDA and ROCm.
+- Chunked prefill with the V3.2 indexer enabled.
+- Tool parser on long reasoning responses.
+- MTP / eager-fallback checks where sparse kernels are unavailable.

--- a/skills/model-optimization/vllm/vllm-deepseek-v32-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-deepseek-v32-optimization/references/pr-history.md
@@ -1,0 +1,56 @@
+# vLLM DeepSeek V3.2 PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Scope: DeepSeek V3.2 sparse-MLA / DSA runtime, indexer, tool parser, MTP fallback, and long-context decode kernels in vLLM.
+
+
+## Landed PRs
+
+### PR #25896 - Support DeepSeek-V3.2
+
+- Link: https://github.com/vllm-project/vllm/pull/25896
+- Why it mattered: Landed the initial V3.2 model registration, sparse-attention runtime, and benchmark hooks.
+- Runtime path: vllm/vllm/model_executor/models/deepseek_v2.py, vllm/vllm/model_executor/layers/rotary_embedding/mrope.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #25999 - Support indexer prefill chunking
+
+- Link: https://github.com/vllm-project/vllm/pull/25999
+- Why it mattered: Made the V3.2 sparse indexer work with chunked prefill instead of eager-only behavior.
+- Runtime path: vllm/vllm/model_executor/models/deepseek_v2.py, vllm/vllm/model_executor/layers/rotary_embedding/mrope.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #26670 - Add AMD GPU support on DeepSeek v3.2 and SparseMLA
+
+- Link: https://github.com/vllm-project/vllm/pull/26670
+- Why it mattered: Opened the ROCm SparseMLA lane for V3.2 deployments.
+- Runtime path: vllm/vllm/model_executor/models/deepseek_v2.py, vllm/vllm/model_executor/layers/rotary_embedding/mrope.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #29848 - Add DeepSeek-V3.2 tool parser
+
+- Link: https://github.com/vllm-project/vllm/pull/29848
+- Why it mattered: Added the parser surface that cookbook-style V3.2 reasoning deployments depend on.
+- Runtime path: vllm/vllm/model_executor/models/deepseek_v2.py, vllm/vllm/model_executor/layers/rotary_embedding/mrope.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #33090 - Fix DeepseekV32 `AssertionError: num_kv_heads == 1`
+
+- Link: https://github.com/vllm-project/vllm/pull/33090
+- Why it mattered: Removed a hard failure triggered by newer V3.2 attention shapes.
+- Runtime path: vllm/vllm/model_executor/models/deepseek_v2.py, vllm/vllm/model_executor/layers/rotary_embedding/mrope.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #37421 - Persistent TopK scheduler for DeepSeek-V3.2 decode
+
+- Link: https://github.com/vllm-project/vllm/pull/37421
+- Why it mattered: Modernized the decode scheduler with a CUDAGraph-safe persistent TopK kernel.
+- Runtime path: vllm/vllm/model_executor/models/deepseek_v2.py, vllm/vllm/model_executor/layers/rotary_embedding/mrope.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-deepseek-v4-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-deepseek-v4-optimization/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: vllm-deepseek-v4-optimization
+description: PR-backed optimization manual for DeepSeek V4 in vLLM. Use when Codex needs to audit, debug, extend, or document DeepSeek V4 open-radar work in vLLM, including the proposed model module, MTP path, tokenizer/renderer, DSML tool parser, and BF16 persistent-topk follow-up before mainline support lands.
+---
+
+# vLLM DeepSeek V4 Optimization
+
+## Overview
+
+This skill tracks DeepSeek V4 in the "not merged yet, but large open PRs exist"
+state. The checked mainline commit still does not ship a `DeepseekV4ForCausalLM`
+alias, tokenizer, renderer, or tool parser. The useful evidence is therefore in
+open PR diffs, not in current-main runtime behavior.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: not landed on current mainline
+- Open PRs reviewed: `#40760`, `#40811`, `#40806`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/deepseek-v4/README.zh.md`
+  and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the bar.
+DeepSeek V4 must stay marked as open radar until the registry alias, config,
+tokenizer/renderer, and parser work are all merged on mainline.
+
+## Runtime Surfaces
+
+- Current main evidence: `vllm/vllm/model_executor/models/registry.py`
+- Proposed model path in open PR: `vllm/vllm/model_executor/models/deepseek_v4.py`
+- Proposed draft path in open PR: `vllm/vllm/model_executor/models/deepseek_v4_mtp.py`
+- Proposed tokenizer/render path in open PR:
+  `vllm/vllm/tokenizers/deepseek_v4.py`,
+  `vllm/vllm/renderers/deepseek_v4.py`
+- Proposed parser path in open PR:
+  `vllm/vllm/tool_parsers/deepseekv4_tool_parser.py`
+- Kernel follow-up in open PR:
+  `vllm/csrc/persistent_topk.cuh`, `vllm/csrc/topk.cu`
+- Spec-decode follow-up in open PR:
+  `vllm/vllm/v1/spec_decode/eagle.py`
+
+## Current Main Summary
+
+- Current mainline has no `DeepseekV4ForCausalLM` alias in
+  `vllm/model_executor/models/registry.py`.
+- Open PR `#40760` is a large bring-up stack: model class, MTP model,
+  DeepSeek-V4 tokenizer/renderer, DSML tool parser, quant config rewrites, and
+  spec-decode wiring.
+- Open PR `#40811` extends persistent top-k from FP32-only assumptions to
+  BF16 input support, which matters for the DeepSeek V4 sparse indexer path.
+- Open PR `#40806` fixes a streaming parser leak where a partial
+  `<｜DSML｜function_calls>` sentinel could be emitted as normal content.
+
+## Open Radar
+
+- [#40760](https://github.com/vllm-project/vllm/pull/40760) `[New Model] Support DeepseekV4`
+- [#40811](https://github.com/vllm-project/vllm/pull/40811) `[Perf][Kernel] BF16 input support for persistent topK - DeepSeekV4`
+- [#40806](https://github.com/vllm-project/vllm/pull/40806) `[Bugfix] Fix the DSML token leakage in DSV4/3.2`
+
+## Validation Lanes
+
+- Re-check mainline `registry.py` before claiming support.
+- If `#40760` merges, validate tokenizer/renderer parity, DSML tool calls, base
+  generation, and MTP speculative decoding.
+- If `#40811` merges, rerun kernel tests in
+  `tests/kernels/test_top_k_per_row.py`, especially BF16 decode and long-context
+  cases.
+- If `#40806` merges, rerun streaming tool-parser tests to ensure DSML sentinels
+  never leak into user-visible content.
+
+## References
+
+- `references/pr-history.md`: diff-reviewed DeepSeek V4 open-radar cards.

--- a/skills/model-optimization/vllm/vllm-deepseek-v4-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-deepseek-v4-optimization/references/pr-history.md
@@ -1,0 +1,161 @@
+# vLLM DeepSeek V4 PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: not landed on current mainline
+- Scope: open-radar DeepSeek V4 bring-up, BF16 sparse top-k, and DSML parser
+  correctness before merge
+
+## Landed PRs
+
+No merged DeepSeek V4 family PR is present in the checked mainline commit.
+Treat every item below as open radar.
+
+## Open PR Radar
+
+### Open PR #40760 - Support DeepseekV4
+
+- Link: https://github.com/vllm-project/vllm/pull/40760
+- State: open
+- Diff coverage: full file list reviewed via GitHub API, `156` files, `16193`
+  additions, `760` deletions
+- Motivation:
+  - vLLM had DeepSeek V3/V3.2 paths but no DeepSeek V4 architecture alias,
+    config class, tokenizer/renderer, DSML tool parser, or MTP draft model.
+  - The PR is trying to land the whole bring-up stack instead of only adding a
+    registry alias.
+- Key implementation:
+  - Adds `DeepseekV4ForCausalLM` and `DeepSeekV4MTPModel` to the registry.
+  - Introduces new runtime files `deepseek_v4.py` and `deepseek_v4_mtp.py`.
+  - Adds `DeepseekV4Config`, `DeepseekV4Tokenizer`, `DeepseekV4Renderer`, and a
+    dedicated `DeepSeekV4ToolParser`.
+  - Extends spec-decode buffers for the V4 hyper-compressed residual path and
+    shares the target `lm_head` into MTP `shared_head.head`.
+- Key code excerpts:
+
+```diff
++    "DeepseekV4ForCausalLM": ("deepseek_v4", "DeepseekV4ForCausalLM"),
++    "DeepSeekV4MTPModel": ("deepseek_v4_mtp", "DeepSeekV4MTP"),
+```
+
+```diff
++class DeepSeekV4ToolParser(DeepSeekV32ToolParser):
++    tool_call_start_token: str = "<｜DSML｜tool_calls>"
++    tool_call_end_token: str = "</｜DSML｜tool_calls>"
+```
+
+```diff
++if hasattr(draft_hf_config, "compress_ratios") and hasattr(
++    draft_hf_config, "hc_mult"
++):
++    self.hidden_size = self.hidden_size * draft_hf_config.hc_mult
+```
+
+- Reviewed files:
+  - runtime: `vllm/model_executor/models/deepseek_v4.py`,
+    `vllm/model_executor/models/deepseek_v4_mtp.py`,
+    `vllm/model_executor/models/registry.py`,
+    `vllm/model_executor/models/config.py`
+  - tokenizer/renderer: `vllm/tokenizers/deepseek_v4.py`,
+    `vllm/renderers/deepseek_v4.py`,
+    `vllm/renderers/registry.py`,
+    `vllm/tokenizers/registry.py`
+  - tool calling: `vllm/tool_parsers/deepseekv4_tool_parser.py`,
+    `vllm/tool_parsers/__init__.py`,
+    `tests/tool_parsers/test_deepseekv4_tool_parser.py`
+  - spec decode: `vllm/v1/spec_decode/eagle.py`,
+    `vllm/v1/worker/gpu/spec_decode/eagle/speculator.py`,
+    `vllm/v1/worker/gpu/spec_decode/eagle/utils.py`
+  - tests: `tests/models/registry.py`, `tests/tokenizers_/test_deepseek_v4.py`
+- Validation implications:
+  - Do not present DeepSeek V4 as supported until the registry alias and parser
+    are merged on mainline.
+  - After merge, validate model load, chat templating, tool calls, and MTP
+    speculative decode together because the PR spans all of those layers.
+
+### Open PR #40811 - BF16 input support for persistent topK - DeepSeekV4
+
+- Link: https://github.com/vllm-project/vllm/pull/40811
+- State: open
+- Diff coverage: full diff reviewed via GitHub API, `3` files, `886`
+  additions, `330` deletions
+- Motivation:
+  - The persistent top-k path used by the DeepSeek sparse indexer assumed FP32
+    ordering logic. BF16 inputs need ordered-key conversion and dedicated test
+    coverage.
+- Key implementation:
+  - Adds BF16 ordered-key helpers and dtype traits to `persistent_topk.cuh`.
+  - Makes `topk.cu` explicitly support both `float32` and `bfloat16`.
+  - Extends `tests/kernels/test_top_k_per_row.py` with BF16 decode and long
+    context cases.
+- Key code excerpts:
+
+```diff
++__device__ __forceinline__ auto convert_to_uint16_bf16(__nv_bfloat16 x)
++    -> uint16_t {
++  uint16_t bits;
++  memcpy(&bits, &x, sizeof(uint16_t));
++  return (bits & 0x8000) ? static_cast<uint16_t>(~bits)
++                         : static_cast<uint16_t>(bits | 0x8000);
++}
+```
+
+```diff
+-// Persistent TopK kernel for DeepSeek V3 sparse attention indexer.
++// Persistent TopK kernel for DeepSeek V3/V4 sparse attention indexer.
++// Supports float32 and bfloat16 input dtypes.
+```
+
+- Reviewed files:
+  - kernel: `csrc/persistent_topk.cuh`, `csrc/topk.cu`
+  - tests: `tests/kernels/test_top_k_per_row.py`
+- Validation implications:
+  - Re-run the kernel suite on CUDA after merge.
+  - Keep BF16 and FP32 lanes separate when debugging DeepSeek V4 indexer output,
+    because this patch changes the dtype-ordering logic rather than only adding
+    a new call site.
+
+### Open PR #40806 - Fix the DSML token leakage in DSV4/3.2
+
+- Link: https://github.com/vllm-project/vllm/pull/40806
+- State: open
+- Diff coverage: full diff reviewed via GitHub API, `2` files, `30` additions,
+  `1` deletion
+- Motivation:
+  - When the `<｜DSML｜function_calls>` start token arrived split across streaming
+    chunks, the parser could emit partial sentinel bytes as plain content.
+  - DeepSeek V4 uses a sibling DSML grammar, so the parser had to buffer partial
+    prefixes instead of forwarding them.
+- Key implementation:
+  - Precomputes all strict prefixes of the start token.
+  - Adds `_is_potential_tool_call_prefix(...)` and returns `None` while the
+    sentinel is still incomplete.
+  - Adds a chunk-size-1 regression test to guarantee no token leakage.
+- Key code excerpts:
+
+```diff
++self._start_prefixes = {
++    self.tool_call_start_token[:i]
++    for i in range(1, len(self.tool_call_start_token))
++}
+...
++elif self._is_potential_tool_call_prefix(current_text):
++    return None
+```
+
+```diff
++def test_no_leakage_during_chunked_streaming(self, parser):
++    full_text = build_tool_call("get_weather", {"location": "SF"})
++    deltas = self._stream_chunked(parser, full_text, chunk_size=1)
++    assert "<｜DSML｜function_calls>" not in content
+```
+
+- Reviewed files:
+  - runtime: `vllm/tool_parsers/deepseekv32_tool_parser.py`
+  - tests: `tests/tool_parsers/test_deepseekv32_tool_parser.py`
+- Validation implications:
+  - Even before a DeepSeek V4 parser lands, this is relevant because V4 tooling
+    builds on the same DSML streaming behavior.
+  - Streaming tool-call tests need to cover partial-sentinel chunk boundaries,
+    not only full-token boundaries.

--- a/skills/model-optimization/vllm/vllm-ernie45-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-ernie45-optimization/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: vllm-ernie45-optimization
+description: PR-backed optimization manual for Ernie4.5 / Ernie4.5-VL in vLLM. Use when Codex needs to audit, debug, extend, or document Baidu Ernie4.5 text/VL/MoE runtime, vision rotary, and long-input stability.
+---
+
+# vLLM Ernie4.5 / Ernie4.5-VL Optimization
+
+## Overview
+
+This skill covers Baidu Ernie4.5 text/VL/MoE runtime, vision rotary, and long-input stability.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/ernie45/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/ernie45.py`
+- `vllm/vllm/model_executor/models/ernie45_moe.py`
+- `vllm/vllm/model_executor/models/ernie45_vl.py`
+
+## Current Main Summary
+
+- Ernie4.5 spans dense, MoE, and VL paths in vLLM.
+- The highest-risk work items are shared-expert behavior, VL rotary/timestamp logic, and long-input stability.
+
+## Key Landed PRs
+
+- [#20220](https://github.com/vllm-project/vllm/pull/20220) `Add Ernie4.5 and Ernie4.5MoE Model Support`: Landed text and MoE support.
+- [#21717](https://github.com/vllm-project/vllm/pull/21717) `Fix Ernie4_5_MoeForCausalLM shared experts`: Fixed shared-expert correctness.
+- [#22514](https://github.com/vllm-project/vllm/pull/22514) `Add Ernie4.5 VL Model Support`: Added the multimodal Ernie4.5-VL lane.
+- [#24074](https://github.com/vllm-project/vllm/pull/24074) `Fix Ernie4.5-VL hanging on long inputs`: Closed a production long-input stall.
+- [#31274](https://github.com/vllm-project/vllm/pull/31274) `Support video metadata for timestamp rendering`: Improved VL video output fidelity.
+
+## Validation Lanes
+
+- Startup on the current vLLM mainline checkpoint.
+- Re-run the parser, quantization, MTP, or multimodal lane that matches this family.
+- Re-check tests after touching loader or processor code.

--- a/skills/model-optimization/vllm/vllm-ernie45-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-ernie45-optimization/references/pr-history.md
@@ -1,0 +1,43 @@
+# vLLM Ernie4.5 / Ernie4.5-VL PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Scope: Baidu Ernie4.5 text/VL/MoE runtime, vision rotary, and long-input stability.
+
+## Landed PRs
+
+### PR #20220 - Add Ernie4.5 and Ernie4.5MoE Model Support
+
+- Link: https://github.com/vllm-project/vllm/pull/20220
+- Why it mattered: Landed text and MoE support.
+- Runtime path: vllm/vllm/model_executor/models/ernie45.py, vllm/vllm/model_executor/models/ernie45_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #21717 - Fix Ernie4_5_MoeForCausalLM shared experts
+
+- Link: https://github.com/vllm-project/vllm/pull/21717
+- Why it mattered: Fixed shared-expert correctness.
+- Runtime path: vllm/vllm/model_executor/models/ernie45.py, vllm/vllm/model_executor/models/ernie45_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #22514 - Add Ernie4.5 VL Model Support
+
+- Link: https://github.com/vllm-project/vllm/pull/22514
+- Why it mattered: Added the multimodal Ernie4.5-VL lane.
+- Runtime path: vllm/vllm/model_executor/models/ernie45.py, vllm/vllm/model_executor/models/ernie45_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #24074 - Fix Ernie4.5-VL hanging on long inputs
+
+- Link: https://github.com/vllm-project/vllm/pull/24074
+- Why it mattered: Closed a production long-input stall.
+- Runtime path: vllm/vllm/model_executor/models/ernie45.py, vllm/vllm/model_executor/models/ernie45_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #31274 - Support video metadata for timestamp rendering
+
+- Link: https://github.com/vllm-project/vllm/pull/31274
+- Why it mattered: Improved VL video output fidelity.
+- Runtime path: vllm/vllm/model_executor/models/ernie45.py, vllm/vllm/model_executor/models/ernie45_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/vllm/vllm-gemma4-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-gemma4-optimization/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: vllm-gemma4-optimization
+description: PR-backed optimization manual for Gemma 4 in vLLM. Use when Codex needs to audit, debug, extend, or document Gemma 4 text, MoE, multimodal, reasoning, tool use, and quantized MoE serving.
+---
+
+# vLLM Gemma 4 Optimization
+
+## Overview
+
+This skill covers Gemma 4 text, MoE, multimodal, reasoning, tool use, and quantized MoE serving.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/gemma4/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/gemma4.py`
+- `vllm/vllm/model_executor/models/gemma4_mm.py`
+
+## Current Main Summary
+
+- Gemma 4 is a genuinely multi-surface family: text, MoE, multimodal, tool calling, and speculative decoding all matter.
+- Fast prefill, quantized MoE, and tool-parser correctness are the main areas that changed rapidly after bring-up.
+
+## Key Landed PRs
+
+- [#38826](https://github.com/vllm-project/vllm/pull/38826) `Implement Google Gemma 4 architecture support`: Initial Gemma 4 text/MoE/multimodal landing.
+- [#38879](https://github.com/vllm-project/vllm/pull/38879) `Enable Fast Prefill Optimization`: Added YOCO KV-sharing based fast prefill for Gemma4.
+- [#39045](https://github.com/vllm-project/vllm/pull/39045) `Support quantized MoE`: Extended Gemma4 to quantized MoE checkpoints.
+- [#38844](https://github.com/vllm-project/vllm/pull/38844) `Enable Gemma4ForCausalLM to load LoRA adapters correctly`: Fixed adapter naming/load behavior.
+- [#39450](https://github.com/vllm-project/vllm/pull/39450) `Add Gemma4 Eagle3 support`: Enabled speculative decode for Gemma4.
+
+## Validation Lanes
+
+- Startup on the current vLLM mainline checkpoint.
+- Re-run the parser, quantization, MTP, or multimodal lane that matches this family.
+- Re-check tests after touching loader or processor code.

--- a/skills/model-optimization/vllm/vllm-gemma4-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-gemma4-optimization/references/pr-history.md
@@ -1,0 +1,43 @@
+# vLLM Gemma 4 PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Scope: Gemma 4 text, MoE, multimodal, reasoning, tool use, and quantized MoE serving.
+
+## Landed PRs
+
+### PR #38826 - Implement Google Gemma 4 architecture support
+
+- Link: https://github.com/vllm-project/vllm/pull/38826
+- Why it mattered: Initial Gemma 4 text/MoE/multimodal landing.
+- Runtime path: vllm/vllm/model_executor/models/gemma4.py, vllm/vllm/model_executor/models/gemma4_mm.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #38879 - Enable Fast Prefill Optimization
+
+- Link: https://github.com/vllm-project/vllm/pull/38879
+- Why it mattered: Added YOCO KV-sharing based fast prefill for Gemma4.
+- Runtime path: vllm/vllm/model_executor/models/gemma4.py, vllm/vllm/model_executor/models/gemma4_mm.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #39045 - Support quantized MoE
+
+- Link: https://github.com/vllm-project/vllm/pull/39045
+- Why it mattered: Extended Gemma4 to quantized MoE checkpoints.
+- Runtime path: vllm/vllm/model_executor/models/gemma4.py, vllm/vllm/model_executor/models/gemma4_mm.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #38844 - Enable Gemma4ForCausalLM to load LoRA adapters correctly
+
+- Link: https://github.com/vllm-project/vllm/pull/38844
+- Why it mattered: Fixed adapter naming/load behavior.
+- Runtime path: vllm/vllm/model_executor/models/gemma4.py, vllm/vllm/model_executor/models/gemma4_mm.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #39450 - Add Gemma4 Eagle3 support
+
+- Link: https://github.com/vllm-project/vllm/pull/39450
+- Why it mattered: Enabled speculative decode for Gemma4.
+- Runtime path: vllm/vllm/model_executor/models/gemma4.py, vllm/vllm/model_executor/models/gemma4_mm.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/vllm/vllm-glm-vlm-ocr-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-glm-vlm-ocr-optimization/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: vllm-glm-vlm-ocr-optimization
+description: PR-backed optimization manual for GLM VLM / OCR in vLLM. Use when Codex needs to audit, debug, extend, or document GLM-4V, GLM-4.1V, GLM-OCR, GLM visual processor, MRoPE, video, and OCR MTP behavior in vLLM.
+---
+
+# vLLM GLM VLM / OCR Optimization
+
+## Overview
+
+This skill covers GLM-4V, GLM-4.1V, GLM-OCR, GLM visual processor, MRoPE, video, and OCR MTP behavior in vLLM.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/glm-vlm-ocr/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/glm4v.py`
+- `vllm/vllm/model_executor/models/glm4_1v.py`
+- `vllm/vllm/model_executor/models/glm_ocr.py`
+
+## Current Main Summary
+
+- GLM visual/OCR support in vLLM spans classic GLM4V, newer GLM4.1V, and GLM-OCR-specific processor paths.
+- The main failures are processor-schema drift, MRoPE/video position handling, and OCR-specific weight or patch-merger mismatches.
+
+## Key Landed PRs
+
+- [#9242](https://github.com/vllm-project/vllm/pull/9242) `Add GLM-4v support`: Landed the original GLM4V multimodal model path.
+- [#19331](https://github.com/vllm-project/vllm/pull/19331) `Add GLM4.1V model`: Extended the family to the newer GLM4.1V checkpoint layout and vision stack.
+- [#27860](https://github.com/vllm-project/vllm/pull/27860) `Fix broken MRoPE for GLM-4.1V/GLM-4.5V`: Closed a positional-embedding bug with large practical accuracy impact on vision inputs.
+- [#33005](https://github.com/vllm-project/vllm/pull/33005) `GLM-OCR with MTP Support`: Added OCR-specific draft / MTP support rather than text-only OCR loading.
+- [#33350](https://github.com/vllm-project/vllm/pull/33350) `Fix broken GLM-OCR initialization`: Fixed startup failures in the GLM-OCR path after the first bring-up.
+- [#37962](https://github.com/vllm-project/vllm/pull/37962) `GLM OCR Patch Merger context_dim`: Updated the patch-merger contract for newer OCR checkpoints.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- Single-image and multi-image GLM4V / GLM4.1V generation.
+- GLM-OCR document extraction and MTP startup.
+- Video / MRoPE correctness under transformers upgrades.

--- a/skills/model-optimization/vllm/vllm-glm-vlm-ocr-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-glm-vlm-ocr-optimization/references/pr-history.md
@@ -1,0 +1,56 @@
+# vLLM GLM VLM / OCR PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Scope: GLM-4V, GLM-4.1V, GLM-OCR, GLM visual processor, MRoPE, video, and OCR MTP behavior in vLLM.
+
+
+## Landed PRs
+
+### PR #9242 - Add GLM-4v support
+
+- Link: https://github.com/vllm-project/vllm/pull/9242
+- Why it mattered: Landed the original GLM4V multimodal model path.
+- Runtime path: vllm/vllm/model_executor/models/glm4v.py, vllm/vllm/model_executor/models/glm4_1v.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #19331 - Add GLM4.1V model
+
+- Link: https://github.com/vllm-project/vllm/pull/19331
+- Why it mattered: Extended the family to the newer GLM4.1V checkpoint layout and vision stack.
+- Runtime path: vllm/vllm/model_executor/models/glm4v.py, vllm/vllm/model_executor/models/glm4_1v.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #27860 - Fix broken MRoPE for GLM-4.1V/GLM-4.5V
+
+- Link: https://github.com/vllm-project/vllm/pull/27860
+- Why it mattered: Closed a positional-embedding bug with large practical accuracy impact on vision inputs.
+- Runtime path: vllm/vllm/model_executor/models/glm4v.py, vllm/vllm/model_executor/models/glm4_1v.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #33005 - GLM-OCR with MTP Support
+
+- Link: https://github.com/vllm-project/vllm/pull/33005
+- Why it mattered: Added OCR-specific draft / MTP support rather than text-only OCR loading.
+- Runtime path: vllm/vllm/model_executor/models/glm4v.py, vllm/vllm/model_executor/models/glm4_1v.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #33350 - Fix broken GLM-OCR initialization
+
+- Link: https://github.com/vllm-project/vllm/pull/33350
+- Why it mattered: Fixed startup failures in the GLM-OCR path after the first bring-up.
+- Runtime path: vllm/vllm/model_executor/models/glm4v.py, vllm/vllm/model_executor/models/glm4_1v.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #37962 - GLM OCR Patch Merger context_dim
+
+- Link: https://github.com/vllm-project/vllm/pull/37962
+- Why it mattered: Updated the patch-merger contract for newer OCR checkpoints.
+- Runtime path: vllm/vllm/model_executor/models/glm4v.py, vllm/vllm/model_executor/models/glm4_1v.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-glm45-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-glm45-optimization/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: vllm-glm45-optimization
+description: PR-backed optimization manual for GLM-4.5 / 4.5V in vLLM. Use when Codex needs to audit, debug, extend, or document GLM-4.5 text, GLM-4.5V, GLM-4.5-Air, shared MoE routing, and tool/reasoning parser behavior in vLLM.
+---
+
+# vLLM GLM-4.5 / 4.5V Optimization
+
+## Overview
+
+This skill covers GLM-4.5 text, GLM-4.5V, GLM-4.5-Air, shared MoE routing, and tool/reasoning parser behavior in vLLM.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/glm45/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/glm4.py`
+- `vllm/vllm/model_executor/models/glm4_moe.py`
+- `vllm/vllm/model_executor/models/glm4v.py`
+
+## Current Main Summary
+
+- The GLM-4.5 lane is where vLLM reorganized the GLM family around text, MoE, and vision variants.
+- Most regressions are in MoE gate behavior, tie-word-embedding policy, and vendor-specific fused MoE tuning.
+
+## Key Landed PRs
+
+- [#22171](https://github.com/vllm-project/vllm/pull/22171) `Modify the organization of GLM series`: Reworked the family layout so 4.5-era models reused a cleaner GLM structure.
+- [#22460](https://github.com/vllm-project/vllm/pull/22460) `not tie_word_embeddings for glm-4.5 and glm-4.5v`: Aligned the loader with the real 4.5 checkpoint contract instead of forcing tied embeddings.
+- [#22832](https://github.com/vllm-project/vllm/pull/22832) `Modify the gate implementation of glm4_moe`: Changed the GLM4.5 MoE gating path used by text and VL variants.
+- [#23695](https://github.com/vllm-project/vllm/pull/23695) `Add triton fused moe config for GLM-4.5-Air-FP8 on B200`: Added a production kernel-tuning lane for the 4.5 Air FP8 deployment path.
+- [#24589](https://github.com/vllm-project/vllm/pull/24589) `Add documentation for GLM-4.5 series tool-calling and reasoning parser`: Codified the parser choices needed to serve 4.5 reasoning / tool checkpoints correctly.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- GLM-4.5 and GLM-4.5-Air text generation.
+- GLM-4.5V startup with image inputs.
+- Tool calling and reasoning parser smoke tests.
+- FP8 fused-MoE launch on Blackwell where relevant.

--- a/skills/model-optimization/vllm/vllm-glm45-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-glm45-optimization/references/pr-history.md
@@ -1,0 +1,49 @@
+# vLLM GLM-4.5 / 4.5V PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Scope: GLM-4.5 text, GLM-4.5V, GLM-4.5-Air, shared MoE routing, and tool/reasoning parser behavior in vLLM.
+
+
+## Landed PRs
+
+### PR #22171 - Modify the organization of GLM series
+
+- Link: https://github.com/vllm-project/vllm/pull/22171
+- Why it mattered: Reworked the family layout so 4.5-era models reused a cleaner GLM structure.
+- Runtime path: vllm/vllm/model_executor/models/glm4.py, vllm/vllm/model_executor/models/glm4_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #22460 - not tie_word_embeddings for glm-4.5 and glm-4.5v
+
+- Link: https://github.com/vllm-project/vllm/pull/22460
+- Why it mattered: Aligned the loader with the real 4.5 checkpoint contract instead of forcing tied embeddings.
+- Runtime path: vllm/vllm/model_executor/models/glm4.py, vllm/vllm/model_executor/models/glm4_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #22832 - Modify the gate implementation of glm4_moe
+
+- Link: https://github.com/vllm-project/vllm/pull/22832
+- Why it mattered: Changed the GLM4.5 MoE gating path used by text and VL variants.
+- Runtime path: vllm/vllm/model_executor/models/glm4.py, vllm/vllm/model_executor/models/glm4_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #23695 - Add triton fused moe config for GLM-4.5-Air-FP8 on B200
+
+- Link: https://github.com/vllm-project/vllm/pull/23695
+- Why it mattered: Added a production kernel-tuning lane for the 4.5 Air FP8 deployment path.
+- Runtime path: vllm/vllm/model_executor/models/glm4.py, vllm/vllm/model_executor/models/glm4_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #24589 - Add documentation for GLM-4.5 series tool-calling and reasoning parser
+
+- Link: https://github.com/vllm-project/vllm/pull/24589
+- Why it mattered: Codified the parser choices needed to serve 4.5 reasoning / tool checkpoints correctly.
+- Runtime path: vllm/vllm/model_executor/models/glm4.py, vllm/vllm/model_executor/models/glm4_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-glm46-glm47-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-glm46-glm47-optimization/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: vllm-glm46-glm47-optimization
+description: PR-backed optimization manual for GLM-4.6 / 4.7 in vLLM. Use when Codex needs to audit, debug, extend, or document GLM-4.6, GLM-4.6V, GLM-4.7, GLM-4.7-Flash, GLM-Lite, and the parser / quant / fused-MoE deltas after the 4.5 generation.
+---
+
+# vLLM GLM-4.6 / 4.7 Optimization
+
+## Overview
+
+This skill covers GLM-4.6, GLM-4.6V, GLM-4.7, GLM-4.7-Flash, GLM-Lite, and the parser / quant / fused-MoE deltas after the 4.5 generation.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/glm46-glm47/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/glm4.py`
+- `vllm/vllm/model_executor/models/glm4_moe.py`
+- `vllm/vllm/model_executor/models/glm4v.py`
+
+## Current Main Summary
+
+- The 4.6/4.7 generation mainly extends the 4.5 base with new tuning tables, parser behavior, and Lite variants.
+- AWQ / Marlin compatibility and content-normalization in tool parsing are the recurring pitfalls.
+
+## Key Landed PRs
+
+- [#26818](https://github.com/vllm-project/vllm/pull/26818) `Add MoE tunings for GLM 4.6-FP8 and GLM 4.5 Air on B200`: Added fused-MoE tuning configs for the new Blackwell deployment lane.
+- [#30210](https://github.com/vllm-project/vllm/pull/30210) `Fix glm46 awq marlin moe compatibility`: Closed an incompatibility between GLM-4.6 AWQ checkpoints and Marlin MoE assumptions.
+- [#30876](https://github.com/vllm-project/vllm/pull/30876) `GLM-4.7 Tool Parser and Doc Update`: Brought parser behavior and docs up to date for 4.7 / 4.7-Flash.
+- [#31386](https://github.com/vllm-project/vllm/pull/31386) `GLM Model support for GLM-Lite`: Extended the same runtime family to the Lite checkpoint line.
+- [#37386](https://github.com/vllm-project/vllm/pull/37386) `Improve tool call parsing and content normalization for glm47`: Fixed concrete parsing errors that surfaced in newer GLM-4.7 outputs.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- GLM-4.6 text and vision startup.
+- GLM-4.7 tool-call extraction and streaming normalization.
+- AWQ / Marlin launch for GLM-4.6 MoE.

--- a/skills/model-optimization/vllm/vllm-glm46-glm47-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-glm46-glm47-optimization/references/pr-history.md
@@ -1,0 +1,49 @@
+# vLLM GLM-4.6 / 4.7 PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Scope: GLM-4.6, GLM-4.6V, GLM-4.7, GLM-4.7-Flash, GLM-Lite, and the parser / quant / fused-MoE deltas after the 4.5 generation.
+
+
+## Landed PRs
+
+### PR #26818 - Add MoE tunings for GLM 4.6-FP8 and GLM 4.5 Air on B200
+
+- Link: https://github.com/vllm-project/vllm/pull/26818
+- Why it mattered: Added fused-MoE tuning configs for the new Blackwell deployment lane.
+- Runtime path: vllm/vllm/model_executor/models/glm4.py, vllm/vllm/model_executor/models/glm4_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #30210 - Fix glm46 awq marlin moe compatibility
+
+- Link: https://github.com/vllm-project/vllm/pull/30210
+- Why it mattered: Closed an incompatibility between GLM-4.6 AWQ checkpoints and Marlin MoE assumptions.
+- Runtime path: vllm/vllm/model_executor/models/glm4.py, vllm/vllm/model_executor/models/glm4_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #30876 - GLM-4.7 Tool Parser and Doc Update
+
+- Link: https://github.com/vllm-project/vllm/pull/30876
+- Why it mattered: Brought parser behavior and docs up to date for 4.7 / 4.7-Flash.
+- Runtime path: vllm/vllm/model_executor/models/glm4.py, vllm/vllm/model_executor/models/glm4_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #31386 - GLM Model support for GLM-Lite
+
+- Link: https://github.com/vllm-project/vllm/pull/31386
+- Why it mattered: Extended the same runtime family to the Lite checkpoint line.
+- Runtime path: vllm/vllm/model_executor/models/glm4.py, vllm/vllm/model_executor/models/glm4_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #37386 - Improve tool call parsing and content normalization for glm47
+
+- Link: https://github.com/vllm-project/vllm/pull/37386
+- Why it mattered: Fixed concrete parsing errors that surfaced in newer GLM-4.7 outputs.
+- Runtime path: vllm/vllm/model_executor/models/glm4.py, vllm/vllm/model_executor/models/glm4_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-glm5-glm51-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-glm5-glm51-optimization/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: vllm-glm5-glm51-optimization
+description: PR-backed optimization manual for GLM-5 / GLM-5.1 in vLLM. Use when Codex needs to audit, debug, extend, or document the current partial GLM-5 bring-up in vLLM, especially the `GlmMoeDsaForCausalLM` aliasing into the DeepSeek-V2/V3 runtime, rope interleave handling, and GLM-5 MTP correctness.
+---
+
+# vLLM GLM-5 / 5.1 Optimization
+
+## Overview
+
+GLM-5 support in vLLM is not a standalone `glm5.py` runtime. The current landed
+path adapts GLM-5 into the existing DeepSeek-V2/V3 MLA/MoE implementation and
+then fixes the GLM-5 MTP draft-model correctness bug separately.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: partially supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/glm5-glm51/README.zh.md`
+  and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the bar.
+For GLM-5, do not pretend support comes from the older `glm4*` modules; the
+actual landed path is the DeepSeek-based alias plus MTP follow-up.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/deepseek_v2.py`
+- `vllm/vllm/model_executor/models/registry.py`
+- `vllm/vllm/config/speculative.py`
+- `vllm/vllm/transformers_utils/model_arch_config_convertor.py`
+- `vllm/vllm/v1/spec_decode/eagle.py`
+- `vllm/tests/models/registry.py`
+- `vllm/tests/models/test_initialization.py`
+
+## Current Main Summary
+
+- `#34124` adds `GlmMoeDsaForCausalLM` as a DeepSeek-V2-derived runtime rather
+  than introducing a dedicated GLM-5 file.
+- The same PR also flips rope style through
+  `indexer_rope_interleave` and teaches speculative config conversion to treat
+  `glm_moe_dsa` like a DeepSeek MTP family.
+- `#34385` fixes GLM-5 MTP accuracy by explicitly sharing the target
+  `lm_head` into every MTP layer `shared_head.head`; without that, logits could
+  become zero or NaN.
+
+## Key Landed PRs
+
+- [#34124](https://github.com/vllm-project/vllm/pull/34124) `GLM adaptation`
+- [#34385](https://github.com/vllm-project/vllm/pull/34385) `Fix MTP accuracy for GLM-5`
+
+## Open Radar
+
+- Re-run PR search before claiming broader GLM-5 router, parser, or multimodal
+  support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- Plain GLM-5 launch through the `GlmMoeDsaForCausalLM` alias.
+- MTP correctness on held-out prompts after `#34385`.
+- Rope/interleaving checks when touching the DeepSeek indexer path, because the
+  GLM adaptation changed `is_neox_style` handling in `deepseek_v2.py`.
+
+## References
+
+- `references/pr-history.md`: diff-reviewed GLM-5 / 5.1 cards.

--- a/skills/model-optimization/vllm/vllm-glm5-glm51-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-glm5-glm51-optimization/references/pr-history.md
@@ -1,0 +1,97 @@
+# vLLM GLM-5 / 5.1 PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: partially supported on current mainline
+- Scope: GLM-5 family adaptation into the DeepSeek runtime plus MTP accuracy
+  stabilization
+
+## Landed PRs
+
+### PR #34124 - GLM adaptation
+
+- Link: https://github.com/vllm-project/vllm/pull/34124
+- State: merged
+- Diff coverage: full diff reviewed, `7` files, `13` additions, `3` deletions
+- Motivation:
+  - GLM-5 checkpoints expose a `glm_moe_dsa` architecture that was close to the
+    DeepSeek MLA/MoE runtime, but vLLM had no registry alias or config
+    conversion for it.
+  - GLM-5 MTP also needed to be routed through the existing `deepseek_mtp`
+    speculative machinery.
+- Key implementation:
+  - Registers `GlmMoeDsaForCausalLM` in `registry.py` but maps it to the
+    `deepseek_v2` module.
+  - Adds a trivial `GlmMoeDsaForCausalLM(DeepseekV2ForCausalLM)` subclass.
+  - Treats `glm_moe_dsa` like `deepseek_mtp` in speculative config override.
+  - Extends the arch config convertor and initialization/test registry.
+  - Changes rope style selection to respect `indexer_rope_interleave`.
+- Key code excerpts:
+
+```diff
++class GlmMoeDsaForCausalLM(DeepseekV2ForCausalLM):
++    pass
+```
+
+```diff
++    "GlmMoeDsaForCausalLM": ("deepseek_v2", "GlmMoeDsaForCausalLM"),
+```
+
+```diff
+-        if hf_config.model_type in ("deepseek_v3", "deepseek_v32"):
++        if hf_config.model_type in ("deepseek_v3", "deepseek_v32", "glm_moe_dsa"):
+             hf_config.model_type = "deepseek_mtp"
+```
+
+```diff
+-                is_neox_style=True,
++                is_neox_style=not getattr(config, "indexer_rope_interleave", True),
+```
+
+- Reviewed files:
+  - runtime: `vllm/model_executor/models/deepseek_v2.py`,
+    `vllm/model_executor/models/registry.py`
+  - config/spec decode:
+    `vllm/config/speculative.py`,
+    `vllm/transformers_utils/model_arch_config_convertor.py`
+  - tests: `tests/models/registry.py`, `tests/models/test_initialization.py`
+- Validation implications:
+  - GLM-5 support should be validated against the DeepSeek runtime, not the
+    older `glm4*` files.
+  - Rope and speculative decode regressions can affect both GLM-5 and DeepSeek
+    because they now share the same path.
+
+### PR #34385 - Fix MTP accuracy for GLM-5
+
+- Link: https://github.com/vllm-project/vllm/pull/34385
+- State: merged
+- Diff coverage: full diff reviewed, `1` file, `18` additions
+- Motivation:
+  - GLM-5 MTP startup could succeed while still producing bad logits because the
+    target `lm_head` was not propagated into each MTP layer's `shared_head.head`.
+- Key implementation:
+  - Walks through the draft model layers inside `SpecDecodeBaseProposer`.
+  - Replaces every `shared_head.head` with the target language model's
+    `lm_head`, not just `self.model.lm_head`.
+- Key code excerpts:
+
+```diff
++            inner = getattr(self.model, "model", None)
++            layers = getattr(inner, "layers", None) if inner else None
++            if layers is not None:
++                items = layers.values() if isinstance(layers, nn.ModuleDict) else layers
++                for layer in items:
++                    sh = getattr(layer, "shared_head", None)
++                    if sh is not None and hasattr(sh, "head"):
++                        del sh.head
++                        sh.head = target_language_model.lm_head
+```
+
+- Reviewed files:
+  - runtime/spec decode: `vllm/v1/spec_decode/eagle.py`
+- Validation implications:
+  - When GLM-5 MTP produces NaN or zero logits, inspect shared-head weight
+    sharing before blaming sampling or tokenizer code.
+  - Any future refactor of `eagle.py` can silently regress GLM-5 MTP because the
+    fix lives in generic speculative infrastructure, not in a GLM-only module.

--- a/skills/model-optimization/vllm/vllm-glm5-glm51-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-glm5-glm51-optimization/references/pr-history.md
@@ -25,7 +25,7 @@ Evidence snapshot:
     `deepseek_v2` module.
   - Adds a trivial `GlmMoeDsaForCausalLM(DeepseekV2ForCausalLM)` subclass.
   - Treats `glm_moe_dsa` like `deepseek_mtp` in speculative config override.
-  - Extends the arch config convertor and initialization/test registry.
+  - Extends the arch config converter and initialization/test registry.
   - Changes rope style selection to respect `indexer_rope_interleave`.
 - Key code excerpts:
 

--- a/skills/model-optimization/vllm/vllm-gpt-oss-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-gpt-oss-optimization/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: vllm-gpt-oss-optimization
+description: PR-backed optimization manual for GPT-OSS in vLLM. Use when Codex needs to audit, debug, extend, or document OpenAI GPT-OSS MoE, MXFP4/FP8 quantization, DP/EP, reasoning parser, tool calling, and Eagle/spec decode.
+---
+
+# vLLM GPT-OSS Optimization
+
+## Overview
+
+This skill covers OpenAI GPT-OSS MoE, MXFP4/FP8 quantization, DP/EP, reasoning parser, tool calling, and Eagle/spec decode.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/gpt-oss/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/gpt_oss.py`
+
+## Current Main Summary
+
+- GPT-OSS is a flagship MoE family in vLLM.
+- Quantization, expert-parallel topology, and reasoning/tool parser behavior all evolved quickly and need per-PR tracking.
+
+## Key Landed PRs
+
+- [#22327](https://github.com/vllm-project/vllm/pull/22327) `Add GPT-OSS model code and config`: Initial GPT-OSS landing in vLLM.
+- [#23819](https://github.com/vllm-project/vllm/pull/23819) `Support DP+EP for GPT-OSS with FlashInfer trtllm-gen MoE`: Opened large-scale GPT-OSS serving topologies.
+- [#25246](https://github.com/vllm-project/vllm/pull/25246) `Enable Eagle3 speculative decoding for GPT-OSS model`: Added draft-model acceleration.
+- [#25515](https://github.com/vllm-project/vllm/pull/25515) `Structure_Tag support for gpt-oss tool-call in cot`: Improved tool calling in reasoning-mode outputs.
+- [#30647](https://github.com/vllm-project/vllm/pull/30647) `Eliminate padding and slicing op for GPT-OSS with Flashinfer MXFP4 MXFP8 MoE`: Targeted the hot MXFP4/MXFP8 path for throughput.
+
+## Validation Lanes
+
+- Startup on the current vLLM mainline checkpoint.
+- Re-run the parser, quantization, MTP, or multimodal lane that matches this family.
+- Re-check tests after touching loader or processor code.

--- a/skills/model-optimization/vllm/vllm-gpt-oss-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-gpt-oss-optimization/references/pr-history.md
@@ -1,0 +1,43 @@
+# vLLM GPT-OSS PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Scope: OpenAI GPT-OSS MoE, MXFP4/FP8 quantization, DP/EP, reasoning parser, tool calling, and Eagle/spec decode.
+
+## Landed PRs
+
+### PR #22327 - Add GPT-OSS model code and config
+
+- Link: https://github.com/vllm-project/vllm/pull/22327
+- Why it mattered: Initial GPT-OSS landing in vLLM.
+- Runtime path: vllm/vllm/model_executor/models/gpt_oss.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #23819 - Support DP+EP for GPT-OSS with FlashInfer trtllm-gen MoE
+
+- Link: https://github.com/vllm-project/vllm/pull/23819
+- Why it mattered: Opened large-scale GPT-OSS serving topologies.
+- Runtime path: vllm/vllm/model_executor/models/gpt_oss.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #25246 - Enable Eagle3 speculative decoding for GPT-OSS model
+
+- Link: https://github.com/vllm-project/vllm/pull/25246
+- Why it mattered: Added draft-model acceleration.
+- Runtime path: vllm/vllm/model_executor/models/gpt_oss.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #25515 - Structure_Tag support for gpt-oss tool-call in cot
+
+- Link: https://github.com/vllm-project/vllm/pull/25515
+- Why it mattered: Improved tool calling in reasoning-mode outputs.
+- Runtime path: vllm/vllm/model_executor/models/gpt_oss.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #30647 - Eliminate padding and slicing op for GPT-OSS with Flashinfer MXFP4 MXFP8 MoE
+
+- Link: https://github.com/vllm-project/vllm/pull/30647
+- Why it mattered: Targeted the hot MXFP4/MXFP8 path for throughput.
+- Runtime path: vllm/vllm/model_executor/models/gpt_oss.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/vllm/vllm-hunyuan3-preview-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-hunyuan3-preview-optimization/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: vllm-hunyuan3-preview-optimization
+description: PR-backed optimization manual for Hunyuan 3 Preview in vLLM. Use when Codex needs to audit, debug, extend, or document Adjacent Hunyuan dense / OCR / VL support in vLLM relevant to Hunyuan 3 Preview planning, without a dedicated `Hunyuan3Preview` mainline alias yet.
+---
+
+# vLLM Hunyuan 3 Preview Optimization
+
+## Overview
+
+This skill covers Adjacent Hunyuan dense / OCR / VL support in vLLM relevant to Hunyuan 3 Preview planning, without a dedicated `Hunyuan3Preview` mainline alias yet.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: partially supported or only adjacent architectures landed on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/hunyuan3-preview/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/hunyuan_v1.py`
+- `vllm/vllm/model_executor/models/hunyuan_vision.py`
+
+## Current Main Summary
+
+- vLLM does not currently expose a dedicated Hunyuan 3 Preview model alias.
+- The closest landed evidence is the Hunyuan dense, Hunyuan OCR, and HunyuanVL / Eagle work already in tree.
+
+## Key Landed PRs
+
+- [#21368](https://github.com/vllm-project/vllm/pull/21368) `Add Hunyuan V1 Dense Model support`: Brought the dense Hunyuan line into vLLM mainline.
+- [#29327](https://github.com/vllm-project/vllm/pull/29327) `Add HunyuanOCR support`: Extended the family to OCR workloads instead of text-only generation.
+- [#33035](https://github.com/vllm-project/vllm/pull/33035) `Eagle3 support for HunyuanVL & Hunyuan`: Added speculative decoding support on top of the Hunyuan family.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- Do not equate Hunyuan V1 / OCR / VL with a landed Hunyuan 3 Preview runtime.
+- If exact Hunyuan 3 Preview parity matters, re-check open PR and registry state first.

--- a/skills/model-optimization/vllm/vllm-hunyuan3-preview-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-hunyuan3-preview-optimization/references/pr-history.md
@@ -1,0 +1,34 @@
+# vLLM Hunyuan 3 Preview PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: partially supported or only adjacent architectures landed on current mainline
+- Scope: Adjacent Hunyuan dense / OCR / VL support in vLLM relevant to Hunyuan 3 Preview planning, without a dedicated `Hunyuan3Preview` mainline alias yet.
+
+## Landed PRs
+
+### PR #21368 - Add Hunyuan V1 Dense Model support
+
+- Link: https://github.com/vllm-project/vllm/pull/21368
+- Why it mattered: Brought the dense Hunyuan line into vLLM mainline.
+- Runtime path: vllm/vllm/model_executor/models/hunyuan_v1.py, vllm/vllm/model_executor/models/hunyuan_vision.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #29327 - Add HunyuanOCR support
+
+- Link: https://github.com/vllm-project/vllm/pull/29327
+- Why it mattered: Extended the family to OCR workloads instead of text-only generation.
+- Runtime path: vllm/vllm/model_executor/models/hunyuan_v1.py, vllm/vllm/model_executor/models/hunyuan_vision.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #33035 - Eagle3 support for HunyuanVL & Hunyuan
+
+- Link: https://github.com/vllm-project/vllm/pull/33035
+- Why it mattered: Added speculative decoding support on top of the Hunyuan family.
+- Runtime path: vllm/vllm/model_executor/models/hunyuan_v1.py, vllm/vllm/model_executor/models/hunyuan_vision.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-intern-s1-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-intern-s1-optimization/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: vllm-intern-s1-optimization
+description: PR-backed optimization manual for Intern-S1 in vLLM. Use when Codex needs to audit, debug, extend, or document Intern-S1 language and video-aware serving, processor integration, and tool/reasoning parser behavior.
+---
+
+# vLLM Intern-S1 Optimization
+
+## Overview
+
+This skill covers Intern-S1 language and video-aware serving, processor integration, and tool/reasoning parser behavior.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/intern-s1/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/interns1.py`
+- `vllm/vllm/model_executor/models/interns1_pro.py`
+
+## Current Main Summary
+
+- Intern-S1 leans heavily on shared InternVL processor code in vLLM.
+- Most regressions come from processor compatibility and video-aware serving rather than the text stack alone.
+
+## Key Landed PRs
+
+- [#21628](https://github.com/vllm-project/vllm/pull/21628) `Support Intern-S1`: Initial Intern-S1 support in vLLM.
+- [#21671](https://github.com/vllm-project/vllm/pull/21671) `Add video support for Intern-S1`: Extended the family beyond static images.
+- [#22417](https://github.com/vllm-project/vllm/pull/22417) `Fix wrong method name in Intern-S1 image processor`: Patched a processor bug after bring-up.
+- [#33636](https://github.com/vllm-project/vllm/pull/33636) `Intern-S1-Pro`: Added the Pro generation / alias path.
+
+## Validation Lanes
+
+- Startup on the current vLLM mainline checkpoint.
+- Re-run the parser, quantization, MTP, or multimodal lane that matches this family.
+- Re-check tests after touching loader or processor code.

--- a/skills/model-optimization/vllm/vllm-intern-s1-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-intern-s1-optimization/references/pr-history.md
@@ -1,0 +1,36 @@
+# vLLM Intern-S1 PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Scope: Intern-S1 language and video-aware serving, processor integration, and tool/reasoning parser behavior.
+
+## Landed PRs
+
+### PR #21628 - Support Intern-S1
+
+- Link: https://github.com/vllm-project/vllm/pull/21628
+- Why it mattered: Initial Intern-S1 support in vLLM.
+- Runtime path: vllm/vllm/model_executor/models/interns1.py, vllm/vllm/model_executor/models/interns1_pro.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #21671 - Add video support for Intern-S1
+
+- Link: https://github.com/vllm-project/vllm/pull/21671
+- Why it mattered: Extended the family beyond static images.
+- Runtime path: vllm/vllm/model_executor/models/interns1.py, vllm/vllm/model_executor/models/interns1_pro.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #22417 - Fix wrong method name in Intern-S1 image processor
+
+- Link: https://github.com/vllm-project/vllm/pull/22417
+- Why it mattered: Patched a processor bug after bring-up.
+- Runtime path: vllm/vllm/model_executor/models/interns1.py, vllm/vllm/model_executor/models/interns1_pro.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #33636 - Intern-S1-Pro
+
+- Link: https://github.com/vllm-project/vllm/pull/33636
+- Why it mattered: Added the Pro generation / alias path.
+- Runtime path: vllm/vllm/model_executor/models/interns1.py, vllm/vllm/model_executor/models/interns1_pro.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/vllm/vllm-internvl35-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-internvl35-optimization/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: vllm-internvl35-optimization
+description: PR-backed optimization manual for InternVL3.5 in vLLM. Use when Codex needs to audit, debug, extend, or document InternVL3.5 multimodal processor, video support, ViT DP / torch.compile, and backend compatibility.
+---
+
+# vLLM InternVL3.5 Optimization
+
+## Overview
+
+This skill covers InternVL3.5 multimodal processor, video support, ViT DP / torch.compile, and backend compatibility.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/internvl35/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/internvl.py`
+
+## Current Main Summary
+
+- InternVL3.5 is mostly a processor / encoder / video problem in vLLM.
+- Video handling, native HF loading, and backend compatibility dominate the risk surface.
+
+## Key Landed PRs
+
+- [#6514](https://github.com/vllm-project/vllm/pull/6514) `Initialize support for InternVL2 series models`: Historical base for current InternVL runtime code.
+- [#18499](https://github.com/vllm-project/vllm/pull/18499) `Initialize video input support for InternVL models`: Added video processing to the family.
+- [#23658](https://github.com/vllm-project/vllm/pull/23658) `Enable video support for InternVL3.5 models`: Carried video support into the 3.5 checkpoints.
+- [#23742](https://github.com/vllm-project/vllm/pull/23742) `Enable native HF format InternVL support`: Removed reliance on ad hoc checkpoint rewrites.
+- [#38049](https://github.com/vllm-project/vllm/pull/38049) `Add torch.compile support for InternVL vision encoder`: Modernized the encoder execution path.
+
+## Validation Lanes
+
+- Startup on the current vLLM mainline checkpoint.
+- Re-run the parser, quantization, MTP, or multimodal lane that matches this family.
+- Re-check tests after touching loader or processor code.

--- a/skills/model-optimization/vllm/vllm-internvl35-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-internvl35-optimization/references/pr-history.md
@@ -1,0 +1,43 @@
+# vLLM InternVL3.5 PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Scope: InternVL3.5 multimodal processor, video support, ViT DP / torch.compile, and backend compatibility.
+
+## Landed PRs
+
+### PR #6514 - Initialize support for InternVL2 series models
+
+- Link: https://github.com/vllm-project/vllm/pull/6514
+- Why it mattered: Historical base for current InternVL runtime code.
+- Runtime path: vllm/vllm/model_executor/models/internvl.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #18499 - Initialize video input support for InternVL models
+
+- Link: https://github.com/vllm-project/vllm/pull/18499
+- Why it mattered: Added video processing to the family.
+- Runtime path: vllm/vllm/model_executor/models/internvl.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #23658 - Enable video support for InternVL3.5 models
+
+- Link: https://github.com/vllm-project/vllm/pull/23658
+- Why it mattered: Carried video support into the 3.5 checkpoints.
+- Runtime path: vllm/vllm/model_executor/models/internvl.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #23742 - Enable native HF format InternVL support
+
+- Link: https://github.com/vllm-project/vllm/pull/23742
+- Why it mattered: Removed reliance on ad hoc checkpoint rewrites.
+- Runtime path: vllm/vllm/model_executor/models/internvl.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #38049 - Add torch.compile support for InternVL vision encoder
+
+- Link: https://github.com/vllm-project/vllm/pull/38049
+- Why it mattered: Modernized the encoder execution path.
+- Runtime path: vllm/vllm/model_executor/models/internvl.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/vllm/vllm-kimi-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-kimi-optimization/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: vllm-kimi-optimization
+description: PR-backed optimization manual for Kimi K2 / K2.5 / Linear / Audio / VL in vLLM. Use when Codex needs to audit, debug, extend, or document Kimi-VL, Kimi-Linear, Kimi-K2.5, Kimi-Audio, parser aliases, and quantized MLA behavior in vLLM.
+---
+
+# vLLM Kimi K2 / K2.5 / Linear / Audio / VL Optimization
+
+## Overview
+
+This skill covers Kimi-VL, Kimi-Linear, Kimi-K2.5, Kimi-Audio, parser aliases, and quantized MLA behavior in vLLM.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/kimi/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/kimi_vl.py`
+- `vllm/vllm/model_executor/models/kimi_linear.py`
+- `vllm/vllm/model_executor/models/kimi_k25.py`
+- `vllm/vllm/model_executor/models/kimi_audio.py`
+
+## Current Main Summary
+
+- The Kimi family in vLLM spans vision, linear-attention, K2.5, and audio checkpoints.
+- The most fragile areas are MLA plus FP8/NVFP4 loading, processor evolution, and parser alias compatibility between K2 and K2.5.
+
+## Key Landed PRs
+
+- [#16387](https://github.com/vllm-project/vllm/pull/16387) `Add Kimi-VL model support`: Landed the original Kimi-VL multimodal runtime.
+- [#27809](https://github.com/vllm-project/vllm/pull/27809) `Introduce Kimi Linear to vLLM`: Added the linear-attention Kimi family instead of only the VL path.
+- [#33131](https://github.com/vllm-project/vllm/pull/33131) `Kimi-K2.5`: Brought the K2.5 generation into mainline.
+- [#33876](https://github.com/vllm-project/vllm/pull/33876) `Fix Kimi-K2.5 NVFP4 checkpoints weight loading`: Closed a concrete launch blocker for quantized K2.5 checkpoints.
+- [#36127](https://github.com/vllm-project/vllm/pull/36127) `Add support for moonshotai/Kimi-Audio-7B-Instruct`: Extended the family to audio-conditioned serving.
+- [#37438](https://github.com/vllm-project/vllm/pull/37438) `Add Kimi-K2.5 reasoning/tool parser aliases`: Aligned parser aliases and tool-call IDs with the newer model outputs.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- K2.5 text and VL launch.
+- Kimi-Linear long-context inference.
+- Kimi-Audio processor and transcription path.
+- NVFP4 or FP8 MLA startup on K2.5.

--- a/skills/model-optimization/vllm/vllm-kimi-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-kimi-optimization/references/pr-history.md
@@ -1,0 +1,55 @@
+# vLLM Kimi K2 / K2.5 / Linear / Audio / VL PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Scope: Kimi-VL, Kimi-Linear, Kimi-K2.5, Kimi-Audio, parser aliases, and quantized MLA behavior in vLLM.
+
+## Landed PRs
+
+### PR #16387 - Add Kimi-VL model support
+
+- Link: https://github.com/vllm-project/vllm/pull/16387
+- Why it mattered: Landed the original Kimi-VL multimodal runtime.
+- Runtime path: vllm/vllm/model_executor/models/kimi_vl.py, vllm/vllm/model_executor/models/kimi_linear.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #27809 - Introduce Kimi Linear to vLLM
+
+- Link: https://github.com/vllm-project/vllm/pull/27809
+- Why it mattered: Added the linear-attention Kimi family instead of only the VL path.
+- Runtime path: vllm/vllm/model_executor/models/kimi_vl.py, vllm/vllm/model_executor/models/kimi_linear.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #33131 - Kimi-K2.5
+
+- Link: https://github.com/vllm-project/vllm/pull/33131
+- Why it mattered: Brought the K2.5 generation into mainline.
+- Runtime path: vllm/vllm/model_executor/models/kimi_vl.py, vllm/vllm/model_executor/models/kimi_linear.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #33876 - Fix Kimi-K2.5 NVFP4 checkpoints weight loading
+
+- Link: https://github.com/vllm-project/vllm/pull/33876
+- Why it mattered: Closed a concrete launch blocker for quantized K2.5 checkpoints.
+- Runtime path: vllm/vllm/model_executor/models/kimi_vl.py, vllm/vllm/model_executor/models/kimi_linear.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #36127 - Add support for moonshotai/Kimi-Audio-7B-Instruct
+
+- Link: https://github.com/vllm-project/vllm/pull/36127
+- Why it mattered: Extended the family to audio-conditioned serving.
+- Runtime path: vllm/vllm/model_executor/models/kimi_vl.py, vllm/vllm/model_executor/models/kimi_linear.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #37438 - Add Kimi-K2.5 reasoning/tool parser aliases
+
+- Link: https://github.com/vllm-project/vllm/pull/37438
+- Why it mattered: Aligned parser aliases and tool-call IDs with the newer model outputs.
+- Runtime path: vllm/vllm/model_executor/models/kimi_vl.py, vllm/vllm/model_executor/models/kimi_linear.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-llama4-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-llama4-optimization/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: vllm-llama4-optimization
+description: PR-backed optimization manual for Llama 4 in vLLM. Use when Codex needs to audit, debug, extend, or document Llama4 text and multimodal runtime, FP8/FP4 quantization, router behavior, long-context attention, and Eagle support.
+---
+
+# vLLM Llama 4 Optimization
+
+## Overview
+
+This skill covers Llama4 text and multimodal runtime, FP8/FP4 quantization, router behavior, long-context attention, and Eagle support.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/llama4/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/llama4.py`
+- `vllm/vllm/model_executor/models/mllama4.py`
+- `vllm/vllm/model_executor/models/llama4_eagle.py`
+
+## Current Main Summary
+
+- Llama4 is mature on the vLLM side but still sensitive to quantized MoE and long-context backend selection.
+- The multimodal path adds a separate vision-rotary and processor validation surface.
+
+## Key Landed PRs
+
+- [#16104](https://github.com/vllm-project/vllm/pull/16104) `Support Llama4 in vLLM`: Initial Llama4 landing.
+- [#20419](https://github.com/vllm-project/vllm/pull/20419) `Enable ModelOpt Llama4 fp8 checkpoint deployment`: Added ModelOpt FP8 coverage.
+- [#20591](https://github.com/vllm-project/vllm/pull/20591) `Llama4 EAGLE Support`: Opened speculative decoding for Llama4.
+- [#22511](https://github.com/vllm-project/vllm/pull/22511) `Fix Llama4 FlashInfer FP4 MoE issues`: Stabilized the FP4 MoE path.
+- [#25889](https://github.com/vllm-project/vllm/pull/25889) `Fix misplaced dtype cast in Llama4VisionRotaryEmbedding`: Patched a multimodal rotary bug.
+
+## Validation Lanes
+
+- Startup on the current vLLM mainline checkpoint.
+- Re-run the parser, quantization, MTP, or multimodal lane that matches this family.
+- Re-check tests after touching loader or processor code.

--- a/skills/model-optimization/vllm/vllm-llama4-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-llama4-optimization/references/pr-history.md
@@ -1,0 +1,43 @@
+# vLLM Llama 4 PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Scope: Llama4 text and multimodal runtime, FP8/FP4 quantization, router behavior, long-context attention, and Eagle support.
+
+## Landed PRs
+
+### PR #16104 - Support Llama4 in vLLM
+
+- Link: https://github.com/vllm-project/vllm/pull/16104
+- Why it mattered: Initial Llama4 landing.
+- Runtime path: vllm/vllm/model_executor/models/llama4.py, vllm/vllm/model_executor/models/mllama4.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #20419 - Enable ModelOpt Llama4 fp8 checkpoint deployment
+
+- Link: https://github.com/vllm-project/vllm/pull/20419
+- Why it mattered: Added ModelOpt FP8 coverage.
+- Runtime path: vllm/vllm/model_executor/models/llama4.py, vllm/vllm/model_executor/models/mllama4.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #20591 - Llama4 EAGLE Support
+
+- Link: https://github.com/vllm-project/vllm/pull/20591
+- Why it mattered: Opened speculative decoding for Llama4.
+- Runtime path: vllm/vllm/model_executor/models/llama4.py, vllm/vllm/model_executor/models/mllama4.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #22511 - Fix Llama4 FlashInfer FP4 MoE issues
+
+- Link: https://github.com/vllm-project/vllm/pull/22511
+- Why it mattered: Stabilized the FP4 MoE path.
+- Runtime path: vllm/vllm/model_executor/models/llama4.py, vllm/vllm/model_executor/models/mllama4.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #25889 - Fix misplaced dtype cast in Llama4VisionRotaryEmbedding
+
+- Link: https://github.com/vllm-project/vllm/pull/25889
+- Why it mattered: Patched a multimodal rotary bug.
+- Runtime path: vllm/vllm/model_executor/models/llama4.py, vllm/vllm/model_executor/models/mllama4.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/vllm/vllm-ltx23-hq-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-ltx23-hq-optimization/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: vllm-ltx23-hq-optimization
+description: PR-backed optimization manual for LTX 2.3 HQ in vLLM. Use when Codex needs to audit, debug, extend, or document Tracking note for LTX 2.3 HQ diffusion/video style models, which are outside current vLLM autoregressive runtime coverage.
+---
+
+# vLLM LTX 2.3 HQ Optimization
+
+## Overview
+
+This skill covers Tracking note for LTX 2.3 HQ diffusion/video style models, which are outside current vLLM autoregressive runtime coverage.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: not supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/ltx23-hq/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## Current Main Summary
+
+- Current vLLM mainline does not ship a dedicated LTX diffusion/video generation runtime.
+- Treat this dossier as an explicit unsupported marker, not as hidden partial support.
+
+## Key Landed PRs
+
+- No landed PR is recorded yet for this family.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- Keep the family marked unsupported until a real model module and registry alias land.

--- a/skills/model-optimization/vllm/vllm-ltx23-hq-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-ltx23-hq-optimization/references/pr-history.md
@@ -1,0 +1,15 @@
+# vLLM LTX 2.3 HQ PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: not supported on current mainline
+- Scope: Tracking note for LTX 2.3 HQ diffusion/video style models, which are outside current vLLM autoregressive runtime coverage.
+
+## Landed PRs
+
+- No landed PR is recorded yet for this family.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-mimo-v2-flash-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-mimo-v2-flash-optimization/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: vllm-mimo-v2-flash-optimization
+description: PR-backed optimization manual for MiMo-V2-Flash in vLLM. Use when Codex needs to audit, debug, extend, or document MiMo-V2-Flash inference-centric MoE runtime, MTP behavior, and the transition from older MiMo checkpoints in vLLM.
+---
+
+# vLLM MiMo-V2-Flash Optimization
+
+## Overview
+
+This skill covers MiMo-V2-Flash inference-centric MoE runtime, MTP behavior, and the transition from older MiMo checkpoints in vLLM.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/mimo-v2-flash/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/mimo_v2_flash.py`
+- `vllm/vllm/model_executor/models/mimo.py`
+- `vllm/vllm/model_executor/models/mimo_mtp.py`
+
+## Current Main Summary
+
+- MiMo-V2-Flash is a throughput-oriented MoE serving family in vLLM.
+- MTP correctness and the split between older MiMo checkpoints and V2-Flash are the key maintenance points.
+
+## Key Landed PRs
+
+- [#17433](https://github.com/vllm-project/vllm/pull/17433) `Support MiMo-7B inference with MTP`: Historical base for the MiMo family.
+- [#25136](https://github.com/vllm-project/vllm/pull/25136) `Fix MTP inference path for MiMo-7B model`: Closed a concrete draft-path bug.
+- [#30836](https://github.com/vllm-project/vllm/pull/30836) `Add MiMo-V2-Flash support`: Landed the dedicated V2-Flash runtime.
+
+## Validation Lanes
+
+- Startup on the current vLLM mainline checkpoint.
+- Re-run the parser, quantization, MTP, or multimodal lane that matches this family.
+- Re-check tests after touching loader or processor code.

--- a/skills/model-optimization/vllm/vllm-mimo-v2-flash-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-mimo-v2-flash-optimization/references/pr-history.md
@@ -1,0 +1,29 @@
+# vLLM MiMo-V2-Flash PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Scope: MiMo-V2-Flash inference-centric MoE runtime, MTP behavior, and the transition from older MiMo checkpoints in vLLM.
+
+## Landed PRs
+
+### PR #17433 - Support MiMo-7B inference with MTP
+
+- Link: https://github.com/vllm-project/vllm/pull/17433
+- Why it mattered: Historical base for the MiMo family.
+- Runtime path: vllm/vllm/model_executor/models/mimo_v2_flash.py, vllm/vllm/model_executor/models/mimo.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #25136 - Fix MTP inference path for MiMo-7B model
+
+- Link: https://github.com/vllm-project/vllm/pull/25136
+- Why it mattered: Closed a concrete draft-path bug.
+- Runtime path: vllm/vllm/model_executor/models/mimo_v2_flash.py, vllm/vllm/model_executor/models/mimo.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #30836 - Add MiMo-V2-Flash support
+
+- Link: https://github.com/vllm-project/vllm/pull/30836
+- Why it mattered: Landed the dedicated V2-Flash runtime.
+- Runtime path: vllm/vllm/model_executor/models/mimo_v2_flash.py, vllm/vllm/model_executor/models/mimo.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/vllm/vllm-minimax-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-minimax-optimization/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: vllm-minimax-optimization
+description: PR-backed optimization manual for MiniMax M1 / M2 / VL in vLLM. Use when Codex needs to audit, debug, extend, or document MiniMaxText01, MiniMax-M1, MiniMax-M2, MiniMax-VL-01, LoRA, and Eagle3 support in vLLM.
+---
+
+# vLLM MiniMax M1 / M2 / VL Optimization
+
+## Overview
+
+This skill covers MiniMaxText01, MiniMax-M1, MiniMax-M2, MiniMax-VL-01, LoRA, and Eagle3 support in vLLM.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/minimax/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/minimax_text_01.py`
+- `vllm/vllm/model_executor/models/minimax_m2.py`
+- `vllm/vllm/model_executor/models/minimax_vl_01.py`
+
+## Current Main Summary
+
+- MiniMax support evolved from the text-01 path into M1/M2 and VL variants.
+- Today the key production surfaces are linear-attention correctness, VL processor behavior, LoRA, and Eagle3 on M2.
+
+## Key Landed PRs
+
+- [#13454](https://github.com/vllm-project/vllm/pull/13454) `Support MiniMaxText01 model inference`: Landed the original MiniMax text runtime.
+- [#16328](https://github.com/vllm-project/vllm/pull/16328) `support MiniMax-VL-01 model`: Added the multimodal MiniMax-VL path.
+- [#19677](https://github.com/vllm-project/vllm/pull/19677) `Add support for MiniMaxM1ForCausalLM`: Connected the M1 checkpoint alias to the shared MiniMax runtime.
+- [#27535](https://github.com/vllm-project/vllm/pull/27535) `Support MiniMax-M2 Model`: Brought the M2 generation into mainline.
+- [#32763](https://github.com/vllm-project/vllm/pull/32763) `Complete LoRA support for MiniMaxM2`: Finished missing adapter wiring in the M2 family.
+- [#37512](https://github.com/vllm-project/vllm/pull/37512) `MiniMax-M2: add Eagle3 speculative decoding support`: Enabled the draft-model acceleration path for MiniMax M2.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- MiniMax text and VL startup.
+- M2 LoRA adapter application.
+- Eagle3 speculative decode on M2.
+- Reasoning and tool parser streaming for MiniMax checkpoints.

--- a/skills/model-optimization/vllm/vllm-minimax-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-minimax-optimization/references/pr-history.md
@@ -1,0 +1,55 @@
+# vLLM MiniMax M1 / M2 / VL PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Scope: MiniMaxText01, MiniMax-M1, MiniMax-M2, MiniMax-VL-01, LoRA, and Eagle3 support in vLLM.
+
+## Landed PRs
+
+### PR #13454 - Support MiniMaxText01 model inference
+
+- Link: https://github.com/vllm-project/vllm/pull/13454
+- Why it mattered: Landed the original MiniMax text runtime.
+- Runtime path: vllm/vllm/model_executor/models/minimax_text_01.py, vllm/vllm/model_executor/models/minimax_m2.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #16328 - support MiniMax-VL-01 model
+
+- Link: https://github.com/vllm-project/vllm/pull/16328
+- Why it mattered: Added the multimodal MiniMax-VL path.
+- Runtime path: vllm/vllm/model_executor/models/minimax_text_01.py, vllm/vllm/model_executor/models/minimax_m2.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #19677 - Add support for MiniMaxM1ForCausalLM
+
+- Link: https://github.com/vllm-project/vllm/pull/19677
+- Why it mattered: Connected the M1 checkpoint alias to the shared MiniMax runtime.
+- Runtime path: vllm/vllm/model_executor/models/minimax_text_01.py, vllm/vllm/model_executor/models/minimax_m2.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #27535 - Support MiniMax-M2 Model
+
+- Link: https://github.com/vllm-project/vllm/pull/27535
+- Why it mattered: Brought the M2 generation into mainline.
+- Runtime path: vllm/vllm/model_executor/models/minimax_text_01.py, vllm/vllm/model_executor/models/minimax_m2.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #32763 - Complete LoRA support for MiniMaxM2
+
+- Link: https://github.com/vllm-project/vllm/pull/32763
+- Why it mattered: Finished missing adapter wiring in the M2 family.
+- Runtime path: vllm/vllm/model_executor/models/minimax_text_01.py, vllm/vllm/model_executor/models/minimax_m2.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #37512 - MiniMax-M2: add Eagle3 speculative decoding support
+
+- Link: https://github.com/vllm-project/vllm/pull/37512
+- Why it mattered: Enabled the draft-model acceleration path for MiniMax M2.
+- Runtime path: vllm/vllm/model_executor/models/minimax_text_01.py, vllm/vllm/model_executor/models/minimax_m2.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-mistral-small-4-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-mistral-small-4-optimization/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: vllm-mistral-small-4-optimization
+description: PR-backed optimization manual for Mistral Small 4 in vLLM. Use when Codex needs to audit, debug, extend, or document Mistral Small 4, Leanstral, and closely related Mistral Large 3 / Ministral serving behavior, including multimodal and MoE execution.
+---
+
+# vLLM Mistral Small 4 Optimization
+
+## Overview
+
+This skill covers Mistral Small 4, Leanstral, and closely related Mistral Large 3 / Ministral serving behavior, including multimodal and MoE execution.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/mistral-small-4/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/mistral_large_3.py`
+- `vllm/vllm/model_executor/models/mistral_large_3_eagle.py`
+- `vllm/vllm/model_executor/models/mistral3.py`
+
+## Current Main Summary
+
+- Mistral Small 4 sits on top of the larger Mistral Large 3 / Ministral runtime work.
+- MoE execution and multimodal projector behavior are the main risk areas.
+
+## Key Landed PRs
+
+- [#29757](https://github.com/vllm-project/vllm/pull/29757) `Add Mistral Large 3 and Ministral 3`: Landed the runtime family that Mistral Small 4 deployments build on in vLLM.
+- [#33174](https://github.com/vllm-project/vllm/pull/33174) `Add support for Mistral Large 3 inference with Flashinfer MoE`: Improved the practical MoE serving path for the same family.
+
+## Validation Lanes
+
+- Startup on the current vLLM mainline checkpoint.
+- Re-run the parser, quantization, MTP, or multimodal lane that matches this family.
+- Re-check tests after touching loader or processor code.

--- a/skills/model-optimization/vllm/vllm-mistral-small-4-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-mistral-small-4-optimization/references/pr-history.md
@@ -1,0 +1,22 @@
+# vLLM Mistral Small 4 PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Scope: Mistral Small 4, Leanstral, and closely related Mistral Large 3 / Ministral serving behavior, including multimodal and MoE execution.
+
+## Landed PRs
+
+### PR #29757 - Add Mistral Large 3 and Ministral 3
+
+- Link: https://github.com/vllm-project/vllm/pull/29757
+- Why it mattered: Landed the runtime family that Mistral Small 4 deployments build on in vLLM.
+- Runtime path: vllm/vllm/model_executor/models/mistral_large_3.py, vllm/vllm/model_executor/models/mistral_large_3_eagle.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #33174 - Add support for Mistral Large 3 inference with Flashinfer MoE
+
+- Link: https://github.com/vllm-project/vllm/pull/33174
+- Why it mattered: Improved the practical MoE serving path for the same family.
+- Runtime path: vllm/vllm/model_executor/models/mistral_large_3.py, vllm/vllm/model_executor/models/mistral_large_3_eagle.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/vllm/vllm-mixtral-quark-int4fp8-moe-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-mixtral-quark-int4fp8-moe-optimization/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: vllm-mixtral-quark-int4fp8-moe-optimization
+description: PR-backed optimization manual for Mixtral Quark / INT4-FP8 MoE in vLLM. Use when Codex needs to audit, debug, extend, or document Mixtral MoE, expert parallelism, FP8 / ModelOpt quantization, and EPLB in vLLM, which together form the nearest equivalent to Quark INT4-FP8 Mixtral serving.
+---
+
+# vLLM Mixtral Quark / INT4-FP8 MoE Optimization
+
+## Overview
+
+This skill covers Mixtral MoE, expert parallelism, FP8 / ModelOpt quantization, and EPLB in vLLM, which together form the nearest equivalent to Quark INT4-FP8 Mixtral serving.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: partially supported or only adjacent architectures landed on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/mixtral-quark-int4fp8-moe/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/mixtral.py`
+- `vllm/vllm/model_executor/layers/fused_moe/layer.py`
+
+## Current Main Summary
+
+- vLLM has rich Mixtral MoE support, but not every Quark-branded checkpoint path is called out by name.
+- The closest production evidence is the Mixtral fused-MoE, FP8, ModelOpt, and EPLB work already merged.
+
+## Key Landed PRs
+
+- [#2011](https://github.com/vllm-project/vllm/pull/2011) `Mixtral 8x7B support`: Initial Mixtral model-family support.
+- [#2090](https://github.com/vllm-project/vllm/pull/2090) `Optimize Mixtral with expert parallelism`: Added early expert-parallel scaling instead of pure TP execution.
+- [#2542](https://github.com/vllm-project/vllm/pull/2542) `Fused MOE for Mixtral`: Brought fused-MoE kernels into the Mixtral serving path.
+- [#4527](https://github.com/vllm-project/vllm/pull/4527) `Support MoE FP8 checkpoints for Mixtral`: Added the first serious FP8 checkpoint path for Mixtral MoE.
+- [#15961](https://github.com/vllm-project/vllm/pull/15961) `Support ModelOpt quantization of Mixtral model`: Extended the family to NVIDIA ModelOpt quantization flows.
+- [#22842](https://github.com/vllm-project/vllm/pull/22842) `Support EPLB for Mixtral Model`: Added expert-parallel load balancing to the Mixtral family.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- FP16 / BF16 Mixtral baseline.
+- FP8 or ModelOpt quantized checkpoint launch.
+- Expert-parallel / EPLB topology checks on multi-GPU setups.

--- a/skills/model-optimization/vllm/vllm-mixtral-quark-int4fp8-moe-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-mixtral-quark-int4fp8-moe-optimization/references/pr-history.md
@@ -1,0 +1,55 @@
+# vLLM Mixtral Quark / INT4-FP8 MoE PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: partially supported or only adjacent architectures landed on current mainline
+- Scope: Mixtral MoE, expert parallelism, FP8 / ModelOpt quantization, and EPLB in vLLM, which together form the nearest equivalent to Quark INT4-FP8 Mixtral serving.
+
+## Landed PRs
+
+### PR #2011 - Mixtral 8x7B support
+
+- Link: https://github.com/vllm-project/vllm/pull/2011
+- Why it mattered: Initial Mixtral model-family support.
+- Runtime path: vllm/vllm/model_executor/models/mixtral.py, vllm/vllm/model_executor/layers/fused_moe/layer.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #2090 - Optimize Mixtral with expert parallelism
+
+- Link: https://github.com/vllm-project/vllm/pull/2090
+- Why it mattered: Added early expert-parallel scaling instead of pure TP execution.
+- Runtime path: vllm/vllm/model_executor/models/mixtral.py, vllm/vllm/model_executor/layers/fused_moe/layer.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #2542 - Fused MOE for Mixtral
+
+- Link: https://github.com/vllm-project/vllm/pull/2542
+- Why it mattered: Brought fused-MoE kernels into the Mixtral serving path.
+- Runtime path: vllm/vllm/model_executor/models/mixtral.py, vllm/vllm/model_executor/layers/fused_moe/layer.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #4527 - Support MoE FP8 checkpoints for Mixtral
+
+- Link: https://github.com/vllm-project/vllm/pull/4527
+- Why it mattered: Added the first serious FP8 checkpoint path for Mixtral MoE.
+- Runtime path: vllm/vllm/model_executor/models/mixtral.py, vllm/vllm/model_executor/layers/fused_moe/layer.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #15961 - Support ModelOpt quantization of Mixtral model
+
+- Link: https://github.com/vllm-project/vllm/pull/15961
+- Why it mattered: Extended the family to NVIDIA ModelOpt quantization flows.
+- Runtime path: vllm/vllm/model_executor/models/mixtral.py, vllm/vllm/model_executor/layers/fused_moe/layer.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #22842 - Support EPLB for Mixtral Model
+
+- Link: https://github.com/vllm-project/vllm/pull/22842
+- Why it mattered: Added expert-parallel load balancing to the Mixtral family.
+- Runtime path: vllm/vllm/model_executor/models/mixtral.py, vllm/vllm/model_executor/layers/fused_moe/layer.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-moss-vl-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-moss-vl-optimization/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: vllm-moss-vl-optimization
+description: PR-backed optimization manual for MOSS-VL in vLLM. Use when Codex needs to audit, debug, extend, or document Tracking note for MOSS-VL, which does not have a native vLLM mainline model module today.
+---
+
+# vLLM MOSS-VL Optimization
+
+## Overview
+
+This skill covers Tracking note for MOSS-VL, which does not have a native vLLM mainline model module today.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: not supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/moss-vl/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## Current Main Summary
+
+- No `moss` or `moss_vl` model module is present in current vLLM mainline.
+- Keep the family explicitly marked unsupported until that changes.
+
+## Key Landed PRs
+
+- No landed PR is recorded yet for this family.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- Re-run source and PR search before claiming any MOSS-VL support.

--- a/skills/model-optimization/vllm/vllm-moss-vl-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-moss-vl-optimization/references/pr-history.md
@@ -1,0 +1,15 @@
+# vLLM MOSS-VL PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: not supported on current mainline
+- Scope: Tracking note for MOSS-VL, which does not have a native vLLM mainline model module today.
+
+## Landed PRs
+
+- No landed PR is recorded yet for this family.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-nemotron-super-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-nemotron-super-optimization/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: vllm-nemotron-super-optimization
+description: PR-backed optimization manual for Nemotron Super / Nano Hybrid in vLLM. Use when Codex needs to audit, debug, extend, or document NemotronH, Nemotron 3 Super, Nemotron Nano hybrid Mamba+Attention+MoE, MTP, NVFP4, and VL adjacencies.
+---
+
+# vLLM Nemotron Super / Nano Hybrid Optimization
+
+## Overview
+
+This skill covers NemotronH, Nemotron 3 Super, Nemotron Nano hybrid Mamba+Attention+MoE, MTP, NVFP4, and VL adjacencies.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/nemotron-super/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/nemotron_h.py`
+- `vllm/vllm/model_executor/models/nemotron_h_mtp.py`
+- `vllm/vllm/model_executor/models/nano_nemotron_vl.py`
+- `vllm/vllm/model_executor/models/nemotron_vl.py`
+
+## Current Main Summary
+
+- Nemotron is a hybrid family: attention, Mamba, MoE, MTP, and VL all intersect.
+- Because of that, graph execution, cache dtype, and quantized MoE correctness are the primary risk areas.
+
+## Key Landed PRs
+
+- [#18863](https://github.com/vllm-project/vllm/pull/18863) `NemotronH support`: Initial NemotronH landing in vLLM.
+- [#25863](https://github.com/vllm-project/vllm/pull/25863) `Add MoE support for NemotronH`: Extended the hybrid family to routed experts.
+- [#33726](https://github.com/vllm-project/vllm/pull/33726) `Nemotron-H MTP and Mamba Speculative Decoding Support`: Opened the MTP / spec-decode path.
+- [#36803](https://github.com/vllm-project/vllm/pull/36803) `E2E Nemotron-3-Super tests`: Added direct Super-family regression coverage.
+- [#37803](https://github.com/vllm-project/vllm/pull/37803) `Enable NemotronHPuzzle + NemotronHMTP`: Expanded hybrid and MTP coverage for the family.
+
+## Validation Lanes
+
+- Startup on the current vLLM mainline checkpoint.
+- Re-run the parser, quantization, MTP, or multimodal lane that matches this family.
+- Re-check tests after touching loader or processor code.

--- a/skills/model-optimization/vllm/vllm-nemotron-super-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-nemotron-super-optimization/references/pr-history.md
@@ -1,0 +1,43 @@
+# vLLM Nemotron Super / Nano Hybrid PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Scope: NemotronH, Nemotron 3 Super, Nemotron Nano hybrid Mamba+Attention+MoE, MTP, NVFP4, and VL adjacencies.
+
+## Landed PRs
+
+### PR #18863 - NemotronH support
+
+- Link: https://github.com/vllm-project/vllm/pull/18863
+- Why it mattered: Initial NemotronH landing in vLLM.
+- Runtime path: vllm/vllm/model_executor/models/nemotron_h.py, vllm/vllm/model_executor/models/nemotron_h_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #25863 - Add MoE support for NemotronH
+
+- Link: https://github.com/vllm-project/vllm/pull/25863
+- Why it mattered: Extended the hybrid family to routed experts.
+- Runtime path: vllm/vllm/model_executor/models/nemotron_h.py, vllm/vllm/model_executor/models/nemotron_h_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #33726 - Nemotron-H MTP and Mamba Speculative Decoding Support
+
+- Link: https://github.com/vllm-project/vllm/pull/33726
+- Why it mattered: Opened the MTP / spec-decode path.
+- Runtime path: vllm/vllm/model_executor/models/nemotron_h.py, vllm/vllm/model_executor/models/nemotron_h_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #36803 - E2E Nemotron-3-Super tests
+
+- Link: https://github.com/vllm-project/vllm/pull/36803
+- Why it mattered: Added direct Super-family regression coverage.
+- Runtime path: vllm/vllm/model_executor/models/nemotron_h.py, vllm/vllm/model_executor/models/nemotron_h_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #37803 - Enable NemotronHPuzzle + NemotronHMTP
+
+- Link: https://github.com/vllm-project/vllm/pull/37803
+- Why it mattered: Expanded hybrid and MTP coverage for the family.
+- Runtime path: vllm/vllm/model_executor/models/nemotron_h.py, vllm/vllm/model_executor/models/nemotron_h_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/vllm/vllm-qwen-image-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-qwen-image-optimization/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: vllm-qwen-image-optimization
+description: PR-backed optimization manual for Qwen-Image in vLLM. Use when Codex needs to audit, debug, extend, or document Tracking note for Qwen-Image diffusion generation, which is outside the current vLLM runtime surface.
+---
+
+# vLLM Qwen-Image Optimization
+
+## Overview
+
+This skill covers Tracking note for Qwen-Image diffusion generation, which is outside the current vLLM runtime surface.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: not supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/qwen-image/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## Current Main Summary
+
+- vLLM current mainline does not ship a Qwen-Image diffusion model runtime.
+- The family should stay marked unsupported rather than being backfilled from Qwen text/VL support.
+
+## Key Landed PRs
+
+- No landed PR is recorded yet for this family.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- Require a real model module and registry alias before changing the status.

--- a/skills/model-optimization/vllm/vllm-qwen-image-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-qwen-image-optimization/references/pr-history.md
@@ -1,0 +1,15 @@
+# vLLM Qwen-Image PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: not supported on current mainline
+- Scope: Tracking note for Qwen-Image diffusion generation, which is outside the current vLLM runtime surface.
+
+## Landed PRs
+
+- No landed PR is recorded yet for this family.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-qwen-vlm-omni-asr-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-qwen-vlm-omni-asr-optimization/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: vllm-qwen-vlm-omni-asr-optimization
+description: PR-backed optimization manual for Qwen2.5-VL / Qwen3-VL / Qwen3-Omni / Qwen3-ASR in vLLM. Use when Codex needs to audit, debug, extend, or document the multimodal Qwen runtime in vLLM, especially Qwen2.5-VL attention hot paths, Qwen3-VL video and interleaved MRoPE handling, Qwen3-Omni thinker audio-in-video logic, and Qwen3-ASR / realtime speech support.
+---
+
+# vLLM Qwen2.5-VL / Qwen3-VL / Qwen3-Omni / Qwen3-ASR Optimization
+
+## Overview
+
+This family is already supported on the checked mainline commit, but the
+high-risk logic lives in processors and multimodal position handling more than
+in the text decoder itself. The important milestones are:
+
+- `#13155`: Qwen2.5-VL hot-path optimization
+- `#24727`: Qwen3-VL and Qwen3-VL-MoE bring-up
+- `#25055`: interleaved MRoPE support for Qwen3-VL
+- `#25550`: Qwen3-Omni thinker path
+- `#33312`: Qwen3-ASR base transcription path
+- `#34613`: Qwen3-ASR realtime streaming path
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors:
+  `model-pr-optimization-history/vllm/qwen-vlm-omni-asr/README.zh.md` and
+  `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the bar.
+When touching this family, name the exact processor/model file because regressions
+usually come from placeholder expansion, timestamps, audio lengths, or MRoPE
+layout, not from generic "multimodal" code.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/qwen2_5_vl.py`
+- `vllm/vllm/model_executor/models/qwen3_vl.py`
+- `vllm/vllm/model_executor/models/qwen3_vl_moe.py`
+- `vllm/vllm/model_executor/models/qwen3_omni_moe_thinker.py`
+- `vllm/vllm/model_executor/models/qwen3_asr.py`
+- `vllm/vllm/model_executor/models/qwen3_asr_realtime.py`
+- `vllm/vllm/model_executor/layers/rotary_embedding/mrope.py`
+- `vllm/vllm/transformers_utils/processors/qwen3_asr.py`
+
+## Current Main Summary
+
+- Qwen2.5-VL optimized its vision attention fallback path and RMSNorm usage.
+- Qwen3-VL introduces native image and video placeholders, video timestamp
+  calculation, and interleaved MRoPE handling.
+- Qwen3-Omni thinker reimplements prompt updates to support
+  `use_audio_in_video`.
+- Qwen3-ASR reuses Qwen3 text plus Omni audio encoder pieces, then adds a
+  separate realtime subclass with an audio buffer and prompt expansion logic.
+
+## Key Landed PRs
+
+- [#13155](https://github.com/vllm-project/vllm/pull/13155) `Qwen2.5-VL Optimization`
+- [#24727](https://github.com/vllm-project/vllm/pull/24727) `Support Qwen3-VL Model Series`
+- [#25055](https://github.com/vllm-project/vllm/pull/25055) `Add Triton kernel for Qwen3-VL interleaved MRoPE`
+- [#25550](https://github.com/vllm-project/vllm/pull/25550) `Add Qwen3-Omni moe thinker`
+- [#33312](https://github.com/vllm-project/vllm/pull/33312) `Qwen3-ASR`
+- [#34613](https://github.com/vllm-project/vllm/pull/34613) `Add Qwen3-ASR realtime streaming support`
+
+## Validation Lanes
+
+- Qwen2.5-VL image and long-video requests on the chosen attention backend.
+- Qwen3-VL image plus video placeholder expansion, timestamp generation, and
+  interleaved MRoPE correctness.
+- Qwen3-Omni thinker runs with and without `use_audio_in_video`.
+- Qwen3-ASR batch transcription and realtime streaming.
+
+## References
+
+- `references/pr-history.md`: diff-reviewed Qwen multimodal cards.

--- a/skills/model-optimization/vllm/vllm-qwen-vlm-omni-asr-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-qwen-vlm-omni-asr-optimization/references/pr-history.md
@@ -1,0 +1,255 @@
+# vLLM Qwen2.5-VL / Qwen3-VL / Qwen3-Omni / Qwen3-ASR PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Scope: Qwen2.5-VL, Qwen3-VL, Qwen3-Omni thinker, and Qwen3-ASR / realtime
+
+## Landed PRs
+
+### PR #13155 - Qwen2.5-VL Optimization
+
+- Link: https://github.com/vllm-project/vllm/pull/13155
+- State: merged
+- Diff coverage: full diff reviewed, `2` files, `47` additions, `51` deletions
+- Motivation:
+  - The Qwen2.5-VL vision stack had an expensive SDPA fallback path and a
+    model-local RMSNorm implementation that diverged from common vLLM layers.
+- Key implementation:
+  - Uses per-entry SDPA execution instead of building a large dense attention
+    mask.
+  - Switches the vision norm path to the shared `RMSNorm`.
+  - Passes `use_flash_attn` into the vision rotary application path.
+- Key code excerpts:
+
+```diff
+-            attention_mask = torch.zeros([1, seq_length, seq_length], ...)
+-            output = F.scaled_dot_product_attention(q, k, v, attention_mask, dropout_p=0.0)
++            outputs = []
++            for i in range(1, len(cu_seqlens)):
++                output_i = F.scaled_dot_product_attention(q_i, k_i, v_i, dropout_p=0.0)
++                outputs.append(output_i)
++            context_layer = torch.cat(outputs, dim=1)
+```
+
+```diff
+-        norm_layer = partial(Qwen2RMSNorm, eps=norm_eps)
++        norm_layer = partial(RMSNorm, eps=norm_eps)
+```
+
+- Reviewed files:
+  - runtime: `vllm/model_executor/models/qwen2_5_vl.py`,
+    `vllm/model_executor/models/qwen2_vl.py`
+- Validation implications:
+  - When Qwen2.5-VL is slow or OOMs on the fallback backend, inspect this PR
+    before changing higher-level multimodal code.
+
+### PR #24727 - Support Qwen3-VL Model Series
+
+- Link: https://github.com/vllm-project/vllm/pull/24727
+- State: merged
+- Diff coverage: full diff reviewed, `13` files, `2084` additions, `17`
+  deletions
+- Motivation:
+  - Qwen3-VL introduced native image and video placeholders, video processors,
+    Qwen3 text integration, and Qwen3-VL-MoE.
+- Key implementation:
+  - Adds `qwen3_vl.py` and `qwen3_vl_moe.py`.
+  - Registers both `Qwen3VLForConditionalGeneration` and
+    `Qwen3VLMoeForConditionalGeneration`.
+  - Adds image and video prompt replacement, timestamp handling, video grid
+    parsing, and multimodal embedding merge for both modalities.
+- Key code excerpts:
+
+```diff
++    "Qwen3VLForConditionalGeneration": ("qwen3_vl", "Qwen3VLForConditionalGeneration"),
++    "Qwen3VLMoeForConditionalGeneration": ("qwen3_vl_moe", "Qwen3VLMoeForConditionalGeneration"),
+```
+
+```diff
++            PromptReplacement(
++                modality="video",
++                target="<|vision_start|><|video_pad|><|vision_end|>",
++                replacement=get_video_replacement_qwen3vl,
++            ),
+```
+
+- Reviewed files:
+  - runtime: `vllm/model_executor/models/qwen3_vl.py`,
+    `vllm/model_executor/models/qwen3_vl_moe.py`,
+    `vllm/model_executor/models/registry.py`
+  - rotary/video support:
+    `vllm/model_executor/layers/rotary_embedding/mrope.py`,
+    `vllm/multimodal/video.py`
+  - docs/tests/examples: `docs/models/supported_models.md`,
+    `tests/models/registry.py`,
+    `tests/models/multimodal/processing/test_common.py`,
+    `examples/offline_inference/vision_language.py`
+- Validation implications:
+  - Regressions often show up as wrong video placeholder counts, wrong
+    timestamps, or wrong `(3, seq_len)` MRoPE positions rather than simple load
+    failures.
+
+### PR #25055 - Add Triton kernel for Qwen3-VL interleaved MRoPE
+
+- Link: https://github.com/vllm-project/vllm/pull/25055
+- State: merged
+- Diff coverage: full diff reviewed, `2` files, `88` additions, `46` deletions
+- Motivation:
+  - Qwen3-VL uses interleaved 3D rotary layout, which could not be handled
+    cleanly by the earlier chunked MRoPE logic.
+- Key implementation:
+  - Adds `apply_interleaved_rope(...)`.
+  - Introduces `mrope_interleaved` and updates the Triton path to distinguish
+    interleaved vs. non-interleaved sections.
+  - Extends MRoPE tests to Qwen3-VL models.
+- Key code excerpts:
+
+```diff
++def apply_interleaved_rope(x: torch.Tensor,
++                           mrope_section: list[int]) -> torch.Tensor:
++    """Apply interleaved MRoPE to 3D rotary embeddings."""
+```
+
+```diff
++        if self.mrope_interleaved:
++            cos = apply_interleaved_rope(cos, self.mrope_section)
++            sin = apply_interleaved_rope(sin, self.mrope_section)
+```
+
+- Reviewed files:
+  - runtime: `vllm/model_executor/layers/rotary_embedding/mrope.py`
+  - tests: `tests/kernels/core/test_mrope.py`
+- Validation implications:
+  - If Qwen3-VL image/video outputs drift only on specific backends or TP sizes,
+    check interleaved MRoPE first.
+
+### PR #25550 - Add Qwen3-Omni moe thinker
+
+- Link: https://github.com/vllm-project/vllm/pull/25550
+- State: merged
+- Diff coverage: full diff reviewed, `6` files, `1795` additions, `36`
+  deletions
+- Motivation:
+  - Qwen3-Omni thinker combines Qwen3-MoE text, a visual tower, an audio tower,
+    and special `use_audio_in_video` prompt semantics that cannot be handled by
+    the older Qwen2.5-Omni thinker unchanged.
+- Key implementation:
+  - Adds `qwen3_omni_moe_thinker.py`.
+  - Registers `Qwen3OmniMoeThinkerForConditionalGeneration`.
+  - Reimplements multimodal prompt updates so `use_audio_in_video` adjusts
+    placeholder accounting instead of double-counting audio items.
+- Key code excerpts:
+
+```diff
++    "Qwen3OmniMoeForConditionalGeneration": (
++        "qwen3_omni_moe_thinker",
++        "Qwen3OmniMoeThinkerForConditionalGeneration",
++    ),
+```
+
+```diff
++        if use_audio_in_video and "video" in mm_item_counts:
++            assert "audio" in mm_item_counts
++            mm_item_counts["audio"] -= mm_item_counts["video"]
+```
+
+- Reviewed files:
+  - runtime: `vllm/model_executor/models/qwen3_omni_moe_thinker.py`,
+    `vllm/model_executor/models/registry.py`
+  - rotary support: `vllm/model_executor/layers/rotary_embedding/mrope.py`
+  - tests/docs: `tests/models/registry.py`,
+    `tests/models/multimodal/processing/test_common.py`,
+    `docs/models/supported_models.md`
+- Validation implications:
+  - Always validate both `use_audio_in_video=True` and `False`.
+  - Placeholder count mismatches can be processor bugs even when the base model
+    loads successfully.
+
+### PR #33312 - Qwen3-ASR
+
+- Link: https://github.com/vllm-project/vllm/pull/33312
+- State: merged
+- Diff coverage: full diff reviewed, `9` files, `1269` additions
+- Motivation:
+  - Qwen3-ASR needs speech-specific configs, audio processor wiring, audio
+    feature-length accounting, and transcription support on top of Qwen3 text.
+- Key implementation:
+  - Adds `qwen3_asr.py`, `transformers_utils/configs/qwen3_asr.py`, and
+    `transformers_utils/processors/qwen3_asr.py`.
+  - Reuses Omni audio encoder pieces and computes audio output lengths from
+    feature lengths for prompt replacement.
+- Key code excerpts:
+
+```diff
++class Qwen3ASRMultiModalProcessor(
++    Qwen3OmniMoeThinkerMultiModalProcessor,
++):
+```
+
+```diff
++def _get_feat_extract_output_lengths(input_lengths: torch.Tensor):
++    ...
++    return output_lengths
+```
+
+- Reviewed files:
+  - runtime: `vllm/model_executor/models/qwen3_asr.py`,
+    `vllm/model_executor/models/registry.py`
+  - configs/processors:
+    `vllm/transformers_utils/configs/qwen3_asr.py`,
+    `vllm/transformers_utils/processors/qwen3_asr.py`,
+    `vllm/transformers_utils/config.py`
+  - docs/examples/tests: `docs/models/supported_models.md`,
+    `examples/offline_inference/audio_language.py`,
+    `tests/models/registry.py`
+- Validation implications:
+  - Audio length bugs can surface as wrong prompt expansion or missing output
+    segments even when transcription itself seems wired up.
+
+### PR #34613 - Add Qwen3-ASR realtime streaming support
+
+- Link: https://github.com/vllm-project/vllm/pull/34613
+- State: merged
+- Diff coverage: full diff reviewed, `5` files, `256` additions, `1` deletion
+- Motivation:
+  - The batch ASR path was not sufficient for realtime streaming; the endpoint
+    needed buffering, per-segment prompt expansion, and a separate model class.
+- Key implementation:
+  - Adds `qwen3_asr_realtime.py`.
+  - Extends `SupportsRealtime` with `realtime_max_tokens`.
+  - Expands `<|audio_pad|>` to the true per-segment audio token count before
+    MRoPE positions are computed.
+- Key code excerpts:
+
+```diff
++    realtime_max_tokens: ClassVar[int] = 1
++    """Maximum tokens to generate per streaming audio segment."""
+```
+
+```diff
++class Qwen3ASRRealtimeGeneration(Qwen3ASRForConditionalGeneration, SupportsRealtime):
++    realtime_max_tokens = 64
+```
+
+```diff
++        if tid == audio_pad_id and pad_start_idx == -1:
++            pad_start_idx = i
++            expanded_ids.extend([audio_pad_id] * audio_len)
+```
+
+- Reviewed files:
+  - runtime: `vllm/model_executor/models/qwen3_asr_realtime.py`,
+    `vllm/model_executor/models/interfaces.py`,
+    `vllm/model_executor/models/registry.py`
+  - endpoint: `vllm/entrypoints/openai/realtime/connection.py`
+  - tests: `tests/models/registry.py`
+- Validation implications:
+  - Realtime regressions can come from buffer segmentation and placeholder
+    expansion, not only from endpoint glue.
+
+## Open PR Radar
+
+- Re-run PR search before claiming new Qwen3-Omni / ASR follow-ups beyond the
+  checked mainline commit.

--- a/skills/model-optimization/vllm/vllm-qwen3-coder-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-qwen3-coder-optimization/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: vllm-qwen3-coder-optimization
+description: PR-backed optimization manual for Qwen3 Coder in vLLM. Use when Codex needs to audit, debug, extend, or document Qwen3 Coder tool parser, structured tool arguments, and coding-oriented parser behavior layered on top of the base Qwen3 runtime.
+---
+
+# vLLM Qwen3 Coder Optimization
+
+## Overview
+
+This skill covers Qwen3 Coder tool parser, structured tool arguments, and coding-oriented parser behavior layered on top of the base Qwen3 runtime.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Family baseline: read `qwen3-core` first; this dossier only records the delta for `qwen3-coder`.
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/qwen3-coder/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/qwen3.py`
+- `vllm/vllm/entrypoints/openai/tool_parsers/`
+
+## Current Main Summary
+
+- Qwen3 Coder inherits the base Qwen3 runtime and adds coder-specific tool parsing.
+- The main regressions are in JSON-schema edge cases, anyOf / oneOf handling, and Responses API tools.
+
+## Key Landed PRs
+
+- [#21396](https://github.com/vllm-project/vllm/pull/21396) `Add Qwen3CoderToolParser`: Created the dedicated coder-tool parser instead of reusing a generic Qwen parser.
+- [#36032](https://github.com/vllm-project/vllm/pull/36032) `Fix anyOf double encoded parameters`: Fixed a concrete schema serialization bug in coder tool calls.
+- [#37831](https://github.com/vllm-project/vllm/pull/37831) `Fix anyOf/oneOf type resolution for nullable params`: Improved nullable parameter handling in complex schemas.
+- [#38848](https://github.com/vllm-project/vllm/pull/38848) `Fix Qwen3 tool parser for Responses API tools`: Aligned the tool parser with the Responses API tool surface.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- Complex tool schema extraction with anyOf / oneOf / nullable parameters.
+- Responses API tool execution on coder checkpoints.
+- Streaming tool-call integrity under speculative decode.

--- a/skills/model-optimization/vllm/vllm-qwen3-coder-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-qwen3-coder-optimization/references/pr-history.md
@@ -1,0 +1,43 @@
+# vLLM Qwen3 Coder PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Scope: Qwen3 Coder tool parser, structured tool arguments, and coding-oriented parser behavior layered on top of the base Qwen3 runtime.
+
+This family inherits the base runtime context from `qwen3-core`; this file records only the delta that is specific to `qwen3-coder`.
+
+## Landed PRs
+
+### PR #21396 - Add Qwen3CoderToolParser
+
+- Link: https://github.com/vllm-project/vllm/pull/21396
+- Why it mattered: Created the dedicated coder-tool parser instead of reusing a generic Qwen parser.
+- Runtime path: vllm/vllm/model_executor/models/qwen3.py, vllm/vllm/entrypoints/openai/tool_parsers/
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #36032 - Fix anyOf double encoded parameters
+
+- Link: https://github.com/vllm-project/vllm/pull/36032
+- Why it mattered: Fixed a concrete schema serialization bug in coder tool calls.
+- Runtime path: vllm/vllm/model_executor/models/qwen3.py, vllm/vllm/entrypoints/openai/tool_parsers/
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #37831 - Fix anyOf/oneOf type resolution for nullable params
+
+- Link: https://github.com/vllm-project/vllm/pull/37831
+- Why it mattered: Improved nullable parameter handling in complex schemas.
+- Runtime path: vllm/vllm/model_executor/models/qwen3.py, vllm/vllm/entrypoints/openai/tool_parsers/
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #38848 - Fix Qwen3 tool parser for Responses API tools
+
+- Link: https://github.com/vllm-project/vllm/pull/38848
+- Why it mattered: Aligned the tool parser with the Responses API tool surface.
+- Runtime path: vllm/vllm/model_executor/models/qwen3.py, vllm/vllm/entrypoints/openai/tool_parsers/
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-qwen3-core-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-qwen3-core-optimization/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: vllm-qwen3-core-optimization
+description: PR-backed optimization manual for Qwen3 Core in vLLM. Use when Codex needs to audit, debug, extend, or document Qwen3 dense, Qwen3 MoE, embeddings/rerankers, GGUF/GPTQ/ModelOpt quant paths, and Eagle3 speculative decoding in vLLM.
+---
+
+# vLLM Qwen3 Core Optimization
+
+## Overview
+
+This skill covers Qwen3 dense, Qwen3 MoE, embeddings/rerankers, GGUF/GPTQ/ModelOpt quant paths, and Eagle3 speculative decoding in vLLM.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/qwen3-core/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/qwen3.py`
+- `vllm/vllm/model_executor/models/qwen3_moe.py`
+- `vllm/vllm/model_executor/models/voyage.py`
+
+## Current Main Summary
+
+- Qwen3 and Qwen3MoE are first-class mainline runtimes in vLLM.
+- The highest-risk regressions show up in quantized MoE weight loading, packed-module mappings, and embedding / reranker special cases.
+
+## Key Landed PRs
+
+- [#15289](https://github.com/vllm-project/vllm/pull/15289) `Add Qwen3 and Qwen3MoE`: Initial Qwen3 dense and MoE support landed here.
+- [#19260](https://github.com/vllm-project/vllm/pull/19260) `Support Qwen3 Embedding & Reranker`: Extended the family to bidirectional embedding / reranker models.
+- [#19598](https://github.com/vllm-project/vllm/pull/19598) `Skip loading extra parameters for modelopt Qwen3 MoE model`: Fixed a concrete ModelOpt launch failure on Qwen3 MoE.
+- [#22017](https://github.com/vllm-project/vllm/pull/22017) `KeyError for Qwen3-MoE with GPTQ on ROCm`: Closed a GPTQ loading failure in the Qwen3 MoE path.
+- [#22785](https://github.com/vllm-project/vllm/pull/22785) `Fix GGUF loader for Qwen3 MoE`: Made the Qwen3 MoE loader accept GGUF weights again.
+- [#23490](https://github.com/vllm-project/vllm/pull/23490) `Fix Qwen3 MoE GPTQ inference`: Patched runtime correctness after GPTQ startup succeeded.
+- [#26485](https://github.com/vllm-project/vllm/pull/26485) `Add EAGLE-3 Speculative Decoding Support for Qwen3 MoE`: Enabled the draft-model path on top of the base Qwen3 MoE runtime.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- Dense and MoE BF16 launch.
+- Embedding / reranker special-case loading.
+- GPTQ / GGUF / ModelOpt startup on Qwen3 MoE.
+- EAGLE-3 acceptance-rate sanity on supported checkpoints.

--- a/skills/model-optimization/vllm/vllm-qwen3-core-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-qwen3-core-optimization/references/pr-history.md
@@ -1,0 +1,63 @@
+# vLLM Qwen3 Core PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Scope: Qwen3 dense, Qwen3 MoE, embeddings/rerankers, GGUF/GPTQ/ModelOpt quant paths, and Eagle3 speculative decoding in vLLM.
+
+
+## Landed PRs
+
+### PR #15289 - Add Qwen3 and Qwen3MoE
+
+- Link: https://github.com/vllm-project/vllm/pull/15289
+- Why it mattered: Initial Qwen3 dense and MoE support landed here.
+- Runtime path: vllm/vllm/model_executor/models/qwen3.py, vllm/vllm/model_executor/models/qwen3_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #19260 - Support Qwen3 Embedding & Reranker
+
+- Link: https://github.com/vllm-project/vllm/pull/19260
+- Why it mattered: Extended the family to bidirectional embedding / reranker models.
+- Runtime path: vllm/vllm/model_executor/models/qwen3.py, vllm/vllm/model_executor/models/qwen3_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #19598 - Skip loading extra parameters for modelopt Qwen3 MoE model
+
+- Link: https://github.com/vllm-project/vllm/pull/19598
+- Why it mattered: Fixed a concrete ModelOpt launch failure on Qwen3 MoE.
+- Runtime path: vllm/vllm/model_executor/models/qwen3.py, vllm/vllm/model_executor/models/qwen3_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #22017 - KeyError for Qwen3-MoE with GPTQ on ROCm
+
+- Link: https://github.com/vllm-project/vllm/pull/22017
+- Why it mattered: Closed a GPTQ loading failure in the Qwen3 MoE path.
+- Runtime path: vllm/vllm/model_executor/models/qwen3.py, vllm/vllm/model_executor/models/qwen3_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #22785 - Fix GGUF loader for Qwen3 MoE
+
+- Link: https://github.com/vllm-project/vllm/pull/22785
+- Why it mattered: Made the Qwen3 MoE loader accept GGUF weights again.
+- Runtime path: vllm/vllm/model_executor/models/qwen3.py, vllm/vllm/model_executor/models/qwen3_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #23490 - Fix Qwen3 MoE GPTQ inference
+
+- Link: https://github.com/vllm-project/vllm/pull/23490
+- Why it mattered: Patched runtime correctness after GPTQ startup succeeded.
+- Runtime path: vllm/vllm/model_executor/models/qwen3.py, vllm/vllm/model_executor/models/qwen3_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #26485 - Add EAGLE-3 Speculative Decoding Support for Qwen3 MoE
+
+- Link: https://github.com/vllm-project/vllm/pull/26485
+- Why it mattered: Enabled the draft-model path on top of the base Qwen3 MoE runtime.
+- Runtime path: vllm/vllm/model_executor/models/qwen3.py, vllm/vllm/model_executor/models/qwen3_moe.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-qwen3-next-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-qwen3-next-optimization/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: vllm-qwen3-next-optimization
+description: PR-backed optimization manual for Qwen3-Next in vLLM. Use when Codex needs to audit, debug, extend, or document Qwen3-Next GDN attention, MTP, packed module naming, PP, and cross-hardware tuned MoE configuration in vLLM.
+---
+
+# vLLM Qwen3-Next Optimization
+
+## Overview
+
+This skill covers Qwen3-Next GDN attention, MTP, packed module naming, PP, and cross-hardware tuned MoE configuration in vLLM.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/qwen3-next/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/qwen3_next.py`
+- `vllm/vllm/model_executor/models/qwen3_next_mtp.py`
+
+## Current Main Summary
+
+- Qwen3-Next is its own runtime family because of Gated DeltaNet attention and its MTP path.
+- The practical risks are PP, MTP varlen handling, quantized shared-expert naming, and GDN-specific CUDA graph bugs.
+
+## Key Landed PRs
+
+- [#24709](https://github.com/vllm-project/vllm/pull/24709) `Fix Qwen3-Next PP`: Corrected pipeline-parallel execution on Qwen3-Next.
+- [#24957](https://github.com/vllm-project/vllm/pull/24957) `Fix the varlen issue in qwen3-next MTP implementation`: Removed a concrete MTP correctness bug on variable-length batches.
+- [#24960](https://github.com/vllm-project/vllm/pull/24960) `Add prefixes to shared_expert in qwen3-next`: Fixed ignored-parameter and quantized weight loading for shared experts.
+- [#25743](https://github.com/vllm-project/vllm/pull/25743) `Fix cuda graph capture bug in GDN metadata and a stride bug`: Stabilized GDN execution under CUDA graphs.
+- [#31722](https://github.com/vllm-project/vllm/pull/31722) `Speed-up of GDN attention decode part`: Improved decode throughput on the GDN attention path.
+- [#33657](https://github.com/vllm-project/vllm/pull/33657) `Initial support for GDN attention on Qwen3-next/Qwen3.5 (XPU)`: Extended the family beyond CUDA with XPU GDN coverage.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- Qwen3-Next PP and MTP correctness.
+- GDN decode throughput / CUDA graph capture.
+- Quantized shared-expert loading.
+- XPU GDN fallback if relevant.

--- a/skills/model-optimization/vllm/vllm-qwen3-next-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-qwen3-next-optimization/references/pr-history.md
@@ -1,0 +1,56 @@
+# vLLM Qwen3-Next PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Scope: Qwen3-Next GDN attention, MTP, packed module naming, PP, and cross-hardware tuned MoE configuration in vLLM.
+
+
+## Landed PRs
+
+### PR #24709 - Fix Qwen3-Next PP
+
+- Link: https://github.com/vllm-project/vllm/pull/24709
+- Why it mattered: Corrected pipeline-parallel execution on Qwen3-Next.
+- Runtime path: vllm/vllm/model_executor/models/qwen3_next.py, vllm/vllm/model_executor/models/qwen3_next_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #24957 - Fix the varlen issue in qwen3-next MTP implementation
+
+- Link: https://github.com/vllm-project/vllm/pull/24957
+- Why it mattered: Removed a concrete MTP correctness bug on variable-length batches.
+- Runtime path: vllm/vllm/model_executor/models/qwen3_next.py, vllm/vllm/model_executor/models/qwen3_next_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #24960 - Add prefixes to shared_expert in qwen3-next
+
+- Link: https://github.com/vllm-project/vllm/pull/24960
+- Why it mattered: Fixed ignored-parameter and quantized weight loading for shared experts.
+- Runtime path: vllm/vllm/model_executor/models/qwen3_next.py, vllm/vllm/model_executor/models/qwen3_next_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #25743 - Fix cuda graph capture bug in GDN metadata and a stride bug
+
+- Link: https://github.com/vllm-project/vllm/pull/25743
+- Why it mattered: Stabilized GDN execution under CUDA graphs.
+- Runtime path: vllm/vllm/model_executor/models/qwen3_next.py, vllm/vllm/model_executor/models/qwen3_next_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #31722 - Speed-up of GDN attention decode part
+
+- Link: https://github.com/vllm-project/vllm/pull/31722
+- Why it mattered: Improved decode throughput on the GDN attention path.
+- Runtime path: vllm/vllm/model_executor/models/qwen3_next.py, vllm/vllm/model_executor/models/qwen3_next_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #33657 - Initial support for GDN attention on Qwen3-next/Qwen3.5 (XPU)
+
+- Link: https://github.com/vllm-project/vllm/pull/33657
+- Why it mattered: Extended the family beyond CUDA with XPU GDN coverage.
+- Runtime path: vllm/vllm/model_executor/models/qwen3_next.py, vllm/vllm/model_executor/models/qwen3_next_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-qwen35-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-qwen35-optimization/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: vllm-qwen35-optimization
+description: PR-backed optimization manual for Qwen3.5 in vLLM. Use when Codex needs to audit, debug, extend, or document Qwen3.5 dense / MoE / GDN runtime, MTP, FP8 and NVFP4 quantization, LoRA, and Eagle3 in vLLM.
+---
+
+# vLLM Qwen3.5 Optimization
+
+## Overview
+
+This skill covers Qwen3.5 dense / MoE / GDN runtime, MTP, FP8 and NVFP4 quantization, LoRA, and Eagle3 in vLLM.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/qwen35/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/qwen3_5.py`
+- `vllm/vllm/model_executor/models/qwen3_5_mtp.py`
+
+## Current Main Summary
+
+- Qwen3.5 builds on the Qwen3-Next era work but has its own model registration and quantization details.
+- The hot spots are GDN fusion, FP8/NVFP4 loading, LoRA target naming, and MoE EP precision.
+
+## Key Landed PRs
+
+- [#34110](https://github.com/vllm-project/vllm/pull/34110) `Adding Support for Qwen3.5 Models`: Landed the Qwen3.5 runtime family.
+- [#34697](https://github.com/vllm-project/vllm/pull/34697) `Redo Qwen3.5/Qwen3-Next GDN projector fusion`: Reworked an earlier fusion that had to be reverted.
+- [#35289](https://github.com/vllm-project/vllm/pull/35289) `Fix Qwen3.5 FP8 quantization tuple shard_id weight loading`: Closed a concrete FP8 weight-loading failure.
+- [#36658](https://github.com/vllm-project/vllm/pull/36658) `Add Eagle3 support for Qwen3.5`: Enabled the draft-model fast path.
+- [#37975](https://github.com/vllm-project/vllm/pull/37975) `Extract GatedDeltaNetAttention into shared layer for Qwen3Next and Qwen3.5`: Reduced duplicated GDN logic across related families.
+- [#39181](https://github.com/vllm-project/vllm/pull/39181) `Fix EP precision for Qwen3.5, Qwen3-Next`: Patched a serving-precision bug under expert parallelism.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- BF16 and FP8 Qwen3.5 serve.
+- NVFP4 or MXFP4 quantized startup.
+- LoRA and MTP paths.
+- Expert-parallel precision regression checks.

--- a/skills/model-optimization/vllm/vllm-qwen35-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-qwen35-optimization/references/pr-history.md
@@ -1,0 +1,56 @@
+# vLLM Qwen3.5 PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: supported on current mainline
+- Scope: Qwen3.5 dense / MoE / GDN runtime, MTP, FP8 and NVFP4 quantization, LoRA, and Eagle3 in vLLM.
+
+
+## Landed PRs
+
+### PR #34110 - Adding Support for Qwen3.5 Models
+
+- Link: https://github.com/vllm-project/vllm/pull/34110
+- Why it mattered: Landed the Qwen3.5 runtime family.
+- Runtime path: vllm/vllm/model_executor/models/qwen3_5.py, vllm/vllm/model_executor/models/qwen3_5_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #34697 - Redo Qwen3.5/Qwen3-Next GDN projector fusion
+
+- Link: https://github.com/vllm-project/vllm/pull/34697
+- Why it mattered: Reworked an earlier fusion that had to be reverted.
+- Runtime path: vllm/vllm/model_executor/models/qwen3_5.py, vllm/vllm/model_executor/models/qwen3_5_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #35289 - Fix Qwen3.5 FP8 quantization tuple shard_id weight loading
+
+- Link: https://github.com/vllm-project/vllm/pull/35289
+- Why it mattered: Closed a concrete FP8 weight-loading failure.
+- Runtime path: vllm/vllm/model_executor/models/qwen3_5.py, vllm/vllm/model_executor/models/qwen3_5_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #36658 - Add Eagle3 support for Qwen3.5
+
+- Link: https://github.com/vllm-project/vllm/pull/36658
+- Why it mattered: Enabled the draft-model fast path.
+- Runtime path: vllm/vllm/model_executor/models/qwen3_5.py, vllm/vllm/model_executor/models/qwen3_5_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #37975 - Extract GatedDeltaNetAttention into shared layer for Qwen3Next and Qwen3.5
+
+- Link: https://github.com/vllm-project/vllm/pull/37975
+- Why it mattered: Reduced duplicated GDN logic across related families.
+- Runtime path: vllm/vllm/model_executor/models/qwen3_5.py, vllm/vllm/model_executor/models/qwen3_5_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #39181 - Fix EP precision for Qwen3.5, Qwen3-Next
+
+- Link: https://github.com/vllm-project/vllm/pull/39181
+- Why it mattered: Patched a serving-precision bug under expert parallelism.
+- Runtime path: vllm/vllm/model_executor/models/qwen3_5.py, vllm/vllm/model_executor/models/qwen3_5_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-qwen36-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-qwen36-optimization/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: vllm-qwen36-optimization
+description: PR-backed optimization manual for Qwen3.6 in vLLM. Use when Codex needs to audit, debug, extend, or document Tracking note for Qwen3.6-specific documentation; current vLLM mainline does not expose a dedicated Qwen3.6 architecture alias.
+---
+
+# vLLM Qwen3.6 Optimization
+
+## Overview
+
+This skill covers Tracking note for Qwen3.6-specific documentation; current vLLM mainline does not expose a dedicated Qwen3.6 architecture alias.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: not supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/qwen36/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## Current Main Summary
+
+- Qwen3.6 should not be treated as automatically covered just because Qwen3 / Qwen3.5 are supported.
+- At the current checked commit, there is no dedicated `Qwen3.6` model module or registry alias.
+
+## Key Landed PRs
+
+- No landed PR is recorded yet for this family.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- Re-check the registry and PR search before changing the status.

--- a/skills/model-optimization/vllm/vllm-qwen36-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-qwen36-optimization/references/pr-history.md
@@ -1,0 +1,16 @@
+# vLLM Qwen3.6 PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: not supported on current mainline
+- Scope: Tracking note for Qwen3.6-specific documentation; current vLLM mainline does not expose a dedicated Qwen3.6 architecture alias.
+
+
+## Landed PRs
+
+- No landed PR is recorded yet for this family.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.

--- a/skills/model-optimization/vllm/vllm-step35-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-step35-optimization/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: vllm-step35-optimization
+description: PR-backed optimization manual for Step3.5 / Step3-VL in vLLM. Use when Codex needs to audit, debug, extend, or document Step3.5-Flash and Step3-VL serving, NVFP4, tool/reasoning parser, and HF-style processor evolution.
+---
+
+# vLLM Step3.5 / Step3-VL Optimization
+
+## Overview
+
+This skill covers Step3.5-Flash and Step3-VL serving, NVFP4, tool/reasoning parser, and HF-style processor evolution.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/step35/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/step3p5.py`
+- `vllm/vllm/model_executor/models/step3p5_mtp.py`
+- `vllm/vllm/model_executor/models/step3_vl.py`
+- `vllm/vllm/model_executor/models/step3_text.py`
+
+## Current Main Summary
+
+- Step3.5 is split between text/MTP and VL processor work.
+- NVFP4 and processor behavior are the main axes to track on the vLLM side.
+
+## Key Landed PRs
+
+- [#33755](https://github.com/vllm-project/vllm/pull/33755) `Enable Step3p5ForCausalLM testing`: Stabilized the core Step3.5 text runtime.
+- [#34478](https://github.com/vllm-project/vllm/pull/34478) `Add NVFP4 quantization support for Step3.5-Flash`: Opened the practical quantized deployment path.
+- [#37579](https://github.com/vllm-project/vllm/pull/37579) `Refactor Step3-VL processor to HF style`: Modernized the Step3-VL processor contract.
+
+## Validation Lanes
+
+- Startup on the current vLLM mainline checkpoint.
+- Re-run the parser, quantization, MTP, or multimodal lane that matches this family.
+- Re-check tests after touching loader or processor code.

--- a/skills/model-optimization/vllm/vllm-step35-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-step35-optimization/references/pr-history.md
@@ -1,0 +1,29 @@
+# vLLM Step3.5 / Step3-VL PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Scope: Step3.5-Flash and Step3-VL serving, NVFP4, tool/reasoning parser, and HF-style processor evolution.
+
+## Landed PRs
+
+### PR #33755 - Enable Step3p5ForCausalLM testing
+
+- Link: https://github.com/vllm-project/vllm/pull/33755
+- Why it mattered: Stabilized the core Step3.5 text runtime.
+- Runtime path: vllm/vllm/model_executor/models/step3p5.py, vllm/vllm/model_executor/models/step3p5_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #34478 - Add NVFP4 quantization support for Step3.5-Flash
+
+- Link: https://github.com/vllm-project/vllm/pull/34478
+- Why it mattered: Opened the practical quantized deployment path.
+- Runtime path: vllm/vllm/model_executor/models/step3p5.py, vllm/vllm/model_executor/models/step3p5_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.
+
+### PR #37579 - Refactor Step3-VL processor to HF style
+
+- Link: https://github.com/vllm-project/vllm/pull/37579
+- Why it mattered: Modernized the Step3-VL processor contract.
+- Runtime path: vllm/vllm/model_executor/models/step3p5.py, vllm/vllm/model_executor/models/step3p5_mtp.py
+- Validation / risk: re-check this PR if you touch the same loader, parser, quantization, or multimodal surface.

--- a/skills/model-optimization/vllm/vllm-z-image-turbo-optimization/SKILL.md
+++ b/skills/model-optimization/vllm/vllm-z-image-turbo-optimization/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: vllm-z-image-turbo-optimization
+description: PR-backed optimization manual for Z-Image-Turbo in vLLM. Use when Codex needs to audit, debug, extend, or document Tracking note for Z-Image-Turbo diffusion generation, which is outside vLLM mainline today.
+---
+
+# vLLM Z-Image-Turbo Optimization
+
+## Overview
+
+This skill covers Tracking note for Z-Image-Turbo diffusion generation, which is outside vLLM mainline today.
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: not supported on current mainline
+- Canonical PR notes: `references/pr-history.md`
+- History mirrors: `model-pr-optimization-history/vllm/z-image-turbo/README.zh.md` and `README.en.md`
+
+## Non-Negotiable Evidence Rule
+
+Use `skills/model-optimization/model-pr-diff-dossier/SKILL.md` as the production bar.
+Every PR cited for this family must be based on diff reading, not only PR titles.
+
+## Runtime Surfaces
+
+- `vllm/vllm/model_executor/models/registry.py`
+
+## Current Main Summary
+
+- vLLM current mainline does not ship a Z-Image diffusion runtime.
+- Keep the family explicitly unsupported instead of inferring support from generic multimodal work.
+
+## Key Landed PRs
+
+- No landed PR is recorded yet for this family.
+
+## Open Radar
+
+- Re-run PR search before claiming new support beyond the checked mainline commit.
+
+## Validation Lanes
+
+- Require a real model implementation before changing the status.

--- a/skills/model-optimization/vllm/vllm-z-image-turbo-optimization/references/pr-history.md
+++ b/skills/model-optimization/vllm/vllm-z-image-turbo-optimization/references/pr-history.md
@@ -1,0 +1,15 @@
+# vLLM Z-Image-Turbo PR History
+
+Evidence snapshot:
+
+- vLLM mainline checked around `0f7be0f2f76814f80f9091220a5fbbb53912ad00`
+- Support status: not supported on current mainline
+- Scope: Tracking note for Z-Image-Turbo diffusion generation, which is outside vLLM mainline today.
+
+## Landed PRs
+
+- No landed PR is recorded yet for this family.
+
+## Open PR Radar
+
+- No specific open PR is pinned here; rerun GitHub PR search before asserting new support.


### PR DESCRIPTION
## Summary
- add vLLM model-optimization skills and model-pr-optimization-history dossiers for the existing SGLang model families already covered in this repo
- add 10 additional SGLang model families from cookbook/runtime overlap, and add matching vLLM families plus index updates
- deepen the highest-value dossiers with diff-reviewed evidence for vLLM DeepSeek V4 open radar, vLLM GLM-5/5.1, vLLM Qwen multimodal (VL/Omni/ASR), and SGLang Ernie4.5-VL

## What changed
- refreshed the top-level and per-framework README indexes under `skills/model-optimization/` and `model-pr-optimization-history/`
- added new skill directories and bilingual history docs under `skills/model-optimization/vllm/`, `skills/model-optimization/sglang/`, `model-pr-optimization-history/vllm/`, and `model-pr-optimization-history/sglang/`
- normalized markdown formatting for the newly generated model dossiers

## Notes
- this PR is intentionally opened as draft: the structure and the first major diff-backed family upgrades are in place, but some newly added family dossiers are still shallower than the fully manual per-PR standard described in `skills/model-optimization/model-pr-diff-dossier/`
- no automated tests were run; this change set is documentation/skill content only
