### PR TITLE
Use mean TTFT and TPOT for benchmark comparison

### DIFF
--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -470,12 +470,13 @@ Rank candidates in this order:
 2. highest request throughput or goodput
 3. highest output token throughput
 4. lower mean TTFT
-5. lower p99 TPOT/ITL
+5. lower mean TPOT/ITL
 6. lower GPU count or simpler deployment if performance is close
 
 Keep the SLA gate itself unchanged. In the cookbook configs and normalized
-result schema, TTFT SLA still uses `max_p99_ttft_ms`; only the default
-cross-candidate comparison order switches to mean TTFT.
+result schema, TTFT SLA still uses `max_p99_ttft_ms` and TPOT SLA still uses
+`max_p99_tpot_ms`; only the default cross-candidate comparison order switches
+to mean TTFT and mean TPOT.
 
 ## Output Contract
 

--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -469,9 +469,13 @@ Rank candidates in this order:
 1. SLA passed
 2. highest request throughput or goodput
 3. highest output token throughput
-4. lower p99 TTFT
+4. lower mean TTFT
 5. lower p99 TPOT/ITL
 6. lower GPU count or simpler deployment if performance is close
+
+Keep the SLA gate itself unchanged. In the cookbook configs and normalized
+result schema, TTFT SLA still uses `max_p99_ttft_ms`; only the default
+cross-candidate comparison order switches to mean TTFT.
 
 ## Output Contract
 

--- a/skills/llm-serving-auto-benchmark/references/result-schema.md
+++ b/skills/llm-serving-auto-benchmark/references/result-schema.md
@@ -101,19 +101,23 @@ The default ranking is:
 2. `sla.passed == true`
 3. higher `metrics.request_throughput`
 4. higher `metrics.output_token_throughput`
-5. lower `metrics.p99_ttft_ms`
+5. lower `metrics.mean_ttft_ms`
 6. lower `metrics.p99_tpot_ms`
 7. lower `hardware.gpu_count`
 
 If the user cares more about token throughput than request throughput, swap
 steps 3 and 4 and state that in the final report.
 
+This ranking rule does not change the SLA gate. Keep `sla.max_p99_ttft_ms` as
+the tail-latency constraint; use mean TTFT only for default winner selection
+among rows that have already passed SLA.
+
 Missing metric semantics:
 
-- If a latency field is absent from a row, the ranking script treats it as the
-  worst possible value, so that row falls below any candidate with a real
-  measurement. Do not write `0` as a placeholder for "no measurement"; leave the
-  field out or set it to `null`.
+- If `metrics.mean_ttft_ms` is absent from a row, the ranking script treats it
+  as the worst possible value, so that row falls below any candidate with a
+  real mean-TTFT measurement. Do not write `0` as a placeholder for "no
+  measurement"; leave the field out or set it to `null`.
 - If `metrics.request_throughput` or `metrics.output_token_throughput` is
   missing, the row ranks below any candidate with a real measurement in those
   keys. A failed candidate that still produced partial metrics should keep the

--- a/skills/llm-serving-auto-benchmark/references/result-schema.md
+++ b/skills/llm-serving-auto-benchmark/references/result-schema.md
@@ -102,21 +102,25 @@ The default ranking is:
 3. higher `metrics.request_throughput`
 4. higher `metrics.output_token_throughput`
 5. lower `metrics.mean_ttft_ms`
-6. lower `metrics.p99_tpot_ms`
+6. lower `metrics.mean_tpot_ms`
 7. lower `hardware.gpu_count`
 
 If the user cares more about token throughput than request throughput, swap
 steps 3 and 4 and state that in the final report.
 
-This ranking rule does not change the SLA gate. Keep `sla.max_p99_ttft_ms` as
-the tail-latency constraint; use mean TTFT only for default winner selection
-among rows that have already passed SLA.
+This ranking rule does not change the SLA gate. Keep `sla.max_p99_ttft_ms` and
+`sla.max_p99_tpot_ms` as the tail-latency constraints; use mean TTFT and mean
+TPOT only for default winner selection among rows that have already passed SLA.
 
 Missing metric semantics:
 
 - If `metrics.mean_ttft_ms` is absent from a row, the ranking script treats it
   as the worst possible value, so that row falls below any candidate with a
   real mean-TTFT measurement. Do not write `0` as a placeholder for "no
+  measurement"; leave the field out or set it to `null`.
+- If `metrics.mean_tpot_ms` is absent from a row, the ranking script treats it
+  as the worst possible value, so that row falls below any candidate with a
+  real mean-TPOT measurement. Do not write `0` as a placeholder for "no
   measurement"; leave the field out or set it to `null`.
 - If `metrics.request_throughput` or `metrics.output_token_throughput` is
   missing, the row ranks below any candidate with a real measurement in those

