### PR TITLE
[codex] Add KernelPilot kernel optimization framework

### DIFF
--- a/kernel-pilot/README.md
+++ b/kernel-pilot/README.md
@@ -1,0 +1,105 @@
+# KernelPilot
+
+KernelPilot is a small, stdlib-only framework for Codex-driven kernel
+optimization. It keeps the useful parts of the paper-inspired loop while using
+our own naming and repo layout.
+
+The core workflow is:
+
+1. define one kernel task with semantic spec, forbidden source files,
+   correctness gates, benchmark cases, and target speedup;
+2. generate a focused Codex prompt from task metadata, source references, and
+   lineage;
+3. implement one candidate at a time from the semantic spec;
+4. run correctness first, then benchmark every configured case;
+5. record both wins and failed directions so the next iteration has context.
+
+## Layout
+
+- `kernelpilot/`: task config loader, prompt builder, lineage store, scoring,
+  knowledge-base rendering, and stagnation hints.
+- `references/`: method notes plus the kernel-source catalog used as reference
+  map before edits.
+- `templates/`: reusable prompts, including the Codex goal prompt template.
+
+Task directories and run artifacts are intentionally user-created inputs. Keep
+operator-specific reproductions, lineage, and benchmark results outside the
+framework tree unless they are meant to be reviewed as examples.
+
+## Contract
+
+KernelPilot intentionally separates semantics from existing optimized kernel
+implementations.
+
+A candidate starts from:
+
+- the operator semantic spec in the task file;
+- a trusted reference expression or test oracle;
+- benchmark shape and dtype contracts;
+- previous lineage entries, if any;
+- approved reference material such as FlashInfer, FlashAttention,
+  Tencent `hpc-ops`, DeepGEMM, and local GPU-kernel references.
+
+A candidate must not copy or pattern-match from the optimized baseline kernel or the
+current target implementation. Target-project tests and wrappers may be used as
+correctness or integration oracles after the candidate exists.
+
+## Knowledge Base
+
+Print the relevant reference map before editing:
+
+```bash
+python -m kernelpilot.cli refs --lane "CUDA C++ JIT"
+```
+
+The current catalog includes:
+
+- user-configured local GPU-kernel reference docs;
+- user-configured target kernel project worktree;
+- verified public kernel repositories: FlashInfer, FlashAttention,
+  Tencent `hpc-ops` / hi-ops, and DeepGEMM;
+- target-project source is treated as an integration and validation oracle, not
+  as an external kernel reference.
+
+## Minimal Use
+
+Validate a task set:
+
+```bash
+python -m kernelpilot.cli validate \
+  --taskset <taskset.json>
+```
+
+Generate the next iteration prompt for a task:
+
+```bash
+python -m kernelpilot.cli prompt \
+  --taskset <taskset.json> \
+  --task <task-id>
+```
+
+Compare a candidate benchmark JSON against the matching baseline:
+
+```bash
+python -m kernelpilot.cli compare \
+  --taskset <taskset.json> \
+  --task <task-id> \
+  --result <candidate-result.json>
+```
+
+Expected candidate result format:
+
+```json
+{
+  "correct": true,
+  "measurements": [
+    {"case_id": "n=4194304", "latency_us": 10.9}
+  ]
+}
+```
+
+## Goal Prompt Template
+
+Use [templates/kernel-goal-prompt.md](templates/kernel-goal-prompt.md)
+as the top-level Codex goal. Fill in the operator, target speedup, GPU, baseline,
+and validation requirements; Codex can then keep iterating until the gate is met.

--- a/kernel-pilot/kernelpilot/__init__.py
+++ b/kernel-pilot/kernelpilot/__init__.py
@@ -1,0 +1,15 @@
+"""KernelPilot kernel iteration helpers."""
+
+from .config import KernelTask, TaskSet, load_taskset
+from .knowledge import load_catalog, render_catalog_for_prompt
+from .scoring import ScoreSummary, score_against_baseline
+
+__all__ = [
+    "KernelTask",
+    "ScoreSummary",
+    "TaskSet",
+    "load_catalog",
+    "load_taskset",
+    "render_catalog_for_prompt",
+    "score_against_baseline",
+]

