### PR TITLE
Add Claude Code plugin manifest for one-shot install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "ai-infra-auto-driven-skills",
+  "owner": {
+    "name": "BBuf",
+    "url": "https://github.com/BBuf"
+  },
+  "plugins": [
+    {
+      "name": "ai-infra-skills",
+      "source": "./",
+      "description": "LLM serving benchmarks, capacity planning, torch-profiler triage, pipeline analysis, compute simulation, SGLang/vLLM SOTA Humanize loops, code review, prod incident triage, and PR-history dossiers.",
+      "version": "0.1.0",
+      "category": "ai-infra",
+      "tags": ["sglang", "vllm", "tensorrt-llm", "benchmarks", "profiler", "kernel", "moe", "llm-serving"]
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "plugins": [
     {
-      "name": "ai-infra-skills",
+      "name": "ai-infra-auto-driven-skills",
       "source": "./",
       "description": "LLM serving benchmarks, capacity planning, torch-profiler triage, pipeline analysis, compute simulation, SGLang/vLLM SOTA Humanize loops, code review, prod incident triage, and PR-history dossiers.",
       "version": "0.1.0",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "ai-infra-skills",
+  "name": "ai-infra-auto-driven-skills",
   "version": "0.1.0",
   "description": "Agent-ready playbooks for LLM serving benchmarks, capacity planning, torch-profiler triage, pipeline analysis, compute simulation, SGLang/vLLM SOTA Humanize loops, human code review, production incident triage, and model PR-history dossiers.",
   "author": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "ai-infra-skills",
+  "version": "0.1.0",
+  "description": "Agent-ready playbooks for LLM serving benchmarks, capacity planning, torch-profiler triage, pipeline analysis, compute simulation, SGLang/vLLM SOTA Humanize loops, human code review, production incident triage, and model PR-history dossiers.",
+  "author": {
+    "name": "BBuf",
+    "url": "https://github.com/BBuf"
+  },
+  "homepage": "https://github.com/BBuf/AI-Infra-Auto-Driven-SKILLS",
+  "repository": "https://github.com/BBuf/AI-Infra-Auto-Driven-SKILLS",
+  "license": "see LICENSE"
+}

--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ installed as a single Claude Code plugin via the built-in marketplace flow:
 
 ```text
 /plugin marketplace add BBuf/AI-Infra-Auto-Driven-SKILLS
-/plugin install ai-infra-skills@ai-infra-auto-driven-skills
+/plugin install ai-infra-auto-driven-skills@ai-infra-auto-driven-skills
 /reload-plugins
 ```
 
 After reload, the 11 skills appear namespaced as
-`ai-infra-skills:<skill-name>` (for example
-`ai-infra-skills:sglang-sota-humanize-loop`). Update later with
+`ai-infra-auto-driven-skills:<skill-name>` (for example
+`ai-infra-auto-driven-skills:sglang-sota-humanize-loop`). Update later with
 `/plugin marketplace update ai-infra-auto-driven-skills`.
 
 ### Claude Code (per-skill symlink, legacy)

--- a/README.md
+++ b/README.md
@@ -127,11 +127,27 @@ This repository is not Codex-only. The skills are plain `SKILL.md` directories
 and can be installed into Claude Code, Codex, Kimi, or another compatible agent
 runtime.
 
-### Claude Code
+### Claude Code (one-shot plugin install)
 
-Install only the skills you want into Claude Code's user skill directory. Symlink
-is recommended for local development because updates to this checkout are picked
-up immediately:
+The repository ships a `.claude-plugin/` manifest so the whole skill set can be
+installed as a single Claude Code plugin via the built-in marketplace flow:
+
+```text
+/plugin marketplace add BBuf/AI-Infra-Auto-Driven-SKILLS
+/plugin install ai-infra-skills@ai-infra-auto-driven-skills
+/reload-plugins
+```
+
+After reload, the 11 skills appear namespaced as
+`ai-infra-skills:<skill-name>` (for example
+`ai-infra-skills:sglang-sota-humanize-loop`). Update later with
+`/plugin marketplace update ai-infra-auto-driven-skills`.
+
+### Claude Code (per-skill symlink, legacy)
+
+Prefer this when you only want a subset of the skills, or when developing
+against a local checkout. Symlink is recommended for local development because
+updates to this checkout are picked up immediately:
 
 ```bash
 git clone https://github.com/BBuf/AI-Infra-Auto-Driven-SKILLS.git


### PR DESCRIPTION
## Summary

Ship a `.claude-plugin/` directory so the whole skill set can be installed as a single Claude Code plugin via the built-in marketplace flow, instead of requiring users to `ln -s` each skill into `~/.claude/skills/`:

```text
/plugin marketplace add BBuf/AI-Infra-Auto-Driven-SKILLS
/plugin install ai-infra-auto-driven-skills@ai-infra-auto-driven-skills
/reload-plugins
```

After reload, the 11 skills appear namespaced as `ai-infra-auto-driven-skills:<skill-name>` (e.g. `ai-infra-auto-driven-skills:sglang-sota-humanize-loop`). Updates pull through `/plugin marketplace update ai-infra-auto-driven-skills`.

## What changed

- `.claude-plugin/plugin.json` — plugin manifest (name, version, description, author, homepage).
- `.claude-plugin/marketplace.json` — single-plugin marketplace pointing at the repo root (`"source": "./"`), so the existing `skills/` tree is auto-discovered with no file moves.
- `README.md` — added a short "Claude Code (one-shot plugin install)" subsection above the existing per-skill symlink instructions; the symlink section is kept and relabelled as the partial-install / local-dev path.

## Non-goals / what is NOT changed

- No skill content is moved or edited.
- No layout changes under `skills/` or `model-pr-optimization-history/`.
- Existing symlink-based installs keep working exactly as before.
- Codex / Kimi / generic skill-dir install instructions are untouched.

## Test plan

- [x] `cat .claude-plugin/plugin.json | jq .` parses
- [x] `cat .claude-plugin/marketplace.json | jq .` parses
- [ ] Reviewer runs the three slash commands above in Claude Code and verifies the 11 skills appear under the `ai-infra-auto-driven-skills:` namespace
- [ ] Reviewer confirms an existing symlink-style install (from the README's per-skill block) still loads side-by-side without name collisions