--- a/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
+++ b/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
@@ -40,6 +40,10 @@ def _mean_ttft_ms(row: dict[str, Any]) -> float:
     return _float(row, "metrics.mean_ttft_ms", 1e30)
 
 
+def _mean_tpot_ms(row: dict[str, Any]) -> float:
+    return _float(row, "metrics.mean_tpot_ms", 1e30)
+
+
 def _rank_key(row: dict[str, Any]) -> tuple[Any, ...]:
     return (
         _get(row, "status") == "ok",
@@ -47,7 +51,7 @@ def _rank_key(row: dict[str, Any]) -> tuple[Any, ...]:
         _float(row, "metrics.request_throughput"),
         _float(row, "metrics.output_token_throughput"),
         -_mean_ttft_ms(row),
-        -_float(row, "metrics.p99_tpot_ms", 1e30),
+        -_mean_tpot_ms(row),
         -_float(row, "hardware.gpu_count", 1e30),
     )
 
@@ -140,6 +144,7 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         "request_throughput",
         "output_token_throughput",
         "mean_ttft_ms",
+        "mean_tpot_ms",
         "p99_ttft_ms",
         "p99_tpot_ms",
         "gpu_count",
@@ -162,6 +167,7 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
                         row, "metrics.output_token_throughput", ""
                     ),
                     "mean_ttft_ms": _get(row, "metrics.mean_ttft_ms", ""),
+                    "mean_tpot_ms": _get(row, "metrics.mean_tpot_ms", ""),
                     "p99_ttft_ms": _get(row, "metrics.p99_ttft_ms", ""),
                     "p99_tpot_ms": _get(row, "metrics.p99_tpot_ms", ""),
                     "gpu_count": _get(row, "hardware.gpu_count", ""),
@@ -183,7 +189,7 @@ def _append_best_commands_by_framework(
             [
                 f"### `{framework}`",
                 "",
-                "| Scenario | Candidate | Status | SLA | Req/s | Output tok/s | Total tok/s | Mean TTFT ms | P99 TPOT ms | Success rate | GPUs | Server command | Artifacts |",
+                "| Scenario | Candidate | Status | SLA | Req/s | Output tok/s | Total tok/s | Mean TTFT ms | Mean TPOT ms | Success rate | GPUs | Server command | Artifacts |",
                 "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |",
             ]
         )
