### PR TITLE
Enable trust_remote_code for GLM cookbook configs

### DIFF
--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.5.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.5.yaml
@@ -55,6 +55,7 @@ frameworks:
       tp_size: 4
       context_length: 9000
       model_path: zai-org/GLM-4.5
+      trust_remote_code: true
       mem_fraction_static: 0.82
       schedule_policy: lpm
     search_space:
@@ -71,6 +72,7 @@ frameworks:
     config_source: framework_generic_translation
     base_server_flags:
       tensor_parallel_size: 4
+      trust_remote_code: true
       gpu_memory_utilization: 0.9
       max_model_len: 9000
       dtype: auto
@@ -104,6 +106,7 @@ frameworks:
       backend: pytorch
       tp_size: 4
       pp_size: 1
+      trust_remote_code: true
       kv_cache_free_gpu_memory_fraction: 0.75
       max_seq_len: 9000
     search_space:

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.6.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.6.yaml
@@ -54,6 +54,7 @@ frameworks:
     base_server_flags:
       tp_size: 8
       model_path: zai-org/GLM-4.6
+      trust_remote_code: true
       mem_fraction_static: 0.82
       schedule_policy: lpm
     search_space:
@@ -80,6 +81,7 @@ frameworks:
     config_source: framework_generic_translation
     base_server_flags:
       tensor_parallel_size: 8
+      trust_remote_code: true
       gpu_memory_utilization: 0.9
       max_model_len: 12288
       dtype: auto
@@ -113,6 +115,7 @@ frameworks:
       backend: pytorch
       tp_size: 8
       pp_size: 1
+      trust_remote_code: true
       kv_cache_free_gpu_memory_fraction: 0.75
       max_seq_len: 12288
     search_space:

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7-flash.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7-flash.yaml
@@ -53,6 +53,7 @@ frameworks:
     server_command: python -m sglang.launch_server
     base_server_flags:
       model_path: zai-org/GLM-4.7-Flash
+      trust_remote_code: true
       mem_fraction_static: 0.82
       schedule_policy: lpm
     search_space:
@@ -75,6 +76,7 @@ frameworks:
     config_source: framework_generic_translation
     base_server_flags:
       tensor_parallel_size: 1
+      trust_remote_code: true
       gpu_memory_utilization: 0.9
       max_model_len: 12288
       dtype: auto
@@ -108,6 +110,7 @@ frameworks:
       backend: pytorch
       tp_size: 1
       pp_size: 1
+      trust_remote_code: true
       kv_cache_free_gpu_memory_fraction: 0.75
       max_seq_len: 12288
     search_space:

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7.yaml
@@ -55,6 +55,7 @@ frameworks:
       tp_size: 4
       context_length: 9000
       model_path: zai-org/GLM-4.7
+      trust_remote_code: true
       mem_fraction_static: 0.82
       schedule_policy: lpm
     search_space:
@@ -75,6 +76,7 @@ frameworks:
     config_source: framework_generic_translation
     base_server_flags:
       tensor_parallel_size: 4
+      trust_remote_code: true
       gpu_memory_utilization: 0.9
       max_model_len: 9000
       dtype: auto
@@ -108,6 +110,7 @@ frameworks:
       backend: pytorch
       tp_size: 4
       pp_size: 1
+      trust_remote_code: true
       kv_cache_free_gpu_memory_fraction: 0.75
       max_seq_len: 9000
     search_space:

--- a/tests/test_llm_serving_cookbook_configs.py
+++ b/tests/test_llm_serving_cookbook_configs.py
@@ -83,6 +83,21 @@ class LlmServingCookbookConfigsTest(unittest.TestCase):
         self.assertIn("--tp_size 8", trt_command)
         self.assertNotIn("--tp-size", trt_command)
 
+    def test_glm_configs_explicitly_enable_trust_remote_code(self) -> None:
+        glm_configs = (
+            "glm-4.5.yaml",
+            "glm-4.6.yaml",
+            "glm-4.7.yaml",
+            "glm-4.7-flash.yaml",
+        )
+
+        for config_name in glm_configs:
+            config = self.load_config(CONFIG_ROOT / config_name)
+            with self.subTest(path=config_name):
+                for framework in self.mod.FRAMEWORKS:
+                    flags = config["frameworks"][framework]["base_server_flags"]
+                    self.assertIs(flags.get("trust_remote_code"), True)
+
     def test_help_snapshot_path_validates_all_config_flags(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             help_dir = Path(tmp)


### PR DESCRIPTION
## Summary
- enable `trust_remote_code: true` in the GLM cookbook configs that need remote model code in benchmark bring-up
- cover `glm-4.5`, `glm-4.6`, `glm-4.7`, and `glm-4.7-flash`
- add a regression test for the cookbook config validator

## Validation
- `python3 -m pytest -q tests/test_llm_serving_cookbook_configs.py`
- `python3 skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py skills/llm-serving-auto-benchmark/configs/cookbook-llm`