--- a/kernel-pilot/kernelpilot/cli.py
+++ b/kernel-pilot/kernelpilot/cli.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+import json
+from pathlib import Path
+import sys
+
+from .config import ConfigError, load_taskset
+from .evaluator import load_result
+from .knowledge import load_catalog, render_catalog_for_prompt
+from .lineage import LineageEntry, LineageStore
+from .prompting import build_iteration_prompt
+from .scoring import score_against_baseline
+from .supervisor import supervisor_hints
+
+
+def _load_lineage(args: argparse.Namespace) -> list[LineageEntry]:
+    if not getattr(args, "lineage_root", None):
+        return []
+    return LineageStore(args.lineage_root, args.task).load()
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    taskset = load_taskset(args.taskset)
+    print(
+        json.dumps(
+            {
+                "name": taskset.name,
+                "base_repo": taskset.base_repo,
+                "base_ref": taskset.base_ref,
+                "tasks": [task.task_id for task in taskset.tasks],
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+def cmd_prompt(args: argparse.Namespace) -> int:
+    taskset = load_taskset(args.taskset)
+    task = taskset.task_by_id(args.task)
+    lineage = _load_lineage(args)
+    print(build_iteration_prompt(taskset, task, lineage))
+    for hint in supervisor_hints(task, lineage):
+        print(f"- supervisor: {hint}", file=sys.stderr)
+    return 0
+
+
+def cmd_compare(args: argparse.Namespace) -> int:
+    taskset = load_taskset(args.taskset)
+    task = taskset.task_by_id(args.task)
+    result = load_result(args.result)
+    summary = score_against_baseline(task, result)
+    print(json.dumps(asdict(summary), indent=2, sort_keys=True))
+    return 0 if summary.correct else 2
+
+
+def cmd_record(args: argparse.Namespace) -> int:
+    taskset = load_taskset(args.taskset)
+    task = taskset.task_by_id(args.task)
+    result = load_result(args.result)
+    summary = score_against_baseline(task, result)
+    store = LineageStore(args.lineage_root, args.task)
+    entry = LineageEntry(
+        version=args.version,
+        task_id=task.task_id,
+        candidate_ref=args.candidate_ref,
+        score=asdict(summary),
+        notes=Path(args.notes).read_text(encoding="utf-8") if args.notes else "",
+    )
+    store.append(entry)
+    print(json.dumps({"recorded": args.version, "lineage": str(store.path)}, indent=2))
+    return 0
+
+
+def cmd_refs(args: argparse.Namespace) -> int:
+    catalog = load_catalog(args.catalog)
+    print(render_catalog_for_prompt(catalog, lane=args.lane))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="KernelPilot kernel iteration helper")
+    sub = parser.add_subparsers(required=True)
+
+    validate = sub.add_parser("validate")
+    validate.add_argument("--taskset", required=True)
+    validate.set_defaults(func=cmd_validate)
+
+    prompt = sub.add_parser("prompt")
+    prompt.add_argument("--taskset", required=True)
+    prompt.add_argument("--task", required=True)
+    prompt.add_argument("--lineage-root")
+    prompt.set_defaults(func=cmd_prompt)
+
+    compare = sub.add_parser("compare")
+    compare.add_argument("--taskset", required=True)
+    compare.add_argument("--task", required=True)
+    compare.add_argument("--result", required=True)
+    compare.set_defaults(func=cmd_compare)
+
+    record = sub.add_parser("record")
+    record.add_argument("--taskset", required=True)
+    record.add_argument("--task", required=True)
+    record.add_argument("--result", required=True)
+    record.add_argument("--lineage-root", required=True)
+    record.add_argument("--version", required=True)
+    record.add_argument("--candidate-ref", required=True)
+    record.add_argument("--notes")
+    record.set_defaults(func=cmd_record)
+
+    refs = sub.add_parser("refs")
+    refs.add_argument("--lane")
+    refs.add_argument("--catalog")
+    refs.set_defaults(func=cmd_refs)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except ConfigError as exc:
+        parser.error(str(exc))
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kernel-pilot/kernelpilot/config.py
+++ b/kernel-pilot/kernelpilot/config.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+
+class ConfigError(ValueError):
+    """Raised when a KernelPilot taskset is malformed."""
+
+
+@dataclass(frozen=True)
+class KernelTask:
+    task_id: str
+    title: str
+    baseline_id: str
+    baseline_url: str
+    operator: str
+    lane: str
+    semantic_spec: str
+    forbidden_files: tuple[str, ...]
+    correctness: tuple[str, ...]
+    benchmark_command: str
+    baseline: tuple[dict[str, Any], ...]
+    search_space: tuple[str, ...]
+    notes: str = ""
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "KernelTask":
+        required = [
+            "id",
+            "title",
+            "baseline_id",
+            "baseline_url",
+            "operator",
+            "lane",
+            "semantic_spec",
+            "forbidden_files",
+            "correctness",
+            "benchmark_command",
+            "baseline",
+            "search_space",
+        ]
+        missing = [key for key in required if key not in raw]
+        if missing:
+            raise ConfigError(f"task missing required keys: {missing}")
+        baseline = tuple(raw["baseline"])
+        if not baseline:
+            raise ConfigError(f"task {raw['id']} has empty baseline")
+        for row in baseline:
+            if "case_id" not in row or "baseline_latency_us" not in row:
+                raise ConfigError(
+                    f"task {raw['id']} baseline rows need case_id and baseline_latency_us"
+                )
+        return cls(
+            task_id=str(raw["id"]),
+            title=str(raw["title"]),
+            baseline_id=str(raw["baseline_id"]),
+            baseline_url=str(raw["baseline_url"]),
+            operator=str(raw["operator"]),
+            lane=str(raw["lane"]),
+            semantic_spec=str(raw["semantic_spec"]),
+            forbidden_files=tuple(str(x) for x in raw["forbidden_files"]),
+            correctness=tuple(str(x) for x in raw["correctness"]),
+            benchmark_command=str(raw["benchmark_command"]),
+            baseline=baseline,
+            search_space=tuple(str(x) for x in raw["search_space"]),
+            notes=str(raw.get("notes", "")),
+        )
+
+
+@dataclass(frozen=True)
+class TaskSet:
+    name: str
+    base_repo: str
+    base_ref: str
+    paper_url: str
+    tasks: tuple[KernelTask, ...]
+    global_rules: tuple[str, ...]
+
+    def task_by_id(self, task_id: str) -> KernelTask:
+        for task in self.tasks:
+            if task.task_id == task_id:
+                return task
+        known = ", ".join(task.task_id for task in self.tasks)
+        raise ConfigError(f"unknown task {task_id!r}; known tasks: {known}")
+
+
+def load_taskset(path: str | Path) -> TaskSet:
+    taskset_path = Path(path)
+    raw = json.loads(taskset_path.read_text(encoding="utf-8"))
+    required = ["name", "base_repo", "base_ref", "paper_url", "tasks", "global_rules"]
+    missing = [key for key in required if key not in raw]
+    if missing:
+        raise ConfigError(f"taskset missing required keys: {missing}")
+    tasks = tuple(KernelTask.from_dict(task) for task in raw["tasks"])
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for task in tasks:
+        if task.task_id in seen:
+            duplicates.append(task.task_id)
+        seen.add(task.task_id)
+    if duplicates:
+        raise ConfigError(f"duplicate task ids: {duplicates}")
+    return TaskSet(
+        name=str(raw["name"]),
+        base_repo=str(raw["base_repo"]),
+        base_ref=str(raw["base_ref"]),
+        paper_url=str(raw["paper_url"]),
+        tasks=tasks,
+        global_rules=tuple(str(rule) for rule in raw["global_rules"]),
+    )

--- a/kernel-pilot/kernelpilot/evaluator.py
+++ b/kernel-pilot/kernelpilot/evaluator.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import subprocess
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    command: str
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def run_command(command: str, *, cwd: str | Path | None = None, timeout_s: int = 900) -> CommandResult:
+    completed = subprocess.run(
+        command,
+        cwd=str(cwd) if cwd is not None else None,
+        shell=True,
+        text=True,
+        capture_output=True,
+        timeout=timeout_s,
+        check=False,
+    )
+    return CommandResult(
+        command=command,
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+def load_result(path: str | Path) -> dict:
+    return json.loads(Path(path).read_text(encoding="utf-8"))

--- a/kernel-pilot/kernelpilot/knowledge.py
+++ b/kernel-pilot/kernelpilot/knowledge.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def default_catalog_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "references" / "kernel-source-catalog.json"
+
+
+def load_catalog(path: str | Path | None = None) -> dict[str, Any]:
+    catalog_path = Path(path) if path else default_catalog_path()
+    return json.loads(catalog_path.read_text(encoding="utf-8"))
+
+
+def relevant_sources(catalog: dict[str, Any], *, lane: str | None = None) -> list[dict[str, Any]]:
+    lane_lower = (lane or "").lower()
+    rows: list[dict[str, Any]] = []
+    for source in catalog.get("local_references", []):
+        rows.append(source)
+    for source in catalog.get("external_repositories", []):
+        if not lane_lower:
+            rows.append(source)
+            continue
+        haystack = " ".join(
+            [
+                source.get("name", ""),
+                " ".join(source.get("read_when", [])),
+                " ".join(source.get("kernel_paths", [])),
+            ]
+        ).lower()
+        if any(token in haystack for token in lane_lower.replace("+", " ").split()):
+            rows.append(source)
+    return rows
+
+
+def render_catalog_for_prompt(catalog: dict[str, Any], *, lane: str | None = None) -> str:
+    lines: list[str] = []
+    for source in relevant_sources(catalog, lane=lane):
+        name = source.get("name") or source.get("repo")
+        location = source.get("path") or source.get("url")
+        lines.append(f"- {name}: {location}")
+        paths = source.get("must_read_first") or source.get("kernel_paths") or []
+        for path in paths[:8]:
+            lines.append(f"  - {path}")
+    rejected = catalog.get("unconfirmed_or_rejected_aliases", [])
+    if rejected:
+        lines.append("- Do not use unconfirmed aliases unless revalidated:")
+        for item in rejected:
+            lines.append(f"  - {item.get('name')}: {item.get('status')}")
+    return "\n".join(lines)

--- a/kernel-pilot/kernelpilot/lineage.py
+++ b/kernel-pilot/kernelpilot/lineage.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class LineageEntry:
+    version: str
+    task_id: str
+    candidate_ref: str
+    score: dict[str, Any]
+    notes: str
+
+
+class LineageStore:
+    """Persistent single-lineage store used by the KernelPilot loop."""
+
+    def __init__(self, root: str | Path, task_id: str) -> None:
+        self.root = Path(root)
+        self.task_id = task_id
+        self.path = self.root / task_id / "lineage.json"
+
+    def load(self) -> list[LineageEntry]:
+        if not self.path.exists():
+            return []
+        raw = json.loads(self.path.read_text(encoding="utf-8"))
+        return [LineageEntry(**entry) for entry in raw.get("entries", [])]
+
+    def append(self, entry: LineageEntry) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        entries = self.load()
+        entries.append(entry)
+        payload = {"task_id": self.task_id, "entries": [asdict(item) for item in entries]}
+        self.path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+    def best(self) -> LineageEntry | None:
+        entries = self.load()
+        if not entries:
+            return None
+        return max(
+            entries,
+            key=lambda item: float(item.score.get("geomean_vs_baseline", 0.0)),
+        )

--- a/kernel-pilot/kernelpilot/prompting.py
+++ b/kernel-pilot/kernelpilot/prompting.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from .config import KernelTask, TaskSet
+from .knowledge import load_catalog, render_catalog_for_prompt
+from .lineage import LineageEntry
+
+
+def build_iteration_prompt(
+    taskset: TaskSet,
+    task: KernelTask,
+    lineage: list[LineageEntry],
+) -> str:
+    best = max(
+        lineage,
+        key=lambda entry: float(entry.score.get("geomean_vs_baseline", 0.0)),
+        default=None,
+    )
+    best_text = "No committed KernelPilot candidate exists yet."
+    if best is not None:
+        best_text = (
+            f"Best committed candidate: {best.version}, "
+            f"geomean_vs_baseline={best.score.get('geomean_vs_baseline', 0.0)}."
+        )
+
+    rules = "\n".join(f"- {rule}" for rule in taskset.global_rules)
+    forbidden = "\n".join(f"- {path}" for path in task.forbidden_files)
+    correctness = "\n".join(f"- {item}" for item in task.correctness)
+    search = "\n".join(f"- {item}" for item in task.search_space)
+    baselines = "\n".join(
+        f"- {row['case_id']}: baseline latency {row['baseline_latency_us']} us"
+        for row in task.baseline
+    )
+    knowledge = render_catalog_for_prompt(load_catalog(), lane=task.lane)
+
+    return f"""You are the KernelPilot iteration agent for one kernel task.
+
+Task: {task.task_id}
+Title: {task.title}
+Base repository: {taskset.base_repo} at {taskset.base_ref}
+Method reference: {taskset.paper_url}
+Baseline source: {task.baseline_url}
+Implementation lane: {task.lane}
+
+KernelPilot operating rules:
+{rules}
+
+Forbidden implementation inputs:
+{forbidden}
+
+Semantic spec:
+{task.semantic_spec}
+
+Correctness gates:
+{correctness}
+
+Benchmark command:
+{task.benchmark_command}
+
+Baseline cases to beat:
+{baselines}
+
+Search-space hints:
+{search}
+
+Knowledge base K to consult before edits:
+{knowledge}
+
+Current lineage:
+{best_text}
+
+Iteration objective:
+1. Start from the semantic spec and write a fresh candidate implementation.
+2. Run correctness first, then benchmark every configured case.
+3. If correctness fails or speed regresses, diagnose and revise before commit.
+4. Commit only a candidate that is correct and improves the best lineage score.
+5. Record failed directions in notes so the supervisor can redirect later.
+"""

--- a/kernel-pilot/kernelpilot/scoring.py
+++ b/kernel-pilot/kernelpilot/scoring.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Any
+
+from .config import KernelTask
+
+
+@dataclass(frozen=True)
+class ScoreSummary:
+    correct: bool
+    matched_cases: int
+    missing_cases: tuple[str, ...]
+    geomean_vs_baseline: float
+    clearly_better_than_baseline: bool
+    per_case: tuple[dict[str, float | str], ...]
+
+
+def _geomean(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    if any(value <= 0 for value in values):
+        return 0.0
+    return math.exp(sum(math.log(value) for value in values) / len(values))
+
+
+def score_against_baseline(
+    task: KernelTask,
+    result: dict[str, Any],
+    *,
+    improvement_threshold: float = 1.05,
+    per_case_floor: float = 1.0,
+) -> ScoreSummary:
+    """Compare candidate latency rows to the configured baseline for one task.
+
+    A ratio above 1.0 means the candidate is faster than the baseline for
+    that case. A candidate is "clearly better" only when it is correct, covers
+    every configured case, and beats the baseline geomean by the threshold.
+    """
+
+    correct = bool(result.get("correct", False))
+    measurements = {
+        str(row["case_id"]): float(row["latency_us"])
+        for row in result.get("measurements", [])
+        if "case_id" in row and "latency_us" in row
+    }
+
+    ratios: list[float] = []
+    per_case: list[dict[str, float | str]] = []
+    missing: list[str] = []
+    for baseline in task.baseline:
+        case_id = str(baseline["case_id"])
+        baseline_latency = float(baseline["baseline_latency_us"])
+        candidate_latency = measurements.get(case_id)
+        if candidate_latency is None:
+            missing.append(case_id)
+            continue
+        ratio = baseline_latency / candidate_latency if candidate_latency > 0 else 0.0
+        ratios.append(ratio)
+        per_case.append(
+            {
+                "case_id": case_id,
+                "baseline_latency_us": baseline_latency,
+                "candidate_latency_us": candidate_latency,
+                "speedup_vs_baseline": ratio,
+            }
+        )
+
+    geomean = _geomean(ratios)
+    no_case_regressed = bool(ratios) and min(ratios) >= per_case_floor
+    clearly_better = (
+        correct
+        and not missing
+        and len(ratios) == len(task.baseline)
+        and no_case_regressed
+        and geomean >= improvement_threshold
+    )
+    if not correct:
+        geomean = 0.0
+        clearly_better = False
+
+    return ScoreSummary(
+        correct=correct,
+        matched_cases=len(ratios),
+        missing_cases=tuple(missing),
+        geomean_vs_baseline=geomean,
+        clearly_better_than_baseline=clearly_better,
+        per_case=tuple(per_case),
+    )

--- a/kernel-pilot/kernelpilot/supervisor.py
+++ b/kernel-pilot/kernelpilot/supervisor.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from .config import KernelTask
+from .lineage import LineageEntry
+
+
+def is_stagnated(
+    lineage: list[LineageEntry],
+    *,
+    window: int = 3,
+    min_relative_gain: float = 0.005,
+) -> bool:
+    if len(lineage) <= window:
+        return False
+    scores = [
+        float(entry.score.get("geomean_vs_baseline", 0.0)) for entry in lineage
+    ]
+    recent_best = max(scores[-window:])
+    previous_best = max(scores[: -window])
+    if previous_best <= 0:
+        return False
+    return (recent_best - previous_best) / previous_best < min_relative_gain
+
+
+def supervisor_hints(task: KernelTask, lineage: list[LineageEntry]) -> list[str]:
+    hints = [
+        "Re-read the semantic spec and benchmark cases before editing.",
+        "Change one hypothesis at a time and keep failed attempts in notes.",
+    ]
+    if "cuda" in task.lane.lower():
+        hints.append(
+            "Profile for memory bandwidth, instruction count, occupancy, and launch overhead before changing tiling."
+        )
+    if "triton" in task.lane.lower():
+        hints.append(
+            "Check program count, vector width, masks, and cache behavior for the hottest shape."
+        )
+    if is_stagnated(lineage):
+        hints.append(
+            "Plateau detected: switch direction instead of refining the last micro-change."
+        )
+    return hints

--- a/kernel-pilot/references/kernel-source-catalog.json
+++ b/kernel-pilot/references/kernel-source-catalog.json
@@ -1,0 +1,158 @@
+{
+  "generated_date": "2026-05-12",
+  "verification_method": [
+    "arXiv PDF and abstract were read through arxiv.org.",
+    "External repositories were verified with git ls-remote.",
+    "Kernel paths were sampled with shallow sparse clones in a user-selected temporary directory.",
+    "GitHub web search was used for public repository discovery when direct API search hit anonymous rate limits."
+  ],
+  "local_references": [
+    {
+      "name": "gpu-kernel-ako4all references",
+      "path": "<user-configured-gpu-kernel-reference-docs>",
+      "use_for": [
+        "AKO loop discipline",
+        "Triton authoring rules",
+        "CUDA C++ and PTX debugging",
+        "CUTLASS and CuTe DSL routing",
+        "SM90/SM100/SM103/SM120 architecture constraints",
+        "profiling and troubleshooting"
+      ],
+      "must_read_first": [
+        "ako4all-kernel-loop.md",
+        "cuda-cpp-kernel-reference.md",
+        "triton-kernel-reference.md",
+        "profiling-debugging-reference.md",
+        "nvidia-architecture-reference.md"
+      ]
+    },
+    {
+      "name": "target kernel project worktree",
+      "path": "<user-configured-target-kernel-project-worktree>",
+      "use_for": [
+        "main-branch tests",
+        "semantic wrappers",
+        "integration targets after standalone candidate wins"
+      ],
+      "important_paths": [
+        "src/kernels",
+        "tests/kernels",
+        "benchmarks",
+        "include/kernel_project",
+        "kernel-library"
+      ]
+    }
+  ],
+  "external_repositories": [
+    {
+      "name": "FlashInfer",
+      "repo": "flashinfer-ai/flashinfer",
+      "url": "https://github.com/flashinfer-ai/flashinfer",
+      "verified_head": "9f4d16174e81dc818ca65f9eb930ec5fd8a9b395",
+      "kernel_paths": [
+        "csrc",
+        "csrc/fmha_v2/fmha",
+        "csrc/fmha_v2/fmha/hopper",
+        "csrc/fmha_v2/fmha/warpspec",
+        "csrc/fmha_cutlass_sm100.cu",
+        "csrc/blackwell_fmha_plan.cu",
+        "benchmarks/bench_blackwell_attention.py",
+        "benchmarks/bench_blackwell_attention_cutedsl.py",
+        "benchmarks/bench_cutlass_fused_moe.py",
+        "benchmarks/bench_cute_dsl_blockscaled_gemm.py"
+      ],
+      "read_when": [
+        "attention prefill/decode/page-cache kernels",
+        "FlashInfer-style generated kernels",
+        "Blackwell FMHA or grouped GEMM comparison",
+        "MoE, rope, norm, sampling, quantization baselines"
+      ],
+      "do_not_copy_rule": "Treat as inspiration and baseline reference. Do not copy code into a KernelPilot candidate unless license and attribution are explicitly handled."
+    },
+    {
+      "name": "FlashAttention",
+      "repo": "Dao-AILab/flash-attention",
+      "url": "https://github.com/Dao-AILab/flash-attention",
+      "verified_head": "ab66326aaa4fe3529fbc00f3156f3a762dd3141b",
+      "kernel_paths": [
+        "csrc/flash_attn/src",
+        "csrc/flash_attn/src/flash_fwd_kernel.h",
+        "csrc/flash_attn/src/flash_bwd_kernel.h",
+        "csrc/flash_attn/src/softmax.h",
+        "csrc/flash_attn/src/kernel_traits.h",
+        "flash_attn/cute",
+        "benchmarks/benchmark_attn.py",
+        "benchmarks/bench_sm90.py"
+      ],
+      "read_when": [
+        "online softmax attention algorithm",
+        "FlashAttention-2/3 CUDA/CUTLASS structure",
+        "FlashAttention-4 CuTe DSL structure",
+        "attention benchmark shape setup"
+      ],
+      "do_not_copy_rule": "Use as a reference implementation family and comparison source, not as direct candidate code."
+    },
+    {
+      "name": "hi-ops / HPC Ops",
+      "repo": "Tencent/hpc-ops",
+      "url": "https://github.com/Tencent/hpc-ops",
+      "verified_head": "8d300e1be9e5e2089e1da3c134f1e237b9063e21",
+      "kernel_paths": [
+        "hpc/attention.py",
+        "hpc/group_gemm.py",
+        "hpc/normalization.py",
+        "hpc/rope.py",
+        "hpc/fuse_moe.py",
+        "hpc/act.py",
+        "src/attention",
+        "src/group_gemm",
+        "src/normalization",
+        "src/rope",
+        "src/fuse_moe",
+        "src/activation",
+        "tests/test_attention_decode_bf16.py",
+        "tests/test_attention_prefill_bf16.py",
+        "tests/test_group_gemm_blockwise.py",
+        "tests/test_normalization.py",
+        "tests/test_rope.py"
+      ],
+      "read_when": [
+        "Tencent hi-ops attention, group GEMM, normalization, RoPE, activation, or fused MoE references",
+        "operator-level API and test design for LLM CUDA kernels",
+        "CUTLASS-backed implementation comparisons"
+      ],
+      "do_not_copy_rule": "Use as a reference source for hypotheses and tests. Do not copy implementation code into a KernelPilot candidate without explicit license and attribution handling."
+    },
+    {
+      "name": "DeepGEMM",
+      "repo": "deepseek-ai/DeepGEMM",
+      "url": "https://github.com/deepseek-ai/DeepGEMM",
+      "verified_head": "714dd1a4a980f7937a74343d19a8eba4fe321480",
+      "kernel_paths": [
+        "csrc/apis/gemm.hpp",
+        "csrc/apis/attention.hpp",
+        "csrc/jit",
+        "csrc/jit_kernels/heuristics",
+        "csrc/jit_kernels/impls",
+        "deep_gemm/include/deep_gemm/common",
+        "deep_gemm/include/deep_gemm/impls",
+        "deep_gemm/include/deep_gemm/mma",
+        "deep_gemm/include/deep_gemm/ptx",
+        "deep_gemm/include/deep_gemm/scheduler",
+        "deep_gemm/testing/bench.py",
+        "tests/test_bf16.py",
+        "tests/test_fp8_fp4.py",
+        "tests/test_attention.py",
+        "tests/test_mega_moe.py"
+      ],
+      "read_when": [
+        "JIT GEMM and grouped GEMM kernels",
+        "SM90/SM100 FP8/FP4/BF16 GEMM scheduling",
+        "TMA/WGMMA/tcgen05 PTX patterns",
+        "DeepSeek-style attention logits and MegaGEMM/MegaMoE layout references"
+      ],
+      "do_not_copy_rule": "Reference only. Treat DeepGEMM kernels as external prior art and use fresh KernelPilot candidates for target tasks."
+    }
+  ],
+  "unconfirmed_or_rejected_aliases": []
+}

--- a/kernel-pilot/references/kernel-source-catalog.md
+++ b/kernel-pilot/references/kernel-source-catalog.md
@@ -1,0 +1,46 @@
+# Kernel Source Catalog
+
+This is the KernelPilot knowledge base `K` for GPU-kernel work. It tells the agent what
+to read before proposing an iteration, and which sources are only references
+rather than candidate-code inputs.
+
+The machine-readable version is `kernel-source-catalog.json`.
+
+## Local References
+
+- User-configured GPU-kernel reference docs
+  - Read `ako4all-kernel-loop.md` for the iteration discipline.
+  - Read `cuda-cpp-kernel-reference.md`, `triton-kernel-reference.md`,
+    `cute-dsl-kernel-reference.md`, or `cutlass-cpp-kernel-reference.md`
+    according to the implementation lane.
+  - Read `profiling-debugging-reference.md` before making a performance claim.
+  - Read `nvidia-architecture-reference.md` and the matching SM guide for
+    architecture-specific work.
+
+- User-configured target kernel project worktree
+  - Clean `origin/main` worktree for integration and validation.
+  - Useful paths: `src/kernels`,
+    `tests/kernels`, `benchmarks`,
+    `include/kernel_project`, and `kernel-library`.
+
+## External Repositories
+
+| Repo | Verified HEAD | Read first |
+| --- | --- | --- |
+| `flashinfer-ai/flashinfer` | `9f4d16174e81dc818ca65f9eb930ec5fd8a9b395` | `csrc`, `csrc/fmha_v2/fmha`, `csrc/fmha_v2/fmha/hopper`, `csrc/fmha_v2/fmha/warpspec`, `benchmarks/bench_blackwell_attention.py` |
+| `Dao-AILab/flash-attention` | `ab66326aaa4fe3529fbc00f3156f3a762dd3141b` | `csrc/flash_attn/src`, `flash_attn/cute`, `benchmarks/benchmark_attn.py`, `benchmarks/bench_sm90.py` |
+| `Tencent/hpc-ops` | `8d300e1be9e5e2089e1da3c134f1e237b9063e21` | `hpc/attention.py`, `hpc/group_gemm.py`, `hpc/normalization.py`, `hpc/rope.py`, `src/attention`, `src/group_gemm`, `src/normalization`, `src/rope`, `tests/` |
+| `deepseek-ai/DeepGEMM` | `714dd1a4a980f7937a74343d19a8eba4fe321480` | `csrc/apis`, `csrc/jit`, `csrc/jit_kernels/heuristics`, `csrc/jit_kernels/impls`, `deep_gemm/include/deep_gemm`, `deep_gemm/testing`, `tests/` |
+
+Target-project source is available only for integration, tests, and benchmarks
+through the local clean worktree above. It is not an external implementation
+reference.
+
+## Usage Rules
+
+1. Read references to identify hypotheses, contracts, and measurement style.
+2. Do not copy external kernel code into a candidate.
+3. For target-project task files, `forbidden_files` cannot seed a from-scratch
+   candidate. They may be read later for integration or old-vs-new comparison.
+4. Every source-derived idea must be logged in lineage notes with the source
+   path and the exact hypothesis being tested.

--- a/kernel-pilot/references/method-notes.md
+++ b/kernel-pilot/references/method-notes.md
@@ -1,0 +1,73 @@
+# Method Notes
+
+Source read:
+
+- https://arxiv.org/abs/2603.24517
+- https://arxiv.org/pdf/2603.24517
+
+## Core Thesis
+
+The useful idea is to replace a fixed mutate-and-test stage with a
+self-directed coding agent. The agent owns one full iteration: inspect previous
+solutions, consult a kernel knowledge base, edit code, run correctness,
+benchmark, diagnose failures, and either continue revising or record a
+candidate.
+
+The abstract loop is:
+
+```text
+NextCandidate = Agent(previous_lineage, knowledge_base, scoring_function)
+```
+
+where:
+
+- `previous_lineage` is the sequence of prior candidates and scores;
+- `knowledge_base` is the curated set of references and implementation rules;
+- `scoring_function` gates on correctness before considering speed.
+
+## Iteration Step
+
+One KernelPilot iteration should:
+
+1. inspect lineage, failed attempts, and prior profiles;
+2. consult only the approved references for the implementation lane;
+3. propose one optimization hypothesis;
+4. edit the candidate implementation;
+5. run correctness;
+6. benchmark every configured case;
+7. diagnose failures or regressions;
+8. revise until the candidate is worth recording.
+
+KernelPilot records failed directions in lineage notes because those failures
+are useful for later human review and for changing direction after stagnation.
+
+## Continuous Optimization
+
+This framework uses a single-lineage loop by default. It is not a broad archive
+or population search. The practical goal is to keep the agent focused on one
+operator until the requested speedup and no-regression gate are both proven.
+
+## Kernel Knowledge Base
+
+For GPU-kernel work, the knowledge base should include:
+
+- local `gpu-kernel-ako4all/references`;
+- architecture-specific material for the target GPU;
+- CUDA, Triton, CUTLASS, or CuTe references matching the implementation lane;
+- high-quality external kernel repositories selected as references only;
+- task-specific tests, benchmark shapes, and forbidden source files.
+
+The current KernelPilot catalog includes FlashInfer, FlashAttention,
+Tencent hpc-ops, and DeepGEMM. The target project remains available for
+integration and validation, but not as an external kernel reference.
+
+## Evidence Style
+
+Every performance claim should preserve:
+
+- exact hardware and software environment;
+- exact shapes, dtypes, and distributions;
+- correctness tolerance and reference oracle;
+- baseline and candidate latency for every case;
+- geomean and minimum per-case speedup;
+- lineage notes explaining which hypotheses worked and failed.

--- a/kernel-pilot/scripts/build_kernel_source_catalog.py
+++ b/kernel-pilot/scripts/build_kernel_source_catalog.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import subprocess
+
+
+REPOS = {
+    "flashinfer-ai/flashinfer": "https://github.com/flashinfer-ai/flashinfer.git",
+    "Dao-AILab/flash-attention": "https://github.com/Dao-AILab/flash-attention.git",
+    "Tencent/hpc-ops": "https://github.com/Tencent/hpc-ops.git",
+    "deepseek-ai/DeepGEMM": "https://github.com/deepseek-ai/DeepGEMM.git",
+}
+
+
+def run(args: list[str], cwd: Path | None = None) -> str:
+    completed = subprocess.run(
+        args,
+        cwd=str(cwd) if cwd else None,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise SystemExit(
+            f"command failed: {' '.join(args)}\n{completed.stdout}\n{completed.stderr}"
+        )
+    return completed.stdout
+
+
+def repo_head(url: str) -> str:
+    out = run(["git", "ls-remote", url, "HEAD"])
+    return out.split()[0]
+
+
+def kernel_like_paths(repo_dir: Path) -> list[str]:
+    out = run(["git", "ls-tree", "-r", "--name-only", "HEAD"], cwd=repo_dir)
+    paths = []
+    for path in out.splitlines():
+        low = path.lower()
+        if (
+            "/csrc/" in f"/{low}/"
+            or "/cuda/" in f"/{low}/"
+            or "/cutlass/" in f"/{low}/"
+            or "/cute/" in f"/{low}/"
+            or "/triton/" in f"/{low}/"
+            or "/kernel/" in f"/{low}/"
+            or "/kernels/" in f"/{low}/"
+            or "/bench/" in f"/{low}/"
+            or "/benchmarks/" in f"/{low}/"
+            or low.endswith((".cu", ".cuh", ".ptx"))
+        ):
+            paths.append(path)
+    return paths
+
+
+def ensure_sparse_clone(repo: str, url: str, root: Path) -> Path:
+    target = root / repo.split("/")[-1]
+    if target.exists():
+        run(["git", "fetch", "--depth", "1", "origin", "main"], cwd=target)
+        run(["git", "checkout", "FETCH_HEAD"], cwd=target)
+        return target
+    run(
+        [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--filter=blob:none",
+            "--sparse",
+            url,
+            str(target),
+        ]
+    )
+    return target
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--clone-root",
+        type=Path,
+        default=Path(".kernelpilot/kernel_refs"),
+    )
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    args.clone_root.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    for repo, url in REPOS.items():
+        repo_dir = ensure_sparse_clone(repo, url, args.clone_root)
+        rows.append(
+            {
+                "repo": repo,
+                "url": url.removesuffix(".git"),
+                "head": repo_head(url),
+                "sample_kernel_paths": kernel_like_paths(repo_dir)[:200],
+            }
+        )
+    text = json.dumps({"repositories": rows}, indent=2, sort_keys=True)
+    if args.output:
+        args.output.write_text(text + "\n", encoding="utf-8")
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kernel-pilot/templates/kernel-goal-prompt.md
+++ b/kernel-pilot/templates/kernel-goal-prompt.md
@@ -1,0 +1,67 @@
+# KernelPilot Kernel Goal Prompt
+
+Copy the prompt below into Codex. In the common case, fill only the operator
+and target speedup. Leave the optional fields unset when you want Codex to
+discover the baseline, tests, benchmark, and hardware configuration.
+
+```text
+Use the KernelPilot workflow in this repository to continuously optimize one
+kernel.
+
+- Operator: <kernel operator name or entry point, for example rmsnorm_hf / timestep_embedding / group_norm_silu>
+- Target speedup: <for example 1.10x; every configured case must be no slower than baseline and geomean speedup must reach this target>
+- Target hardware: <optional; leave unset to let Codex use the available GPU validation environment>
+- Target repository: <optional target kernel project worktree or branch; leave unset to let Codex create or use an isolated clean worktree>
+- Runtime environment: <optional; user-managed shell, SSH host, CI runner, or other execution environment>
+- KernelPilot root: <path to the KernelPilot directory in the current workspace, or leave unset if already running from it>
+
+Do not stop at a plan. Keep iterating until the target is met or a concrete
+blocker is proven. Requirements:
+
+1. Locate the operator's Python/CUDA/Triton entry points, tests, benchmarks,
+   shape and dtype distributions, and current baseline in the target kernel
+   project.
+2. Create or update a KernelPilot task directory for this operator. Record the
+   semantic spec, forbidden files, correctness gates, benchmark cases, baseline,
+   and lineage.
+3. Follow the KernelPilot single-lineage loop: one hypothesis at a time, a
+   from-scratch candidate, correctness first, then a full benchmark.
+4. Use references only to form hypotheses and validation methods. Do not copy
+   external kernel code. Approved references include:
+   - local GPU-kernel reference docs configured by the user;
+   - FlashInfer;
+   - FlashAttention;
+   - Tencent/hpc-ops;
+   - DeepGEMM.
+   The target project is used for wrappers, tests, and benchmarks. Do not use
+   existing target kernels as external reference implementations.
+5. If a direction fails, record the reason, data, and next decision in lineage
+   notes. Do not repeat the same direction without new evidence.
+6. If three consecutive iterations do not improve the best candidate, reread
+   lineage, benchmark distributions, and profiler evidence, then switch
+   direction.
+7. Finish only when all gates pass:
+   - correctness tests pass;
+   - the benchmark covers every configured case;
+   - every case has speedup >= 1.0x;
+   - geomean speedup >= target speedup;
+   - the result is validated on the selected hardware, when hardware is
+     specified or available;
+   - KernelPilot run artifacts, lineage, and final comparison are updated.
+8. Final response must include:
+   - changed or added file paths;
+   - baseline vs candidate table;
+   - acceleration or failure source for each major candidate version;
+   - correctness and performance commands that were run;
+   - whether the result is integrated into the target project or remains a standalone
+     harness.
+```
+
+Optional fields:
+
+```text
+- Baseline: <source change link, commit, benchmark JSON, or "measure current main">
+- Shape/dtype cases: <target workload distribution, if known>
+- Forbidden files: <stricter file list, if needed>
+- Acceptance tests: <pytest, benchmark, or server smoke commands>
+```

--- a/tests/test_kernelpilot_framework.py
+++ b/tests/test_kernelpilot_framework.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+KERNELPILOT_ROOT = ROOT / "kernel-pilot"
+
+sys.path.insert(0, str(KERNELPILOT_ROOT))
+
+from kernelpilot.config import load_taskset  # noqa: E402
+from kernelpilot.knowledge import load_catalog, render_catalog_for_prompt  # noqa: E402
+from kernelpilot.lineage import LineageEntry, LineageStore  # noqa: E402
+from kernelpilot.prompting import build_iteration_prompt  # noqa: E402
+from kernelpilot.scoring import score_against_baseline  # noqa: E402
+from kernelpilot.supervisor import is_stagnated  # noqa: E402
+
+
+def write_sample_taskset(tmp_path: Path) -> Path:
+    payload = {
+        "name": "sample-kernel-taskset",
+        "base_repo": "<target-kernel-repository>",
+        "base_ref": "origin/main",
+        "paper_url": "https://arxiv.org/abs/2603.24517",
+        "global_rules": [
+            "Use a single-lineage KernelPilot loop.",
+            "Start candidates from the semantic spec.",
+            "Correctness failure gives score zero regardless of latency.",
+        ],
+        "tasks": [
+            {
+                "id": "add_constant_large_int32",
+                "title": "Optimize large add_constant tensors",
+                "baseline_id": "baseline-add-constant",
+                "baseline_url": "<baseline-source>",
+                "operator": "add_constant",
+                "lane": "CUDA C++ JIT",
+                "semantic_spec": (
+                    "Add a constant to every element while preserving exact "
+                    "integer arithmetic."
+                ),
+                "forbidden_files": ["src/kernels/add_constant.cuh"],
+                "correctness": [
+                    "Exact equality against x + constant over selected sizes."
+                ],
+                "benchmark_command": "python benchmarks/bench_add_constant.py",
+                "baseline": [
+                    {"case_id": "n=1048576", "baseline_latency_us": 7.456},
+                    {"case_id": "n=4194304", "baseline_latency_us": 11.632},
+                    {"case_id": "n=16777216", "baseline_latency_us": 49.712},
+                ],
+                "search_space": [
+                    "vectorized int32 memory path",
+                    "alignment and size threshold",
+                ],
+            }
+        ],
+    }
+    taskset_path = tmp_path / "taskset.json"
+    taskset_path.write_text(json.dumps(payload), encoding="utf-8")
+    return taskset_path
+
+
+def test_taskset_loads_generic_kernel_baseline(tmp_path: Path) -> None:
+    taskset = load_taskset(write_sample_taskset(tmp_path))
+    assert len(taskset.tasks) == 1
+    assert taskset.tasks[0].baseline_id == "baseline-add-constant"
+    for task in taskset.tasks:
+        assert task.forbidden_files
+        assert task.baseline
+        assert task.correctness
+
+
+def test_prompt_enforces_from_scratch_kernel_constraint(tmp_path: Path) -> None:
+    taskset = load_taskset(write_sample_taskset(tmp_path))
+    task = taskset.task_by_id("add_constant_large_int32")
+    prompt = build_iteration_prompt(taskset, task, [])
+    assert "Start candidates from the semantic spec" in prompt
+    assert "src/kernels/add_constant.cuh" in prompt
+    assert "Knowledge base K to consult before edits" in prompt
+    assert "gpu-kernel-ako4all references" in prompt
+    assert "No committed KernelPilot candidate exists yet" in prompt
+
+
+def test_score_requires_correctness_and_full_case_coverage(tmp_path: Path) -> None:
+    task = load_taskset(write_sample_taskset(tmp_path)).task_by_id(
+        "add_constant_large_int32"
+    )
+    faster = {
+        "correct": True,
+        "measurements": [
+            {"case_id": "n=1048576", "latency_us": 7.0},
+            {"case_id": "n=4194304", "latency_us": 10.0},
+            {"case_id": "n=16777216", "latency_us": 45.0},
+        ],
+    }
+    summary = score_against_baseline(task, faster)
+    assert summary.correct
+    assert summary.matched_cases == 3
+    assert not summary.missing_cases
+    assert summary.geomean_vs_baseline > 1.05
+    assert summary.clearly_better_than_baseline
+
+    incomplete = {"correct": True, "measurements": faster["measurements"][:1]}
+    incomplete_summary = score_against_baseline(task, incomplete)
+    assert incomplete_summary.missing_cases
+    assert not incomplete_summary.clearly_better_than_baseline
+
+    wrong = dict(faster)
+    wrong["correct"] = False
+    wrong_summary = score_against_baseline(task, wrong)
+    assert wrong_summary.geomean_vs_baseline == 0.0
+    assert not wrong_summary.clearly_better_than_baseline
+
+    mixed = {
+        "correct": True,
+        "measurements": [
+            {"case_id": "n=1048576", "latency_us": 2.0},
+            {"case_id": "n=4194304", "latency_us": 8.0},
+            {"case_id": "n=16777216", "latency_us": 90.0},
+        ],
+    }
+    mixed_summary = score_against_baseline(task, mixed)
+    assert mixed_summary.geomean_vs_baseline > 1.05
+    assert not mixed_summary.clearly_better_than_baseline
+
+
+def test_lineage_store_and_stagnation_detection() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        store = LineageStore(tmp, "task")
+        for idx, score in enumerate([1.0, 1.01, 1.0101, 1.0102, 1.0103], start=1):
+            store.append(
+                LineageEntry(
+                    version=f"v{idx}",
+                    task_id="task",
+                    candidate_ref=f"candidate-{idx}",
+                    score={"geomean_vs_baseline": score},
+                    notes="",
+                )
+            )
+
+        entries = store.load()
+        assert len(entries) == 5
+        assert store.best() is not None
+        assert store.best().version == "v5"
+        assert is_stagnated(entries, window=3, min_relative_gain=0.02)
+
+
+def test_cli_module_is_importable() -> None:
+    from kernelpilot import cli
+
+    parser = cli.build_parser()
+    args = parser.parse_args(["validate", "--taskset", "<taskset.json>"])
+    assert args.taskset == "<taskset.json>"
+
+
+def test_kernel_source_catalog_lists_confirmed_and_rejected_sources() -> None:
+    catalog = load_catalog()
+    rendered = render_catalog_for_prompt(catalog, lane="CUDA C++ JIT")
+    assert "FlashInfer" in rendered
+    assert "FlashAttention" in rendered
+    assert "hi-ops / HPC Ops" in rendered
+    assert "DeepGEMM" in rendered
+    assert "target kernel project worktree" in rendered


### PR DESCRIPTION
## Summary

Adds KernelPilot, a small stdlib-only framework for Codex-driven kernel optimization loops.

The framework includes:

- taskset loading and validation
- prompt generation from task metadata, references, and lineage
- baseline scoring with correctness and full-case coverage gates
- single-lineage recording and stagnation hints
- a curated kernel reference catalog for FlashInfer, FlashAttention, Tencent hpc-ops, DeepGEMM, and local GPU-kernel references
- a reusable generic kernel goal prompt template

Operator-specific reproduction artifacts are intentionally not included in this PR. Task directories and benchmark outputs are treated as user-created inputs outside the framework tree.

## Validation

- `find kernel-pilot -name '*.json' -print0 | xargs -0 -n1 python3 -m json.tool >/dev/null`\n- `python3 -m py_compile kernel-pilot/kernelpilot/*.py kernel-pilot/scripts/*.py`\n- `python3 -m pytest -q tests/test_kernelpilot_framework.py`