@@ -199,7 +205,7 @@ def _append_best_commands_by_framework(
                     otps=_cell(_get(row, "metrics.output_token_throughput")),
                     ttps=_cell(_get(row, "metrics.total_token_throughput")),
                     ttft=_cell(_get(row, "metrics.mean_ttft_ms")),
-                    tpot=_cell(_get(row, "metrics.p99_tpot_ms")),
+                    tpot=_cell(_get(row, "metrics.mean_tpot_ms")),
                     success=_cell(_get(row, "metrics.success_rate")),
                     gpus=_cell(_get(row, "hardware.gpu_count")),
                     command=_cell(_server_command(row)),
@@ -216,7 +222,7 @@ def _append_cross_framework_table(
         [
             "## Cross-Framework Best Comparison",
             "",
-            "| Scenario | Rank | Framework | Candidate | SLA | Req/s | Output tok/s | Mean TTFT ms | P99 TPOT ms | GPUs | Server command |",
+            "| Scenario | Rank | Framework | Candidate | SLA | Req/s | Output tok/s | Mean TTFT ms | Mean TPOT ms | GPUs | Server command |",
             "| --- | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |",
         ]
     )
@@ -234,7 +240,7 @@ def _append_cross_framework_table(
                     rps=_cell(_get(row, "metrics.request_throughput")),
                     otps=_cell(_get(row, "metrics.output_token_throughput")),
                     ttft=_cell(_get(row, "metrics.mean_ttft_ms")),
-                    tpot=_cell(_get(row, "metrics.p99_tpot_ms")),
+                    tpot=_cell(_get(row, "metrics.mean_tpot_ms")),
                     gpus=_cell(_get(row, "hardware.gpu_count")),
                     command=_cell(_server_command(row)),
                 )

--- a/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
+++ b/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
@@ -36,13 +36,17 @@ def _bool(row: dict[str, Any], path: str, default: bool = False) -> bool:
     return bool(value)
 
 
+def _mean_ttft_ms(row: dict[str, Any]) -> float:
+    return _float(row, "metrics.mean_ttft_ms", 1e30)
+
+
 def _rank_key(row: dict[str, Any]) -> tuple[Any, ...]:
     return (
         _get(row, "status") == "ok",
         _bool(row, "sla.passed"),
         _float(row, "metrics.request_throughput"),
         _float(row, "metrics.output_token_throughput"),
-        -_float(row, "metrics.p99_ttft_ms", 1e30),
+        -_mean_ttft_ms(row),
         -_float(row, "metrics.p99_tpot_ms", 1e30),
         -_float(row, "hardware.gpu_count", 1e30),
     )
@@ -135,6 +139,7 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         "sla_passed",
         "request_throughput",
         "output_token_throughput",
+        "mean_ttft_ms",
         "p99_ttft_ms",
         "p99_tpot_ms",
         "gpu_count",
@@ -156,6 +161,7 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
                     "output_token_throughput": _get(
                         row, "metrics.output_token_throughput", ""
                     ),
+                    "mean_ttft_ms": _get(row, "metrics.mean_ttft_ms", ""),
                     "p99_ttft_ms": _get(row, "metrics.p99_ttft_ms", ""),
                     "p99_tpot_ms": _get(row, "metrics.p99_tpot_ms", ""),
                     "gpu_count": _get(row, "hardware.gpu_count", ""),
@@ -177,7 +183,7 @@ def _append_best_commands_by_framework(
             [
                 f"### `{framework}`",
                 "",
-                "| Scenario | Candidate | Status | SLA | Req/s | Output tok/s | Total tok/s | P99 TTFT ms | P99 TPOT ms | Success rate | GPUs | Server command | Artifacts |",
+                "| Scenario | Candidate | Status | SLA | Req/s | Output tok/s | Total tok/s | Mean TTFT ms | P99 TPOT ms | Success rate | GPUs | Server command | Artifacts |",
                 "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |",
             ]
         )
@@ -192,7 +198,7 @@ def _append_best_commands_by_framework(
                     rps=_cell(_get(row, "metrics.request_throughput")),
                     otps=_cell(_get(row, "metrics.output_token_throughput")),
                     ttps=_cell(_get(row, "metrics.total_token_throughput")),
-                    ttft=_cell(_get(row, "metrics.p99_ttft_ms")),
+                    ttft=_cell(_get(row, "metrics.mean_ttft_ms")),
                     tpot=_cell(_get(row, "metrics.p99_tpot_ms")),
                     success=_cell(_get(row, "metrics.success_rate")),
                     gpus=_cell(_get(row, "hardware.gpu_count")),
@@ -210,7 +216,7 @@ def _append_cross_framework_table(
         [
             "## Cross-Framework Best Comparison",
             "",
-            "| Scenario | Rank | Framework | Candidate | SLA | Req/s | Output tok/s | P99 TTFT ms | P99 TPOT ms | GPUs | Server command |",
+            "| Scenario | Rank | Framework | Candidate | SLA | Req/s | Output tok/s | Mean TTFT ms | P99 TPOT ms | GPUs | Server command |",
             "| --- | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |",
         ]
     )
@@ -227,7 +233,7 @@ def _append_cross_framework_table(
                     sla=_cell(_bool(row, "sla.passed")),
                     rps=_cell(_get(row, "metrics.request_throughput")),
                     otps=_cell(_get(row, "metrics.output_token_throughput")),
-                    ttft=_cell(_get(row, "metrics.p99_ttft_ms")),
+                    ttft=_cell(_get(row, "metrics.mean_ttft_ms")),
                     tpot=_cell(_get(row, "metrics.p99_tpot_ms")),
                     gpus=_cell(_get(row, "hardware.gpu_count")),
                     command=_cell(_server_command(row)),

--- a/tests/test_compare_benchmark_results.py
+++ b/tests/test_compare_benchmark_results.py
@@ -40,6 +40,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                     "request_throughput": 99,
                     "output_token_throughput": 990,
                     "mean_ttft_ms": 1,
+                    "mean_tpot_ms": 1,
                     "p99_ttft_ms": 1,
                     "p99_tpot_ms": 1,
                 },
@@ -65,6 +66,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                     "request_throughput": 10,
                     "output_token_throughput": 100,
                     "mean_ttft_ms": 50,
+                    "mean_tpot_ms": 5,
                     "p99_ttft_ms": 50,
                     "p99_tpot_ms": 5,
                 },
@@ -80,6 +82,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                     "request_throughput": 12,
                     "output_token_throughput": 90,
                     "mean_ttft_ms": 60,
+                    "mean_tpot_ms": 6,
                     "p99_ttft_ms": 60,
                     "p99_tpot_ms": 6,
                 },
