### PR TITLE
README: add How I Drive The Agents + Ultracode launch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,50 @@ cp -R skills/model-architecture-diagram <agent-skill-dir>/model-architecture-dia
 cp -R model-pr-optimization-history <agent-skill-dir>/model-pr-history-knowledge
 ```
 
+## How I Drive The Agents
+
+These skills are exercised with coding agents in full-autonomy mode. For
+reproducibility, here is exactly how I launch them.
+
+**Claude Code** — Opus 4.8 at max effort with Auto mode (the "Effort (Max)" +
+"Auto mode" toggles), i.e. auto/bypass-permission so the agent runs unattended:
+
+```bash
+claude --permission-mode bypassPermissions --model opus --effort max
+```
+
+**Ultracode mode** — the maximum-thoroughness setting (the "Effort (Ultracode –
+xhigh + workflows)" entry in the effort menu, paired with Auto mode). Ultracode
+is *not* a launch-flag effort value: `claude --effort ultracode` warns (`Unknown
+--effort value 'ultracode'`) and falls back to the default — the valid `--effort`
+flag levels are `low, medium, high, xhigh, max`. It is a composite of **xhigh
+effort + dynamic workflows enabled**, so the agent reasons at xhigh and authors
+multi-agent workflows on substantive tasks. Enable dynamic workflows once — the
+**Dynamic workflows** toggle in `/config` (settings key `enableWorkflows`) — then
+launch at xhigh:
+
+```bash
+claude --permission-mode bypassPermissions --model opus --effort xhigh
+```
+
+Or in one self-contained command:
+
+```bash
+claude --permission-mode bypassPermissions --model opus --effort xhigh --settings '{"enableWorkflows": true}'
+```
+
+With workflows enabled, the in-session `/effort` menu shows "Ultracode"; to opt a
+single prompt in instead, include the keyword `ultracode` in that message.
+
+**Codex** — full-access, no approval prompts:
+
+```bash
+codex --yolo --sandbox danger-full-access --ask-for-approval never
+```
+
+Both run unsandboxed / auto-approve because the work happens against isolated
+checkouts with their own benchmark + correctness gates.
+
 ## Repository Map
 
 ```text


### PR DESCRIPTION
Adds a **How I Drive The Agents** section (mirroring the sibling KDA-Pilot README): Claude Code Opus 4.8 at max effort + Auto mode, Codex `--yolo` full-access, and an **Ultracode mode** entry.

Ultracode is **not** a `--effort` value — `claude --effort ultracode` is rejected (valid levels: `low, medium, high, xhigh, max`). It is **xhigh effort + Dynamic workflows enabled**:

```bash
claude --permission-mode bypassPermissions --model opus --effort xhigh --settings '{"workflowsEnabled": true}'
```

Verified against the local Claude Code 2.1.177 CLI. README-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)