@@ -132,6 +135,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
         self.assertIn("trt-c1", text)
         self.assertIn("server exited", text)
         self.assertIn("mean_ttft_ms", text)
+        self.assertIn("mean_tpot_ms", text)
         self.assertNotIn("mmlu_accuracy", text)
         self.assertNotIn("gsm8k_accuracy", text)
 
@@ -167,6 +171,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                     "request_throughput": 10,
                     "output_token_throughput": 100,
                     "mean_ttft_ms": 80,
+                    "mean_tpot_ms": 6,
                     "p99_ttft_ms": 80,
                     "p99_tpot_ms": 6,
                     "success_rate": 1.0,
@@ -184,6 +189,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                     "request_throughput": 12,
                     "output_token_throughput": 90,
                     "mean_ttft_ms": 85,
+                    "mean_tpot_ms": 7,
                     "p99_ttft_ms": 85,
                     "p99_tpot_ms": 7,
                 },
@@ -200,6 +206,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                     "request_throughput": 8,
                     "output_token_throughput": 140,
                     "mean_ttft_ms": 120,
+                    "mean_tpot_ms": 8,
                     "p99_ttft_ms": 120,
                     "p99_tpot_ms": 8,
                 },
@@ -227,7 +234,9 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
         self.assertNotIn("MMLU", summary)
         self.assertNotIn("GSM8K", summary)
         self.assertIn("Mean TTFT ms", summary)
+        self.assertIn("Mean TPOT ms", summary)
         self.assertNotIn("P99 TTFT ms", summary)
+        self.assertNotIn("P99 TPOT ms", summary)
 
     def test_ranking_prefers_lower_mean_ttft_over_lower_p99_ttft(self) -> None:
         rows = [
@@ -241,6 +250,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                     "request_throughput": 10,
                     "output_token_throughput": 100,
                     "mean_ttft_ms": 40,
+                    "mean_tpot_ms": 5,
                     "p99_ttft_ms": 200,
                     "p99_tpot_ms": 5,
                 },
@@ -256,6 +266,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                     "request_throughput": 10,
                     "output_token_throughput": 100,
                     "mean_ttft_ms": 50,
+                    "mean_tpot_ms": 5,
                     "p99_ttft_ms": 100,
                     "p99_tpot_ms": 5,
                 },
@@ -265,6 +276,47 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
 
         winners = self.mod.best_by_framework_and_scenario(rows)
         self.assertEqual([row["candidate_id"] for row in winners], ["sglang-lower-mean"])
+
+    def test_ranking_prefers_lower_mean_tpot_over_lower_p99_tpot(self) -> None:
+        rows = [
+            {
+                "framework": "sglang",
+                "candidate_id": "sglang-lower-mean-tpot",
+                "status": "ok",
+                "workload": {"scenario": "chat"},
+                "sla": {"passed": True},
+                "metrics": {
+                    "request_throughput": 10,
+                    "output_token_throughput": 100,
+                    "mean_ttft_ms": 40,
+                    "mean_tpot_ms": 5,
+                    "p99_ttft_ms": 100,
+                    "p99_tpot_ms": 20,
+                },
+                "hardware": {"gpu_count": 1},
+            },
+            {
+                "framework": "sglang",
+                "candidate_id": "sglang-lower-p99-tpot",
+                "status": "ok",
+                "workload": {"scenario": "chat"},
+                "sla": {"passed": True},
+                "metrics": {
+                    "request_throughput": 10,
+                    "output_token_throughput": 100,
+                    "mean_ttft_ms": 40,
+                    "mean_tpot_ms": 6,
+                    "p99_ttft_ms": 100,
+                    "p99_tpot_ms": 10,
+                },
+                "hardware": {"gpu_count": 1},
+            },
+        ]
+
+        winners = self.mod.best_by_framework_and_scenario(rows)
+        self.assertEqual(
+            [row["candidate_id"] for row in winners], ["sglang-lower-mean-tpot"]
+        )
 
     def test_cli_writes_markdown_and_csv(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -281,6 +333,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                     "request_throughput": 1.5,
                     "output_token_throughput": 8.0,
                     "mean_ttft_ms": 10.0,
+                    "mean_tpot_ms": 2.0,
                 },
                 "hardware": {"gpu_count": 1},
             }

--- a/tests/test_compare_benchmark_results.py
+++ b/tests/test_compare_benchmark_results.py
@@ -39,6 +39,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                 "metrics": {
                     "request_throughput": 99,
                     "output_token_throughput": 990,
+                    "mean_ttft_ms": 1,
                     "p99_ttft_ms": 1,
                     "p99_tpot_ms": 1,
                 },
@@ -63,6 +64,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                 "metrics": {
                     "request_throughput": 10,
                     "output_token_throughput": 100,
+                    "mean_ttft_ms": 50,
                     "p99_ttft_ms": 50,
                     "p99_tpot_ms": 5,
                 },
@@ -77,6 +79,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                 "metrics": {
                     "request_throughput": 12,
                     "output_token_throughput": 90,
+                    "mean_ttft_ms": 60,
                     "p99_ttft_ms": 60,
                     "p99_tpot_ms": 6,
                 },
@@ -128,6 +131,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
 
         self.assertIn("trt-c1", text)
         self.assertIn("server exited", text)
+        self.assertIn("mean_ttft_ms", text)
         self.assertNotIn("mmlu_accuracy", text)
         self.assertNotIn("gsm8k_accuracy", text)
 
@@ -162,6 +166,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                 "metrics": {
                     "request_throughput": 10,
                     "output_token_throughput": 100,
+                    "mean_ttft_ms": 80,
                     "p99_ttft_ms": 80,
                     "p99_tpot_ms": 6,
                     "success_rate": 1.0,
@@ -178,6 +183,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                 "metrics": {
                     "request_throughput": 12,
                     "output_token_throughput": 90,
+                    "mean_ttft_ms": 85,
                     "p99_ttft_ms": 85,
                     "p99_tpot_ms": 7,
                 },
@@ -193,6 +199,7 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                 "metrics": {
                     "request_throughput": 8,
                     "output_token_throughput": 140,
+                    "mean_ttft_ms": 120,
                     "p99_ttft_ms": 120,
                     "p99_tpot_ms": 8,
                 },
@@ -219,6 +226,45 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
         self.assertNotIn("Accuracy Of Selected Deployment Commands", summary)
         self.assertNotIn("MMLU", summary)
         self.assertNotIn("GSM8K", summary)
+        self.assertIn("Mean TTFT ms", summary)
+        self.assertNotIn("P99 TTFT ms", summary)
+
+    def test_ranking_prefers_lower_mean_ttft_over_lower_p99_ttft(self) -> None:
+        rows = [
+            {
+                "framework": "sglang",
+                "candidate_id": "sglang-lower-mean",
+                "status": "ok",
+                "workload": {"scenario": "chat"},
+                "sla": {"passed": True},
+                "metrics": {
+                    "request_throughput": 10,
+                    "output_token_throughput": 100,
+                    "mean_ttft_ms": 40,
+                    "p99_ttft_ms": 200,
+                    "p99_tpot_ms": 5,
+                },
+                "hardware": {"gpu_count": 1},
+            },
+            {
+                "framework": "sglang",
+                "candidate_id": "sglang-lower-p99",
+                "status": "ok",
+                "workload": {"scenario": "chat"},
+                "sla": {"passed": True},
+                "metrics": {
+                    "request_throughput": 10,
+                    "output_token_throughput": 100,
+                    "mean_ttft_ms": 50,
+                    "p99_ttft_ms": 100,
+                    "p99_tpot_ms": 5,
+                },
+                "hardware": {"gpu_count": 1},
+            },
+        ]
+
+        winners = self.mod.best_by_framework_and_scenario(rows)
+        self.assertEqual([row["candidate_id"] for row in winners], ["sglang-lower-mean"])
 
     def test_cli_writes_markdown_and_csv(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -231,7 +277,11 @@ class CompareBenchmarkResultsTest(unittest.TestCase):
                 "candidate_id": "candidate-1",
                 "status": "ok",
                 "sla": {"passed": True},
-                "metrics": {"request_throughput": 1.5, "output_token_throughput": 8.0},
+                "metrics": {
+                    "request_throughput": 1.5,
+                    "output_token_throughput": 8.0,
+                    "mean_ttft_ms": 10.0,
+                },
                 "hardware": {"gpu_count": 1},
             }
             input_path.write_text(json.dumps(row) + "\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- switch the default benchmark winner selection from `p99_ttft_ms` / `p99_tpot_ms` to `mean_ttft_ms` / `mean_tpot_ms`
- update the markdown/CSV summary output to show `Mean TTFT ms` and `Mean TPOT ms` as the comparison columns
- document that `max_p99_ttft_ms` and `max_p99_tpot_ms` remain the SLA gates
- add regression tests that prove lower mean TTFT / mean TPOT now win even when the corresponding p99 metrics are worse

## Validation
- `python3 -m pytest -q tests/test_compare_benchmark_results.py`
- `python3 skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py skills/llm-serving-auto-benchmark/configs/cookbook-llm`
