### PR TITLE
[codex] Update serving SOTA loop framework docs

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-ignore-words-list = ans, als, hel, boostrap, childs, te, vas, hsa, ment, cann, thi, makro, wil, rouge, PRIS, SER
+ignore-words-list = ans, als, hel, boostrap, childs, te, vas, hsa, ment, cann, thi, makro, wil, rouge, PRIS, SER, thirdparty
 skip = *.json,*.jsonl,*.patch,*.txt,model-pr-optimization-history/*,skills/model-optimization/*/*/references/pr-history.md,skills/gpu-kernel-ako4all/references/triton/*,skills/gpu-kernel-ako4all/references/cuda-cpp/*,skills/gpu-kernel-ako4all/references/cute-dsl/*,skills/gpu-kernel-ako4all/references/cutlass-cpp/*

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ intelligence.**
 [![GitHub forks](https://img.shields.io/github/forks/BBuf/AI-Infra-Auto-Driven-SKILLS?style=social)](https://github.com/BBuf/AI-Infra-Auto-Driven-SKILLS/forks)
 [![Last commit](https://img.shields.io/github/last-commit/BBuf/AI-Infra-Auto-Driven-SKILLS?style=flat-square)](https://github.com/BBuf/AI-Infra-Auto-Driven-SKILLS/commits/main)
 [![Core skills](https://img.shields.io/badge/core_skills-10-2f80ed?style=flat-square)](#core-skills)
-[![PR histories](https://img.shields.io/badge/pr_histories-58-2ea44f?style=flat-square)](#model-pr-history-catalog)
+[![PR histories](https://img.shields.io/badge/pr_histories-66-2ea44f?style=flat-square)](#model-pr-history-catalog)
 [![KDA-Pilot](https://img.shields.io/badge/sibling-KDA--Pilot-ff7b72?style=flat-square)](https://github.com/BBuf/KDA-Pilot)
 
 </div>
@@ -19,13 +19,13 @@ intelligence.**
 This repository is built for AI infrastructure engineers who want agents to do
 real work, not recite generic prompts.
 
-It gives an agent the operational memory needed to benchmark SGLang, vLLM, and
-TensorRT-LLM fairly; explain serving capacity from startup logs; split prefill
-and decode profiler evidence; inspect traces at layer and kernel level; estimate
-operator FLOPs and MFU; review SGLang patches against real maintainer discussion
-patterns; run Humanize-governed SGLang and vLLM SOTA loops; triage SGLang
-production incidents from a replay; and keep model-family optimization history
-close to the code that actually changed.
+It gives an agent the operational memory needed to benchmark SGLang, vLLM,
+TensorRT-LLM, and TokenSpeed fairly; explain serving capacity from startup logs;
+split prefill and decode profiler evidence; inspect traces at layer and kernel
+level; estimate operator FLOPs and MFU; review SGLang patches against real
+maintainer discussion patterns; run Humanize-governed SGLang and vLLM SOTA
+loops; triage SGLang production incidents from a replay; and keep model-family
+optimization history close to the code that actually changed.
 
 For standalone kernel campaigns and kernel evidence tools, see the sibling
 project **[KDA-Pilot](https://github.com/BBuf/KDA-Pilot)**.
@@ -38,13 +38,13 @@ find it.
 
 | Skill | Use it when |
 | --- | --- |
-| [`llm-serving-auto-benchmark`](skills/llm-serving-auto-benchmark/) | You need a fair, bounded serving benchmark search for SGLang, vLLM, TensorRT-LLM, or another OpenAI-compatible stack. |
+| [`llm-serving-auto-benchmark`](skills/llm-serving-auto-benchmark/) | You need a fair, bounded serving benchmark search for SGLang, vLLM, TensorRT-LLM, TokenSpeed, or another OpenAI-compatible stack. |
 | [`llm-serving-capacity-planner`](skills/llm-serving-capacity-planner/) | You need to explain SGLang or vLLM startup memory, KV cache budget, request capacity, or OOM pressure from logs. |
 | [`llm-torch-profiler-analysis`](skills/llm-torch-profiler-analysis/) | You need a three-table profiler report that keeps `extend/prefill` and `decode` evidence separate. |
 | [`llm-pipeline-analysis`](skills/llm-pipeline-analysis/) | You need forward-pass, layer, and kernel-level timing from a torch profiler trace, including anchor boundaries and Perfetto ranges. |
 | [`model-compute-simulation`](skills/model-compute-simulation/) | You need operator shapes, FLOPs, MFU estimates, kernel-to-op mapping, or parallelism what-if analysis for an LLM serving shape. |
 | [`sglang-humanize-review`](skills/sglang-humanize-review/) | You need SGLang code-review findings grounded in full human PR review episodes from project start through the latest refresh (June 2026), including inline code context, top-level discussion, review summaries, and multi-round replies. Every review opens with a PR comprehension pass — a change summary plus a Mermaid execution flowchart with the diff's modified steps marked — so the reviewer sees how the PR runs before the findings. |
-| [`sglang-sota-humanize-loop`](skills/sglang-sota-humanize-loop/) | You want one model-level Humanize RLCR loop that owns gap decisions, profiler triage, required layer-pipeline deep dives, SGLang patches, optional `ncu-report-skill` evidence, and real-model revalidation after the fixed fair benchmark. |
+| [`sglang-sota-humanize-loop`](skills/sglang-sota-humanize-loop/) | You want one model-level Humanize RLCR loop that owns SGLang gap decisions against a selected comparison framework set, profiler triage, required layer-pipeline deep dives, SGLang patches, optional `ncu-report-skill` evidence, and real-model revalidation after the fixed fair benchmark. |
 | [`vllm-sota-humanize-loop`](skills/vllm-sota-humanize-loop/) | You want one model-level Humanize RLCR loop that owns gap decisions, profiler triage, required layer-pipeline deep dives, vLLM patches, optional `ncu-report-skill` evidence, and real-model revalidation after the fixed fair benchmark. |
 | [`sglang-prod-incident-triage`](skills/sglang-prod-incident-triage/) | You need to turn queue growth, timeouts, wrong outputs, crashes, or distributed stalls into a replay and next debug step. |
 | [`model-architecture-diagram`](skills/model-architecture-diagram/) | You need original public architecture diagrams for popular LLM, VLM, MoE, OCR, and diffusion model families. |
@@ -55,19 +55,31 @@ find it.
   <img src="https://raw.githubusercontent.com/BBuf/AI-Infra-Auto-Driven-SKILLS/main/docs/assets/sglang-sota-performance-loop.svg" alt="SGLang SOTA Performance Loop" width="620">
 </p>
 
+`sglang-sota-humanize-loop` always patches SGLang, while the competitor set is
+caller-controlled. By default the comparison framework set can include vLLM,
+TensorRT-LLM, and TokenSpeed; a prompt can also narrow it, for example:
+
+```text
+Use sglang-sota-humanize-loop for <model>.
+comparison_frameworks: [vllm]
+Do not consider TensorRT-LLM or TokenSpeed; record them as user-excluded.
+```
+
 ## Model PR History Catalog
 
 The model optimization layer is now one knowledge base:
 [`model-pr-optimization-history`](model-pr-optimization-history/). It contains
-58 PR-driven history dossiers and a small query helper. These are not
+66 PR-driven history dossiers and a small query helper. These are not
 per-model runbook skills; they preserve diff-backed model evolution records for
-SGLang and vLLM so SOTA loops can read prior source and PR evidence before
-patching.
+SGLang, vLLM, TensorRT-LLM, and TokenSpeed so SOTA loops can read prior source
+and PR evidence before patching.
 
 | Framework | PR histories |
 | --- | ---: |
-| [SGLang](model-pr-optimization-history/sglang/) | 29 |
-| [vLLM](model-pr-optimization-history/vllm/) | 29 |
+| [SGLang](model-pr-optimization-history/sglang/) | 31 |
+| [vLLM](model-pr-optimization-history/vllm/) | 31 |
+| [TensorRT-LLM](model-pr-optimization-history/tensorrt_llm/) | 2 |
+| [TokenSpeed](model-pr-optimization-history/tokenspeed/) | 2 |
 
 Covered families include:
 
@@ -94,6 +106,7 @@ cd model-pr-optimization-history
 python3 scripts/query.py --list
 python3 scripts/query.py --framework sglang --model qwen3-core --paths-only
 python3 scripts/query.py --framework vllm "qwen3 fused qk norm"
+python3 scripts/query.py --framework tokenspeed --model qwen35 qk rmsnorm
 ```
 
 ## Evidence Standards
@@ -265,8 +278,10 @@ skills/
 model-pr-optimization-history/
 ├── SKILL.md                         # knowledge-base usage instructions
 ├── scripts/query.py                 # local model/keyword query helper
-├── sglang/                          # 29 PR-driven SGLang model histories
-└── vllm/                            # 29 PR-driven vLLM model histories
+├── sglang/                          # 31 PR-driven SGLang model histories
+├── vllm/                            # 31 PR-driven vLLM model histories
+├── tensorrt_llm/                    # TensorRT-LLM competitor histories
+└── tokenspeed/                      # TokenSpeed competitor histories
 
 prompts/
 ├── sglang-sota-b200-prompts.md       # B200 SGLang SOTA task prompts

--- a/docs/assets/sglang-sota-performance-loop.svg
+++ b/docs/assets/sglang-sota-performance-loop.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="720" height="1420" viewBox="0 0 720 1420" role="img" aria-labelledby="title desc">
   <title id="title">SGLang SOTA Performance Loop</title>
-  <desc id="desc">A vertical workflow diagram for the SGLang SOTA Humanize loop, with fixed baseline setup followed by one RLCR loop that owns gap decisions, profiling, layer deep dives, patches, NCU evidence, and revalidation.</desc>
+  <desc id="desc">A vertical workflow diagram for the SGLang SOTA Humanize loop, with a fixed fair benchmark against selected comparison frameworks followed by one RLCR loop that owns gap decisions, profiling, layer deep dives, patches, NCU evidence, and revalidation.</desc>
   <defs>
     <linearGradient id="hero" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#111827"/>
@@ -62,7 +62,8 @@
   <text x="230" y="347" text-anchor="middle" class="small">model source memory</text>
   <rect x="382" y="302" width="216" height="62" rx="14" class="blue"/>
   <text x="490" y="327" text-anchor="middle" class="label">Fair benchmark</text>
-  <text x="490" y="347" text-anchor="middle" class="small">SGLang / vLLM / TRT-LLM</text>
+  <text x="490" y="344" text-anchor="middle" class="small">SGLang vs comparison set</text>
+  <text x="490" y="360" text-anchor="middle" class="small">vLLM / TRT-LLM / TokenSpeed</text>
 
   <path d="M 230 364 C 238 402 304 402 360 402" class="lineSoft"/>
   <path d="M 490 364 C 482 402 416 402 360 402" class="lineSoft"/>

--- a/model-pr-optimization-history/README.md
+++ b/model-pr-optimization-history/README.md
@@ -6,13 +6,17 @@ the directory acts as one queryable knowledge base for model-family PR evidence.
 
 - `sglang/`: SGLang model histories and audits.
 - `vllm/`: vLLM model histories and audits.
+- `tensorrt_llm/`: TensorRT-LLM model histories and audits.
+- `tokenspeed/`: TokenSpeed model histories and audits.
 - `SKILL.md`: agent instructions for using this directory as knowledge.
 - `scripts/query.py`: small local search helper for model slugs, doc paths, and
   keyword snippets.
 
 Each model history is bilingual when practical (`README.zh.md` and
 `README.en.md`) and should be grounded in inspected PR diffs, source files, and
-validation/risk notes.
+validation/risk notes. SGLang, vLLM, TensorRT-LLM, and TokenSpeed entries use
+the same timeline plus per-PR diff-card format whenever a model family has
+upstream PR evidence.
 
 When a doc is rechecked for timeliness, a dated `## <YYYY-MM-DD> PR Backfill
 Audit` section is prepended right after the title. It lists PR-numbered merges
@@ -30,5 +34,6 @@ python3 scripts/query.py --framework vllm "qwen3 fused qk norm"
 ```
 
 SGLang SOTA and Humanize loops should read the matching SGLang history before
-patch planning, read vLLM history when vLLM is the leading competitor, and save
-the short extracted evidence under `history/model-pr-history-notes.md`.
+patch planning, read competitor history when vLLM, TensorRT-LLM, or TokenSpeed
+is the leading competitor, and save the short extracted evidence under
+`history/model-pr-history-notes.md`.

--- a/model-pr-optimization-history/SKILL.md
+++ b/model-pr-optimization-history/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: model-pr-history-knowledge
-description: Use when an SGLang, vLLM, or TensorRT-LLM serving/model optimization task needs prior model-family PR evidence. Query and read the PR-driven history docs under model-pr-optimization-history before choosing source paths, fast paths, kernel/fusion ideas, regression risks, or validation lanes.
+description: Use when an SGLang, vLLM, TensorRT-LLM, or TokenSpeed serving/model optimization task needs prior model-family PR evidence. Query and read the PR-driven history docs under model-pr-optimization-history before choosing source paths, fast paths, kernel/fusion ideas, regression risks, or validation lanes.
 ---
 
 # Model PR History Knowledge
@@ -22,11 +22,13 @@ python3 scripts/query.py --list
 python3 scripts/query.py --framework sglang --model qwen3-core --paths-only
 python3 scripts/query.py --framework sglang --model qwen3-core "fused qk norm rope"
 python3 scripts/query.py --framework vllm "DeepSeek-V4 fused norm router" --limit 5
+python3 scripts/query.py --framework tokenspeed qwen35 --paths-only
 ```
 
 Useful options:
 
-- `--framework sglang|vllm`: restrict to one serving framework.
+- `--framework sglang|vllm|tensorrt_llm|tokenspeed`: restrict to one serving
+  framework.
 - `--model <slug>`: restrict to one model family directory.
 - `--lang en|zh|both`: select English, Chinese, or both docs.
 - `--paths-only`: print the exact docs to read without snippets.
@@ -36,11 +38,12 @@ Useful options:
 
 1. Infer the model-family slug from the user's model id, checkpoint path, or
    SGLang source path. If unsure, run `scripts/query.py "<model name>"`.
-2. Read the matching SGLang history first for SGLang patch work. Read the vLLM
-   history too when vLLM is the leading competitor or its trace suggests a
-   missing SGLang fast path. If the doc opens with a dated `PR Backfill Audit`
-   section, read it first: it lists the most recent PR-numbered merges that are
-   not yet folded into the older timeline / diff-audit cards.
+2. Read the matching SGLang history first for SGLang patch work. Read competitor
+   history too when vLLM, TensorRT-LLM, or TokenSpeed is the leading competitor
+   or its trace suggests a missing SGLang fast path. If the doc opens with a
+   dated `PR Backfill Audit` section, read it first: it lists the most recent
+   PR-numbered merges that are not yet folded into the older timeline /
+   diff-audit cards.
 3. Extract only actionable evidence:
    - model implementation files and symbols
    - PRs that changed the hot source path
@@ -60,6 +63,8 @@ Current frameworks:
 
 - `sglang`
 - `vllm`
+- `tensorrt_llm`
+- `tokenspeed`
 
 Current model-family slugs include:
 
@@ -83,4 +88,6 @@ source:
 - If the profiler points at a known model path, check whether the history has
   prior changes on that file before writing a new patch.
 - If a competitor is faster, search that competitor's model history for the
-  same model family and stage before assuming the gap is kernel-local.
+  same model family and stage before assuming the gap is kernel-local. Refresh
+  live source/PRs for the exact target commit before patch planning when the
+  comparison depends on latest upstream behavior.

--- a/model-pr-optimization-history/scripts/query.py
+++ b/model-pr-optimization-history/scripts/query.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-FRAMEWORKS = ("sglang", "vllm")
+FRAMEWORKS = ("sglang", "vllm", "tensorrt_llm", "tokenspeed")
 LANG_TO_FILES = {
     "en": ("README.en.md",),
     "zh": ("README.zh.md",),
@@ -43,6 +43,8 @@ def _frameworks(selected: str | None) -> list[str]:
 
 def _model_dirs(framework: str, selected: str | None) -> list[Path]:
     root = ROOT / framework
+    if not root.exists():
+        return []
     if selected:
         target = root / _slugify(selected)
         if target.exists():
@@ -77,6 +79,8 @@ def _docs(framework: str | None, model: str | None, lang: str) -> list[Doc]:
 def _list_models(framework: str | None) -> None:
     for fw in _frameworks(framework):
         root = ROOT / fw
+        if not root.exists():
+            continue
         for model_dir in sorted(path for path in root.iterdir() if path.is_dir()):
             print(f"{fw}/{model_dir.name}")
 

--- a/model-pr-optimization-history/sglang/README.md
+++ b/model-pr-optimization-history/sglang/README.md
@@ -37,7 +37,7 @@ Current model families:
 ## Current Optimization Items
 
 Refresh: `2026-06-26`. Source head:
-`sgl-project/sglang@b91348071e6ca21f9357fd8b1adc83a18781df30`.
+`sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90`.
 
 Keep active rows close to the relevant model histories;
 landed or closed rows remain here only as cross-model navigation hints until
@@ -45,6 +45,8 @@ they are mirrored in a per-model PR history.
 
 | PR | Model / area | Status | Current signal | Why it matters |
 | --- | --- | --- | --- | --- |
+| [#29390](https://github.com/sgl-project/sglang/pull/29390) | LTX-2.3 diffusion | merged | fused Ada values | Adds a Triton `ltx2_ada_values9` path that removes repeated Ada table materialization; profiler loops should classify split Ada add/reshape/slice ladders as a missing shipped fusion. |
+| [#29250](https://github.com/sgl-project/sglang/pull/29250) | MiniMax / MSA | merged | optional `fmha_sm100` fallback | Converts missing/incompatible MSA plan API into Triton sparse-attention fallback; benchmark comparisons should not count an image with broken optional MSA as a model-level SGLang regression without this fix. |
 | [#23882](https://github.com/sgl-project/sglang/pull/23882) | DeepSeek-V4 | merged | rebase tracking | Keeps DSV4 branch integration moving; check before assuming local DeepSeek-V4 support is final. |
 | [#24047](https://github.com/sgl-project/sglang/pull/24047) | DeepSeek-V4 / SM120 | closed | Blackwell-lite support | Affects FP4, MoE, and attention kernel eligibility on SM120 hardware. |
 | [#18612](https://github.com/sgl-project/sglang/pull/18612) | NVFP4 CUTLASS MoE | open | fused SiLU+Mul into expert quant | Covers a concrete activation-plus-quant MoE fuse opportunity. |

--- a/model-pr-optimization-history/sglang/README.md
+++ b/model-pr-optimization-history/sglang/README.md
@@ -36,7 +36,10 @@ Current model families:
 
 ## Current Optimization Items
 
-Refresh: `2026-05-26`. Keep active rows close to the relevant model histories;
+Refresh: `2026-06-26`. Source head:
+`sgl-project/sglang@b91348071e6ca21f9357fd8b1adc83a18781df30`.
+
+Keep active rows close to the relevant model histories;
 landed or closed rows remain here only as cross-model navigation hints until
 they are mirrored in a per-model PR history.
 

--- a/model-pr-optimization-history/sglang/deepseek-ocr-2/README.en.md
+++ b/model-pr-optimization-history/sglang/deepseek-ocr-2/README.en.md
@@ -1,5 +1,18 @@
 # sglang DeepSeek OCR 2 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 3 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-23 | [#27527](https://github.com/sgl-project/sglang/pull/27527) | Vectorize _create_custom_4d_mask in CustomQwen2Decoder | `deepseek_ocr.py` |
+| 2026-06-23 | [#28988](https://github.com/sgl-project/sglang/pull/28988) | [CI] Fix lint brought by #27527 | `deepseek_ocr.py` |
+| 2026-06-06 | [#27248](https://github.com/sgl-project/sglang/pull/27248) | [Doc][CPU]Update Cookbook with Xeon support info | `DeepSeek-OCR-2.mdx`, `deepseek-ocr-v2-deployment.jsx` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 3 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/deepseek-ocr-2/README.zh.md
+++ b/model-pr-optimization-history/sglang/deepseek-ocr-2/README.zh.md
@@ -1,5 +1,18 @@
 # sglang DeepSeek OCR 2 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 3 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-23 | [#27527](https://github.com/sgl-project/sglang/pull/27527) | Vectorize _create_custom_4d_mask in CustomQwen2Decoder | `deepseek_ocr.py` |
+| 2026-06-23 | [#28988](https://github.com/sgl-project/sglang/pull/28988) | [CI] Fix lint brought by #27527 | `deepseek_ocr.py` |
+| 2026-06-06 | [#27248](https://github.com/sgl-project/sglang/pull/27248) | [Doc][CPU]Update Cookbook with Xeon support info | `DeepSeek-OCR-2.mdx`, `deepseek-ocr-v2-deployment.jsx` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 3 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/deepseek-ocr/README.en.md
+++ b/model-pr-optimization-history/sglang/deepseek-ocr/README.en.md
@@ -1,5 +1,18 @@
 # sglang DeepSeek OCR Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 3 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-23 | [#27527](https://github.com/sgl-project/sglang/pull/27527) | Vectorize _create_custom_4d_mask in CustomQwen2Decoder | `deepseek_ocr.py` |
+| 2026-06-23 | [#28988](https://github.com/sgl-project/sglang/pull/28988) | [CI] Fix lint brought by #27527 | `deepseek_ocr.py` |
+| 2026-06-06 | [#27248](https://github.com/sgl-project/sglang/pull/27248) | [Doc][CPU]Update Cookbook with Xeon support info | `DeepSeek-OCR.mdx`, `deepseek-ocr-deployment.jsx` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 3 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/deepseek-ocr/README.zh.md
+++ b/model-pr-optimization-history/sglang/deepseek-ocr/README.zh.md
@@ -1,5 +1,18 @@
 # sglang DeepSeek OCR 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 3 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-23 | [#27527](https://github.com/sgl-project/sglang/pull/27527) | Vectorize _create_custom_4d_mask in CustomQwen2Decoder | `deepseek_ocr.py` |
+| 2026-06-23 | [#28988](https://github.com/sgl-project/sglang/pull/28988) | [CI] Fix lint brought by #27527 | `deepseek_ocr.py` |
+| 2026-06-06 | [#27248](https://github.com/sgl-project/sglang/pull/27248) | [Doc][CPU]Update Cookbook with Xeon support info | `DeepSeek-OCR.mdx`, `deepseek-ocr-deployment.jsx` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 3 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/deepseek-v3-r1/README.en.md
+++ b/model-pr-optimization-history/sglang/deepseek-v3-r1/README.en.md
@@ -1,5 +1,45 @@
 # sglang DeepSeek V3/R1 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 30 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-26 | [#29142](https://github.com/sgl-project/sglang/pull/29142) | [DeepSeek V3] Run routed experts on main stream in dual-stream MoE | `deepseek_v2.py` |
+| 2026-06-25 | [#29042](https://github.com/sgl-project/sglang/pull/29042) | [NPU] Fix the DeepSeek-V2-Coder model accuracy issue | `deepseek_v2.py` |
+| 2026-06-24 | [#29129](https://github.com/sgl-project/sglang/pull/29129) | [NPU] [DOC] Fix TOC of Ascend NPU Docs | `DeepSeek-V3.mdx` |
+| 2026-06-24 | [#27053](https://github.com/sgl-project/sglang/pull/27053) | [BCG][GLM5] perf: BCG support and prefill enhancements | `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-23 | [#28938](https://github.com/sgl-project/sglang/pull/28938) | [AMD] Improve performance of dsv4 in high concurrency | `deepseek_v2.py` |
+| 2026-06-24 | [#27833](https://github.com/sgl-project/sglang/pull/27833) | [AMD] Enable BCG on ROCm + route aiter prefill via MHA during PCG/BCG capture for Kimi-2.5 | `attention_backend_handler.py` |
+| 2026-06-21 | [#28785](https://github.com/sgl-project/sglang/pull/28785) | Pass DSA topk through PP warmup proxy buffers | `deepseek_v2.py` |
+| 2026-06-19 | [#28751](https://github.com/sgl-project/sglang/pull/28751) | Revert "ci: add 4-GPU mi35x runner and rebalance off the saturated 8-GPU pool" | `test_deepseek_r1_mxfp4_8gpu.py` |
+| 2026-06-19 | [#28532](https://github.com/sgl-project/sglang/pull/28532) | Fix IndexCache PP topk handoff | `deepseek_v2.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `deepseek-r1-advanced-deployment.jsx`, `deepseek-r1-basic-deployment.jsx`, `deepseek-v32-deployment.jsx` |
+| 2026-06-18 | [#28559](https://github.com/sgl-project/sglang/pull/28559) | fix: speculative draft worker clobbering target attention backend | `deepseek_v2.py` |
+| 2026-06-18 | [#25144](https://github.com/sgl-project/sglang/pull/25144) | [NPU] Add Ascend NPU support for DeepSeek-V4 | `deepseek_v2.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `deepseek_v2.py` |
+| 2026-06-17 | [#28436](https://github.com/sgl-project/sglang/pull/28436) | [NPU] Use use_dsa to dispatch Ascend DSA attention | `attention_backend_handler.py` |
+| 2026-06-17 | [#28343](https://github.com/sgl-project/sglang/pull/28343) | [Kimi K2.5] Fix eagle3 aux capture for tp>1 when AR fusion is enabled | `deepseek_v2.py` |
+| 2026-06-17 | [#27798](https://github.com/sgl-project/sglang/pull/27798) | [AMD] Add transpose_scale arg for o_proj to fix GLM accuracy issue | `forward_mla.py` |
+| 2026-06-16 | [#24515](https://github.com/sgl-project/sglang/pull/24515) | LPLB: linear-programming load balancer for MoE expert parallelism | `deepseek_v2.py` |
+| 2026-06-15 | [#28118](https://github.com/sgl-project/sglang/pull/28118) | 【bugfix】The NPU's forward_dsa_prepare_npu also needs special handling for is_nextn | `deepseek_v2_attention_mla_npu.py` |
+| 2026-06-13 | [#28129](https://github.com/sgl-project/sglang/pull/28129) | [Spec] Remove deprecated EAGLE v1 DRAFT_EXTEND forward mode | `deepseek_v2_attention_mla_npu.py`, `attention_backend_handler.py`, `deepseek_v2.py` |
+| 2026-06-13 | [#27720](https://github.com/sgl-project/sglang/pull/27720) | [DeepSeek V3] Defer moe finalize and fused it with main stream add | `deepseek_v2.py` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `DeepSeek-V3.mdx`, `DeepSeek-V3_2.mdx` |
+| 2026-06-12 | [#27956](https://github.com/sgl-project/sglang/pull/27956) | Use the correct wrapper for `fp4_quantize` | `deepseek_v2.py` |
+| 2026-06-10 | [#27510](https://github.com/sgl-project/sglang/pull/27510) | [deepseek] Enable DP attention + TBO + shared experts fusion | `deepseek_v2.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `attention_backend_handler.py`, `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-08 | [#27289](https://github.com/sgl-project/sglang/pull/27289) | [ROCm] dsv4: remove the redundant fp8 scale transpose-copy on decode | `forward_mha.py`, `forward_mla.py`, `utils.py`, `deepseek_v2.py` |
+| 2026-06-07 | [#22299](https://github.com/sgl-project/sglang/pull/22299) | [AMD] Enable Piecewise CUDA Graph for AMD GPUs | `test_deepseek_r1_mxfp4_8gpu.py` |
+| 2026-06-06 | [#27114](https://github.com/sgl-project/sglang/pull/27114) | [Bugfix] Restore overridden HF config fields and support index_skip_topk_offset for DSA topk sharing | `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-05 | [#27329](https://github.com/sgl-project/sglang/pull/27329) | [LoRA] Experimental fast LoRA path with `experimental_sgl_trtllm` MoE backend for FP8 and NVFP4 models | `forward_mla.py` |
+| 2026-06-06 | [#27248](https://github.com/sgl-project/sglang/pull/27248) | [Doc][CPU]Update Cookbook with Xeon support info | `DeepSeek-R1.mdx`, `DeepSeek-V3.mdx`, `DeepSeek-V3_1.mdx`, `deepseek-r1-basic-deployment.jsx`, ... (+2) |
+| 2026-06-05 | [#27150](https://github.com/sgl-project/sglang/pull/27150) | Support Waterfill with dynamic EPLB | `deepseek_v2.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 75 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-24). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/deepseek-v3-r1/README.zh.md
+++ b/model-pr-optimization-history/sglang/deepseek-v3-r1/README.zh.md
@@ -1,5 +1,45 @@
 # sglang DeepSeek V3/R1 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 30 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-26 | [#29142](https://github.com/sgl-project/sglang/pull/29142) | [DeepSeek V3] Run routed experts on main stream in dual-stream MoE | `deepseek_v2.py` |
+| 2026-06-25 | [#29042](https://github.com/sgl-project/sglang/pull/29042) | [NPU] Fix the DeepSeek-V2-Coder model accuracy issue | `deepseek_v2.py` |
+| 2026-06-24 | [#29129](https://github.com/sgl-project/sglang/pull/29129) | [NPU] [DOC] Fix TOC of Ascend NPU Docs | `DeepSeek-V3.mdx` |
+| 2026-06-24 | [#27053](https://github.com/sgl-project/sglang/pull/27053) | [BCG][GLM5] perf: BCG support and prefill enhancements | `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-23 | [#28938](https://github.com/sgl-project/sglang/pull/28938) | [AMD] Improve performance of dsv4 in high concurrency | `deepseek_v2.py` |
+| 2026-06-24 | [#27833](https://github.com/sgl-project/sglang/pull/27833) | [AMD] Enable BCG on ROCm + route aiter prefill via MHA during PCG/BCG capture for Kimi-2.5 | `attention_backend_handler.py` |
+| 2026-06-21 | [#28785](https://github.com/sgl-project/sglang/pull/28785) | Pass DSA topk through PP warmup proxy buffers | `deepseek_v2.py` |
+| 2026-06-19 | [#28751](https://github.com/sgl-project/sglang/pull/28751) | Revert "ci: add 4-GPU mi35x runner and rebalance off the saturated 8-GPU pool" | `test_deepseek_r1_mxfp4_8gpu.py` |
+| 2026-06-19 | [#28532](https://github.com/sgl-project/sglang/pull/28532) | Fix IndexCache PP topk handoff | `deepseek_v2.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `deepseek-r1-advanced-deployment.jsx`, `deepseek-r1-basic-deployment.jsx`, `deepseek-v32-deployment.jsx` |
+| 2026-06-18 | [#28559](https://github.com/sgl-project/sglang/pull/28559) | fix: speculative draft worker clobbering target attention backend | `deepseek_v2.py` |
+| 2026-06-18 | [#25144](https://github.com/sgl-project/sglang/pull/25144) | [NPU] Add Ascend NPU support for DeepSeek-V4 | `deepseek_v2.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `deepseek_v2.py` |
+| 2026-06-17 | [#28436](https://github.com/sgl-project/sglang/pull/28436) | [NPU] Use use_dsa to dispatch Ascend DSA attention | `attention_backend_handler.py` |
+| 2026-06-17 | [#28343](https://github.com/sgl-project/sglang/pull/28343) | [Kimi K2.5] Fix eagle3 aux capture for tp>1 when AR fusion is enabled | `deepseek_v2.py` |
+| 2026-06-17 | [#27798](https://github.com/sgl-project/sglang/pull/27798) | [AMD] Add transpose_scale arg for o_proj to fix GLM accuracy issue | `forward_mla.py` |
+| 2026-06-16 | [#24515](https://github.com/sgl-project/sglang/pull/24515) | LPLB: linear-programming load balancer for MoE expert parallelism | `deepseek_v2.py` |
+| 2026-06-15 | [#28118](https://github.com/sgl-project/sglang/pull/28118) | 【bugfix】The NPU's forward_dsa_prepare_npu also needs special handling for is_nextn | `deepseek_v2_attention_mla_npu.py` |
+| 2026-06-13 | [#28129](https://github.com/sgl-project/sglang/pull/28129) | [Spec] Remove deprecated EAGLE v1 DRAFT_EXTEND forward mode | `deepseek_v2_attention_mla_npu.py`, `attention_backend_handler.py`, `deepseek_v2.py` |
+| 2026-06-13 | [#27720](https://github.com/sgl-project/sglang/pull/27720) | [DeepSeek V3] Defer moe finalize and fused it with main stream add | `deepseek_v2.py` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `DeepSeek-V3.mdx`, `DeepSeek-V3_2.mdx` |
+| 2026-06-12 | [#27956](https://github.com/sgl-project/sglang/pull/27956) | Use the correct wrapper for `fp4_quantize` | `deepseek_v2.py` |
+| 2026-06-10 | [#27510](https://github.com/sgl-project/sglang/pull/27510) | [deepseek] Enable DP attention + TBO + shared experts fusion | `deepseek_v2.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `attention_backend_handler.py`, `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-08 | [#27289](https://github.com/sgl-project/sglang/pull/27289) | [ROCm] dsv4: remove the redundant fp8 scale transpose-copy on decode | `forward_mha.py`, `forward_mla.py`, `utils.py`, `deepseek_v2.py` |
+| 2026-06-07 | [#22299](https://github.com/sgl-project/sglang/pull/22299) | [AMD] Enable Piecewise CUDA Graph for AMD GPUs | `test_deepseek_r1_mxfp4_8gpu.py` |
+| 2026-06-06 | [#27114](https://github.com/sgl-project/sglang/pull/27114) | [Bugfix] Restore overridden HF config fields and support index_skip_topk_offset for DSA topk sharing | `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-05 | [#27329](https://github.com/sgl-project/sglang/pull/27329) | [LoRA] Experimental fast LoRA path with `experimental_sgl_trtllm` MoE backend for FP8 and NVFP4 models | `forward_mla.py` |
+| 2026-06-06 | [#27248](https://github.com/sgl-project/sglang/pull/27248) | [Doc][CPU]Update Cookbook with Xeon support info | `DeepSeek-R1.mdx`, `DeepSeek-V3.mdx`, `DeepSeek-V3_1.mdx`, `deepseek-r1-basic-deployment.jsx`, ... (+2) |
+| 2026-06-05 | [#27150](https://github.com/sgl-project/sglang/pull/27150) | Support Waterfill with dynamic EPLB | `deepseek_v2.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-04-24）以来，共有 75 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/deepseek-v31/README.en.md
+++ b/model-pr-optimization-history/sglang/deepseek-v31/README.en.md
@@ -1,5 +1,40 @@
 # sglang DeepSeek V3.1 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 25 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-26 | [#29142](https://github.com/sgl-project/sglang/pull/29142) | [DeepSeek V3] Run routed experts on main stream in dual-stream MoE | `deepseek_v2.py` |
+| 2026-06-25 | [#29042](https://github.com/sgl-project/sglang/pull/29042) | [NPU] Fix the DeepSeek-V2-Coder model accuracy issue | `deepseek_v2.py` |
+| 2026-06-25 | [#14194](https://github.com/sgl-project/sglang/pull/14194) | [feature] implement dcp for deepseek_v2 | `forward_mha.py`, `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-24 | [#27053](https://github.com/sgl-project/sglang/pull/27053) | [BCG][GLM5] perf: BCG support and prefill enhancements | `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-23 | [#28938](https://github.com/sgl-project/sglang/pull/28938) | [AMD] Improve performance of dsv4 in high concurrency | `deepseek_v2.py` |
+| 2026-06-24 | [#27833](https://github.com/sgl-project/sglang/pull/27833) | [AMD] Enable BCG on ROCm + route aiter prefill via MHA during PCG/BCG capture for Kimi-2.5 | `attention_backend_handler.py` |
+| 2026-06-21 | [#28785](https://github.com/sgl-project/sglang/pull/28785) | Pass DSA topk through PP warmup proxy buffers | `deepseek_v2.py` |
+| 2026-06-19 | [#28532](https://github.com/sgl-project/sglang/pull/28532) | Fix IndexCache PP topk handoff | `deepseek_v2.py` |
+| 2026-06-18 | [#28559](https://github.com/sgl-project/sglang/pull/28559) | fix: speculative draft worker clobbering target attention backend | `deepseek_v2.py` |
+| 2026-06-18 | [#25144](https://github.com/sgl-project/sglang/pull/25144) | [NPU] Add Ascend NPU support for DeepSeek-V4 | `deepseek_v2.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `deepseek_v2.py` |
+| 2026-06-17 | [#28436](https://github.com/sgl-project/sglang/pull/28436) | [NPU] Use use_dsa to dispatch Ascend DSA attention | `attention_backend_handler.py` |
+| 2026-06-17 | [#28343](https://github.com/sgl-project/sglang/pull/28343) | [Kimi K2.5] Fix eagle3 aux capture for tp>1 when AR fusion is enabled | `deepseek_v2.py` |
+| 2026-06-17 | [#27798](https://github.com/sgl-project/sglang/pull/27798) | [AMD] Add transpose_scale arg for o_proj to fix GLM accuracy issue | `forward_mla.py` |
+| 2026-06-16 | [#24515](https://github.com/sgl-project/sglang/pull/24515) | LPLB: linear-programming load balancer for MoE expert parallelism | `deepseek_v2.py` |
+| 2026-06-15 | [#28118](https://github.com/sgl-project/sglang/pull/28118) | 【bugfix】The NPU's forward_dsa_prepare_npu also needs special handling for is_nextn | `deepseek_v2_attention_mla_npu.py` |
+| 2026-06-13 | [#28129](https://github.com/sgl-project/sglang/pull/28129) | [Spec] Remove deprecated EAGLE v1 DRAFT_EXTEND forward mode | `deepseek_v2_attention_mla_npu.py`, `attention_backend_handler.py`, `deepseek_v2.py` |
+| 2026-06-13 | [#27720](https://github.com/sgl-project/sglang/pull/27720) | [DeepSeek V3] Defer moe finalize and fused it with main stream add | `deepseek_v2.py` |
+| 2026-06-12 | [#27956](https://github.com/sgl-project/sglang/pull/27956) | Use the correct wrapper for `fp4_quantize` | `deepseek_v2.py` |
+| 2026-06-10 | [#27510](https://github.com/sgl-project/sglang/pull/27510) | [deepseek] Enable DP attention + TBO + shared experts fusion | `deepseek_v2.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `attention_backend_handler.py`, `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-08 | [#27289](https://github.com/sgl-project/sglang/pull/27289) | [ROCm] dsv4: remove the redundant fp8 scale transpose-copy on decode | `forward_mha.py`, `forward_mla.py`, `utils.py`, `deepseek_v2.py` |
+| 2026-06-06 | [#27114](https://github.com/sgl-project/sglang/pull/27114) | [Bugfix] Restore overridden HF config fields and support index_skip_topk_offset for DSA topk sharing | `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-05 | [#27329](https://github.com/sgl-project/sglang/pull/27329) | [LoRA] Experimental fast LoRA path with `experimental_sgl_trtllm` MoE backend for FP8 and NVFP4 models | `forward_mla.py` |
+| 2026-06-05 | [#27150](https://github.com/sgl-project/sglang/pull/27150) | Support Waterfill with dynamic EPLB | `deepseek_v2.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 52 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-21). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/deepseek-v31/README.zh.md
+++ b/model-pr-optimization-history/sglang/deepseek-v31/README.zh.md
@@ -1,5 +1,40 @@
 # sglang DeepSeek V3.1 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 25 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-26 | [#29142](https://github.com/sgl-project/sglang/pull/29142) | [DeepSeek V3] Run routed experts on main stream in dual-stream MoE | `deepseek_v2.py` |
+| 2026-06-25 | [#29042](https://github.com/sgl-project/sglang/pull/29042) | [NPU] Fix the DeepSeek-V2-Coder model accuracy issue | `deepseek_v2.py` |
+| 2026-06-25 | [#14194](https://github.com/sgl-project/sglang/pull/14194) | [feature] implement dcp for deepseek_v2 | `forward_mha.py`, `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-24 | [#27053](https://github.com/sgl-project/sglang/pull/27053) | [BCG][GLM5] perf: BCG support and prefill enhancements | `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-23 | [#28938](https://github.com/sgl-project/sglang/pull/28938) | [AMD] Improve performance of dsv4 in high concurrency | `deepseek_v2.py` |
+| 2026-06-24 | [#27833](https://github.com/sgl-project/sglang/pull/27833) | [AMD] Enable BCG on ROCm + route aiter prefill via MHA during PCG/BCG capture for Kimi-2.5 | `attention_backend_handler.py` |
+| 2026-06-21 | [#28785](https://github.com/sgl-project/sglang/pull/28785) | Pass DSA topk through PP warmup proxy buffers | `deepseek_v2.py` |
+| 2026-06-19 | [#28532](https://github.com/sgl-project/sglang/pull/28532) | Fix IndexCache PP topk handoff | `deepseek_v2.py` |
+| 2026-06-18 | [#28559](https://github.com/sgl-project/sglang/pull/28559) | fix: speculative draft worker clobbering target attention backend | `deepseek_v2.py` |
+| 2026-06-18 | [#25144](https://github.com/sgl-project/sglang/pull/25144) | [NPU] Add Ascend NPU support for DeepSeek-V4 | `deepseek_v2.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `deepseek_v2.py` |
+| 2026-06-17 | [#28436](https://github.com/sgl-project/sglang/pull/28436) | [NPU] Use use_dsa to dispatch Ascend DSA attention | `attention_backend_handler.py` |
+| 2026-06-17 | [#28343](https://github.com/sgl-project/sglang/pull/28343) | [Kimi K2.5] Fix eagle3 aux capture for tp>1 when AR fusion is enabled | `deepseek_v2.py` |
+| 2026-06-17 | [#27798](https://github.com/sgl-project/sglang/pull/27798) | [AMD] Add transpose_scale arg for o_proj to fix GLM accuracy issue | `forward_mla.py` |
+| 2026-06-16 | [#24515](https://github.com/sgl-project/sglang/pull/24515) | LPLB: linear-programming load balancer for MoE expert parallelism | `deepseek_v2.py` |
+| 2026-06-15 | [#28118](https://github.com/sgl-project/sglang/pull/28118) | 【bugfix】The NPU's forward_dsa_prepare_npu also needs special handling for is_nextn | `deepseek_v2_attention_mla_npu.py` |
+| 2026-06-13 | [#28129](https://github.com/sgl-project/sglang/pull/28129) | [Spec] Remove deprecated EAGLE v1 DRAFT_EXTEND forward mode | `deepseek_v2_attention_mla_npu.py`, `attention_backend_handler.py`, `deepseek_v2.py` |
+| 2026-06-13 | [#27720](https://github.com/sgl-project/sglang/pull/27720) | [DeepSeek V3] Defer moe finalize and fused it with main stream add | `deepseek_v2.py` |
+| 2026-06-12 | [#27956](https://github.com/sgl-project/sglang/pull/27956) | Use the correct wrapper for `fp4_quantize` | `deepseek_v2.py` |
+| 2026-06-10 | [#27510](https://github.com/sgl-project/sglang/pull/27510) | [deepseek] Enable DP attention + TBO + shared experts fusion | `deepseek_v2.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `attention_backend_handler.py`, `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-08 | [#27289](https://github.com/sgl-project/sglang/pull/27289) | [ROCm] dsv4: remove the redundant fp8 scale transpose-copy on decode | `forward_mha.py`, `forward_mla.py`, `utils.py`, `deepseek_v2.py` |
+| 2026-06-06 | [#27114](https://github.com/sgl-project/sglang/pull/27114) | [Bugfix] Restore overridden HF config fields and support index_skip_topk_offset for DSA topk sharing | `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-05 | [#27329](https://github.com/sgl-project/sglang/pull/27329) | [LoRA] Experimental fast LoRA path with `experimental_sgl_trtllm` MoE backend for FP8 and NVFP4 models | `forward_mla.py` |
+| 2026-06-05 | [#27150](https://github.com/sgl-project/sglang/pull/27150) | Support Waterfill with dynamic EPLB | `deepseek_v2.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-04-21）以来，共有 52 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/deepseek-v32/README.en.md
+++ b/model-pr-optimization-history/sglang/deepseek-v32/README.en.md
@@ -1,5 +1,44 @@
 # sglang DeepSeek V3.2 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 29 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-26 | [#29142](https://github.com/sgl-project/sglang/pull/29142) | [DeepSeek V3] Run routed experts on main stream in dual-stream MoE | `deepseek_v2.py` |
+| 2026-06-25 | [#29042](https://github.com/sgl-project/sglang/pull/29042) | [NPU] Fix the DeepSeek-V2-Coder model accuracy issue | `deepseek_v2.py` |
+| 2026-06-25 | [#14194](https://github.com/sgl-project/sglang/pull/14194) | [feature] implement dcp for deepseek_v2 | `forward_mha.py`, `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-24 | [#27053](https://github.com/sgl-project/sglang/pull/27053) | [BCG][GLM5] perf: BCG support and prefill enhancements | `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-23 | [#28938](https://github.com/sgl-project/sglang/pull/28938) | [AMD] Improve performance of dsv4 in high concurrency | `deepseek_v2.py` |
+| 2026-06-24 | [#27833](https://github.com/sgl-project/sglang/pull/27833) | [AMD] Enable BCG on ROCm + route aiter prefill via MHA during PCG/BCG capture for Kimi-2.5 | `attention_backend_handler.py` |
+| 2026-06-22 | [#28855](https://github.com/sgl-project/sglang/pull/28855) | [Spec] Redo: split init_backends; account draft weights in --mem-fraction-static | `test_deepseek_v32.py`, `test_deepseek_v32_cp_single_node.py` |
+| 2026-06-21 | [#28785](https://github.com/sgl-project/sglang/pull/28785) | Pass DSA topk through PP warmup proxy buffers | `deepseek_v2.py` |
+| 2026-06-19 | [#28536](https://github.com/sgl-project/sglang/pull/28536) | ci: run GB300 nightly suite in the standard Nvidia nightly workflow | `test_deepseek_v32.py`, `test_deepseek_v32_nvfp4.py` |
+| 2026-06-19 | [#28532](https://github.com/sgl-project/sglang/pull/28532) | Fix IndexCache PP topk handoff | `deepseek_v2.py` |
+| 2026-06-18 | [#28559](https://github.com/sgl-project/sglang/pull/28559) | fix: speculative draft worker clobbering target attention backend | `deepseek_v2.py` |
+| 2026-06-18 | [#25144](https://github.com/sgl-project/sglang/pull/25144) | [NPU] Add Ascend NPU support for DeepSeek-V4 | `deepseek_v2.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `deepseek_v2.py` |
+| 2026-06-17 | [#28436](https://github.com/sgl-project/sglang/pull/28436) | [NPU] Use use_dsa to dispatch Ascend DSA attention | `attention_backend_handler.py` |
+| 2026-06-17 | [#28343](https://github.com/sgl-project/sglang/pull/28343) | [Kimi K2.5] Fix eagle3 aux capture for tp>1 when AR fusion is enabled | `deepseek_v2.py` |
+| 2026-06-17 | [#27798](https://github.com/sgl-project/sglang/pull/27798) | [AMD] Add transpose_scale arg for o_proj to fix GLM accuracy issue | `forward_mla.py` |
+| 2026-06-16 | [#28035](https://github.com/sgl-project/sglang/pull/28035) | fix(openai): validate assistant tool call arguments before chat template | `encoding_dsv32.py` |
+| 2026-06-16 | [#24515](https://github.com/sgl-project/sglang/pull/24515) | LPLB: linear-programming load balancer for MoE expert parallelism | `deepseek_v2.py` |
+| 2026-06-15 | [#28118](https://github.com/sgl-project/sglang/pull/28118) | 【bugfix】The NPU's forward_dsa_prepare_npu also needs special handling for is_nextn | `deepseek_v2_attention_mla_npu.py` |
+| 2026-06-13 | [#28129](https://github.com/sgl-project/sglang/pull/28129) | [Spec] Remove deprecated EAGLE v1 DRAFT_EXTEND forward mode | `deepseek_v2_attention_mla_npu.py`, `attention_backend_handler.py`, `deepseek_v2.py` |
+| 2026-06-13 | [#27720](https://github.com/sgl-project/sglang/pull/27720) | [DeepSeek V3] Defer moe finalize and fused it with main stream add | `deepseek_v2.py` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `test_deepseek_v32.py`, `test_deepseek_v32_nvfp4.py` |
+| 2026-06-12 | [#27956](https://github.com/sgl-project/sglang/pull/27956) | Use the correct wrapper for `fp4_quantize` | `deepseek_v2.py` |
+| 2026-06-10 | [#27510](https://github.com/sgl-project/sglang/pull/27510) | [deepseek] Enable DP attention + TBO + shared experts fusion | `deepseek_v2.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `attention_backend_handler.py`, `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-08 | [#27289](https://github.com/sgl-project/sglang/pull/27289) | [ROCm] dsv4: remove the redundant fp8 scale transpose-copy on decode | `forward_mha.py`, `forward_mla.py`, `utils.py`, `deepseek_v2.py` |
+| 2026-06-06 | [#27114](https://github.com/sgl-project/sglang/pull/27114) | [Bugfix] Restore overridden HF config fields and support index_skip_topk_offset for DSA topk sharing | `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-05 | [#27329](https://github.com/sgl-project/sglang/pull/27329) | [LoRA] Experimental fast LoRA path with `experimental_sgl_trtllm` MoE backend for FP8 and NVFP4 models | `forward_mla.py` |
+| 2026-06-05 | [#27150](https://github.com/sgl-project/sglang/pull/27150) | Support Waterfill with dynamic EPLB | `deepseek_v2.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 26 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/deepseek-v32/README.zh.md
+++ b/model-pr-optimization-history/sglang/deepseek-v32/README.zh.md
@@ -1,5 +1,44 @@
 # sglang DeepSeek V3.2 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 29 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-26 | [#29142](https://github.com/sgl-project/sglang/pull/29142) | [DeepSeek V3] Run routed experts on main stream in dual-stream MoE | `deepseek_v2.py` |
+| 2026-06-25 | [#29042](https://github.com/sgl-project/sglang/pull/29042) | [NPU] Fix the DeepSeek-V2-Coder model accuracy issue | `deepseek_v2.py` |
+| 2026-06-25 | [#14194](https://github.com/sgl-project/sglang/pull/14194) | [feature] implement dcp for deepseek_v2 | `forward_mha.py`, `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-24 | [#27053](https://github.com/sgl-project/sglang/pull/27053) | [BCG][GLM5] perf: BCG support and prefill enhancements | `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-23 | [#28938](https://github.com/sgl-project/sglang/pull/28938) | [AMD] Improve performance of dsv4 in high concurrency | `deepseek_v2.py` |
+| 2026-06-24 | [#27833](https://github.com/sgl-project/sglang/pull/27833) | [AMD] Enable BCG on ROCm + route aiter prefill via MHA during PCG/BCG capture for Kimi-2.5 | `attention_backend_handler.py` |
+| 2026-06-22 | [#28855](https://github.com/sgl-project/sglang/pull/28855) | [Spec] Redo: split init_backends; account draft weights in --mem-fraction-static | `test_deepseek_v32.py`, `test_deepseek_v32_cp_single_node.py` |
+| 2026-06-21 | [#28785](https://github.com/sgl-project/sglang/pull/28785) | Pass DSA topk through PP warmup proxy buffers | `deepseek_v2.py` |
+| 2026-06-19 | [#28536](https://github.com/sgl-project/sglang/pull/28536) | ci: run GB300 nightly suite in the standard Nvidia nightly workflow | `test_deepseek_v32.py`, `test_deepseek_v32_nvfp4.py` |
+| 2026-06-19 | [#28532](https://github.com/sgl-project/sglang/pull/28532) | Fix IndexCache PP topk handoff | `deepseek_v2.py` |
+| 2026-06-18 | [#28559](https://github.com/sgl-project/sglang/pull/28559) | fix: speculative draft worker clobbering target attention backend | `deepseek_v2.py` |
+| 2026-06-18 | [#25144](https://github.com/sgl-project/sglang/pull/25144) | [NPU] Add Ascend NPU support for DeepSeek-V4 | `deepseek_v2.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `deepseek_v2.py` |
+| 2026-06-17 | [#28436](https://github.com/sgl-project/sglang/pull/28436) | [NPU] Use use_dsa to dispatch Ascend DSA attention | `attention_backend_handler.py` |
+| 2026-06-17 | [#28343](https://github.com/sgl-project/sglang/pull/28343) | [Kimi K2.5] Fix eagle3 aux capture for tp>1 when AR fusion is enabled | `deepseek_v2.py` |
+| 2026-06-17 | [#27798](https://github.com/sgl-project/sglang/pull/27798) | [AMD] Add transpose_scale arg for o_proj to fix GLM accuracy issue | `forward_mla.py` |
+| 2026-06-16 | [#28035](https://github.com/sgl-project/sglang/pull/28035) | fix(openai): validate assistant tool call arguments before chat template | `encoding_dsv32.py` |
+| 2026-06-16 | [#24515](https://github.com/sgl-project/sglang/pull/24515) | LPLB: linear-programming load balancer for MoE expert parallelism | `deepseek_v2.py` |
+| 2026-06-15 | [#28118](https://github.com/sgl-project/sglang/pull/28118) | 【bugfix】The NPU's forward_dsa_prepare_npu also needs special handling for is_nextn | `deepseek_v2_attention_mla_npu.py` |
+| 2026-06-13 | [#28129](https://github.com/sgl-project/sglang/pull/28129) | [Spec] Remove deprecated EAGLE v1 DRAFT_EXTEND forward mode | `deepseek_v2_attention_mla_npu.py`, `attention_backend_handler.py`, `deepseek_v2.py` |
+| 2026-06-13 | [#27720](https://github.com/sgl-project/sglang/pull/27720) | [DeepSeek V3] Defer moe finalize and fused it with main stream add | `deepseek_v2.py` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `test_deepseek_v32.py`, `test_deepseek_v32_nvfp4.py` |
+| 2026-06-12 | [#27956](https://github.com/sgl-project/sglang/pull/27956) | Use the correct wrapper for `fp4_quantize` | `deepseek_v2.py` |
+| 2026-06-10 | [#27510](https://github.com/sgl-project/sglang/pull/27510) | [deepseek] Enable DP attention + TBO + shared experts fusion | `deepseek_v2.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `attention_backend_handler.py`, `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-08 | [#27289](https://github.com/sgl-project/sglang/pull/27289) | [ROCm] dsv4: remove the redundant fp8 scale transpose-copy on decode | `forward_mha.py`, `forward_mla.py`, `utils.py`, `deepseek_v2.py` |
+| 2026-06-06 | [#27114](https://github.com/sgl-project/sglang/pull/27114) | [Bugfix] Restore overridden HF config fields and support index_skip_topk_offset for DSA topk sharing | `forward_mla.py`, `deepseek_v2.py` |
+| 2026-06-05 | [#27329](https://github.com/sgl-project/sglang/pull/27329) | [LoRA] Experimental fast LoRA path with `experimental_sgl_trtllm` MoE backend for FP8 and NVFP4 models | `forward_mla.py` |
+| 2026-06-05 | [#27150](https://github.com/sgl-project/sglang/pull/27150) | Support Waterfill with dynamic EPLB | `deepseek_v2.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 26 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/deepseek-v4/README.en.md
+++ b/model-pr-optimization-history/sglang/deepseek-v4/README.en.md
@@ -1,5 +1,25 @@
 # sglang DeepSeek V4 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 10 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29261](https://github.com/sgl-project/sglang/pull/29261) | [Docs] Fix broken links in cookbook | `DeepSeek-V4.mdx` |
+| 2026-06-24 | [#28952](https://github.com/sgl-project/sglang/pull/28952) | Add DeepSeek V4 Flash demo notebook | `DeepSeek-V4.mdx` |
+| 2026-06-23 | [#28981](https://github.com/sgl-project/sglang/pull/28981) | [AMD] Update v4 cookbook to clean env vars | `DeepSeek-V4.mdx` |
+| 2026-06-22 | [#25820](https://github.com/sgl-project/sglang/pull/25820) | [NVIDIA] Support NVFP4 MoE for DeepSeek-V4 | `DeepSeek-V4.mdx` |
+| 2026-06-18 | [#28613](https://github.com/sgl-project/sglang/pull/28613) | docs: add DeepSeek-V4 compressed state dtype tip | `DeepSeek-V4.mdx` |
+| 2026-06-17 | [#28423](https://github.com/sgl-project/sglang/pull/28423) | [AMD] Update v4 amd cookbook | `DeepSeek-V4.mdx` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `DeepSeek-V4.mdx` |
+| 2026-06-10 | [#27830](https://github.com/sgl-project/sglang/pull/27830) | [Docs] Restore right-hand ToC on the DeepSeek-V4 cookbook page | `DeepSeek-V4.mdx` |
+| 2026-06-08 | [#26885](https://github.com/sgl-project/sglang/pull/26885) | Cookbook renovation | `DeepSeek-V4.mdx`, `deepseek-v4-deployment.jsx` |
+| 2026-06-05 | [#27404](https://github.com/sgl-project/sglang/pull/27404) | Remove DeepSeek V4 release Docker workflow | `release-docker-deepseek-v4.yml` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 12 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/deepseek-v4/README.zh.md
+++ b/model-pr-optimization-history/sglang/deepseek-v4/README.zh.md
@@ -1,5 +1,25 @@
 # sglang DeepSeek V4 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 10 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29261](https://github.com/sgl-project/sglang/pull/29261) | [Docs] Fix broken links in cookbook | `DeepSeek-V4.mdx` |
+| 2026-06-24 | [#28952](https://github.com/sgl-project/sglang/pull/28952) | Add DeepSeek V4 Flash demo notebook | `DeepSeek-V4.mdx` |
+| 2026-06-23 | [#28981](https://github.com/sgl-project/sglang/pull/28981) | [AMD] Update v4 cookbook to clean env vars | `DeepSeek-V4.mdx` |
+| 2026-06-22 | [#25820](https://github.com/sgl-project/sglang/pull/25820) | [NVIDIA] Support NVFP4 MoE for DeepSeek-V4 | `DeepSeek-V4.mdx` |
+| 2026-06-18 | [#28613](https://github.com/sgl-project/sglang/pull/28613) | docs: add DeepSeek-V4 compressed state dtype tip | `DeepSeek-V4.mdx` |
+| 2026-06-17 | [#28423](https://github.com/sgl-project/sglang/pull/28423) | [AMD] Update v4 amd cookbook | `DeepSeek-V4.mdx` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `DeepSeek-V4.mdx` |
+| 2026-06-10 | [#27830](https://github.com/sgl-project/sglang/pull/27830) | [Docs] Restore right-hand ToC on the DeepSeek-V4 cookbook page | `DeepSeek-V4.mdx` |
+| 2026-06-08 | [#26885](https://github.com/sgl-project/sglang/pull/26885) | Cookbook renovation | `DeepSeek-V4.mdx`, `deepseek-v4-deployment.jsx` |
+| 2026-06-05 | [#27404](https://github.com/sgl-project/sglang/pull/27404) | Remove DeepSeek V4 release Docker workflow | `release-docker-deepseek-v4.yml` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 12 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/gemma4/README.en.md
+++ b/model-pr-optimization-history/sglang/gemma4/README.en.md
@@ -1,5 +1,24 @@
 # sglang Gemma 4 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 9 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29266](https://github.com/sgl-project/sglang/pull/29266) | Sync Gemma4 hardware table with Blackwell recipes | `Gemma4.mdx` |
+| 2026-06-25 | [#29252](https://github.com/sgl-project/sglang/pull/29252) | Tune Gemma4 26B-A4B B200 memory recipe | `Gemma4.mdx`, `gemma4-deployment.jsx` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `gemma4-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `gemma4_audio.py`, `gemma4_causal.py`, `gemma4_vision.py` |
+| 2026-06-17 | [#27471](https://github.com/sgl-project/sglang/pull/27471) | add dflash gemma4 support | `gemma4_causal.py`, `gemma4_mm.py` |
+| 2026-06-12 | [#26147](https://github.com/sgl-project/sglang/pull/26147) | [NPU] Add Gemma4 Sliding Window Attention support on Ascend backend | `gemma4_causal.py`, `gemma4_mm.py` |
+| 2026-06-09 | [#26320](https://github.com/sgl-project/sglang/pull/26320) | fix(gemma4): register image/video/audio token_regex for HF-expanded prompts | `gemma4.py` |
+| 2026-06-06 | [#26588](https://github.com/sgl-project/sglang/pull/26588) | Optimize Gemma4 H200 MoE and extend attention | `gemma4_fused_ops.py` |
+| 2026-06-05 | [#27396](https://github.com/sgl-project/sglang/pull/27396) | Cookbook for QAT | `Gemma4.mdx`, `gemma4-deployment.jsx` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 12 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/gemma4/README.zh.md
+++ b/model-pr-optimization-history/sglang/gemma4/README.zh.md
@@ -1,5 +1,24 @@
 # sglang Gemma 4 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 9 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29266](https://github.com/sgl-project/sglang/pull/29266) | Sync Gemma4 hardware table with Blackwell recipes | `Gemma4.mdx` |
+| 2026-06-25 | [#29252](https://github.com/sgl-project/sglang/pull/29252) | Tune Gemma4 26B-A4B B200 memory recipe | `Gemma4.mdx`, `gemma4-deployment.jsx` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `gemma4-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `gemma4_audio.py`, `gemma4_causal.py`, `gemma4_vision.py` |
+| 2026-06-17 | [#27471](https://github.com/sgl-project/sglang/pull/27471) | add dflash gemma4 support | `gemma4_causal.py`, `gemma4_mm.py` |
+| 2026-06-12 | [#26147](https://github.com/sgl-project/sglang/pull/26147) | [NPU] Add Gemma4 Sliding Window Attention support on Ascend backend | `gemma4_causal.py`, `gemma4_mm.py` |
+| 2026-06-09 | [#26320](https://github.com/sgl-project/sglang/pull/26320) | fix(gemma4): register image/video/audio token_regex for HF-expanded prompts | `gemma4.py` |
+| 2026-06-06 | [#26588](https://github.com/sgl-project/sglang/pull/26588) | Optimize Gemma4 H200 MoE and extend attention | `gemma4_fused_ops.py` |
+| 2026-06-05 | [#27396](https://github.com/sgl-project/sglang/pull/27396) | Cookbook for QAT | `Gemma4.mdx`, `gemma4-deployment.jsx` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 12 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/glm-vlm-ocr/README.en.md
+++ b/model-pr-optimization-history/sglang/glm-vlm-ocr/README.en.md
@@ -1,5 +1,16 @@
 # sglang GLM VLM/OCR Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 1 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `glm4v.py`, `glm4v_moe.py`, `glm_ocr_nextn.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 1 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-28). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/glm-vlm-ocr/README.zh.md
+++ b/model-pr-optimization-history/sglang/glm-vlm-ocr/README.zh.md
@@ -1,5 +1,16 @@
 # sglang GLM VLM/OCR 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 1 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `glm4v.py`, `glm4v_moe.py`, `glm_ocr_nextn.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-04-28）以来，共有 1 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/glm45/README.en.md
+++ b/model-pr-optimization-history/sglang/glm45/README.en.md
@@ -1,5 +1,19 @@
 # sglang GLM-4.5 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 4 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28516](https://github.com/sgl-project/sglang/pull/28516) | [NPU] Add MTP support for GLM-4.7-Flash | `glm4_moe_lite.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `glm4_moe.py`, `glm4_moe_lite.py`, `glm4_moe_nextn.py` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `GLM-4.5.mdx` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `glm4_moe.py`, `glm4_moe_lite.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 9 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-28). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/glm45/README.zh.md
+++ b/model-pr-optimization-history/sglang/glm45/README.zh.md
@@ -1,5 +1,19 @@
 # sglang GLM-4.5 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 4 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28516](https://github.com/sgl-project/sglang/pull/28516) | [NPU] Add MTP support for GLM-4.7-Flash | `glm4_moe_lite.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `glm4_moe.py`, `glm4_moe_lite.py`, `glm4_moe_nextn.py` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `GLM-4.5.mdx` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `glm4_moe.py`, `glm4_moe_lite.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-04-28）以来，共有 9 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/glm46-glm47/README.en.md
+++ b/model-pr-optimization-history/sglang/glm46-glm47/README.en.md
@@ -1,5 +1,21 @@
 # sglang GLM-4.6/4.7 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 6 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29261](https://github.com/sgl-project/sglang/pull/29261) | [Docs] Fix broken links in cookbook | `GLM-4.7.mdx` |
+| 2026-06-18 | [#28516](https://github.com/sgl-project/sglang/pull/28516) | [NPU] Add MTP support for GLM-4.7-Flash | `glm4_moe_lite.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `glm4_moe.py`, `glm4_moe_lite.py`, `glm4_moe_nextn.py` |
+| 2026-06-14 | [#28149](https://github.com/sgl-project/sglang/pull/28149) | Support GLM-4.7 function calling via structural tags | `glm47_moe_detector.py` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `GLM-4.6.mdx`, `GLM-4.7-Flash.mdx`, `GLM-4.7.mdx` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `glm4_moe.py`, `glm4_moe_lite.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 15 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-22). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/glm46-glm47/README.zh.md
+++ b/model-pr-optimization-history/sglang/glm46-glm47/README.zh.md
@@ -1,5 +1,21 @@
 # sglang GLM-4.6/4.7 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 6 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29261](https://github.com/sgl-project/sglang/pull/29261) | [Docs] Fix broken links in cookbook | `GLM-4.7.mdx` |
+| 2026-06-18 | [#28516](https://github.com/sgl-project/sglang/pull/28516) | [NPU] Add MTP support for GLM-4.7-Flash | `glm4_moe_lite.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `glm4_moe.py`, `glm4_moe_lite.py`, `glm4_moe_nextn.py` |
+| 2026-06-14 | [#28149](https://github.com/sgl-project/sglang/pull/28149) | Support GLM-4.7 function calling via structural tags | `glm47_moe_detector.py` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `GLM-4.6.mdx`, `GLM-4.7-Flash.mdx`, `GLM-4.7.mdx` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `glm4_moe.py`, `glm4_moe_lite.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-04-22）以来，共有 15 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/glm5-glm51/README.en.md
+++ b/model-pr-optimization-history/sglang/glm5-glm51/README.en.md
@@ -1,5 +1,24 @@
 # sglang GLM-5/5.1 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 9 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-26 | [#29313](https://github.com/sgl-project/sglang/pull/29313) | [AMD] [GLM5] Mark EAGLE verified on MI300X/MI325X (gfx942) in GLM-5.1 cookbook | `GLM-5.1.mdx`, `glm-51-deployment.jsx` |
+| 2026-06-25 | [#29194](https://github.com/sgl-project/sglang/pull/29194) | [AMD] [GLM5] GLM-5.1 MXFP4 (MI355X) + enable EAGLE for gfx950 in cookbook | `GLM-5.1.mdx`, `glm-51-deployment.jsx` |
+| 2026-06-25 | [#28103](https://github.com/sgl-project/sglang/pull/28103) | Add DeepSeek V4 Pro GB300 nightly and expand Kimi K25 nightly test | `test_glm5_fp8.py`, `test_glm5_nvfp4.py` |
+| 2026-06-22 | [#27893](https://github.com/sgl-project/sglang/pull/27893) | [NPU] [DOC] Create deployment tutorials for mainstream models on Ascend NPU | `ascend_npu_glm5_examples.mdx` |
+| 2026-06-19 | [#28536](https://github.com/sgl-project/sglang/pull/28536) | ci: run GB300 nightly suite in the standard Nvidia nightly workflow | `test_glm5_fp8.py`, `test_glm5_nvfp4.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `glm-5-deployment.jsx` |
+| 2026-06-16 | [#28437](https://github.com/sgl-project/sglang/pull/28437) | docs(cookbook): add GLM-5.2 deployment cookbook | `GLM-5.1.mdx` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `ascend_npu_glm5_examples.mdx`, `test_glm5_fp8.py`, `test_glm5_nvfp4.py` |
+| 2026-06-10 | [#27708](https://github.com/sgl-project/sglang/pull/27708) | [Docs] Add GLM-5.1 NVFP4 to cookbook | `GLM-5.1.mdx`, `glm-51-deployment.jsx` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 6 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/glm5-glm51/README.zh.md
+++ b/model-pr-optimization-history/sglang/glm5-glm51/README.zh.md
@@ -1,5 +1,24 @@
 # sglang GLM-5/5.1 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 9 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-26 | [#29313](https://github.com/sgl-project/sglang/pull/29313) | [AMD] [GLM5] Mark EAGLE verified on MI300X/MI325X (gfx942) in GLM-5.1 cookbook | `GLM-5.1.mdx`, `glm-51-deployment.jsx` |
+| 2026-06-25 | [#29194](https://github.com/sgl-project/sglang/pull/29194) | [AMD] [GLM5] GLM-5.1 MXFP4 (MI355X) + enable EAGLE for gfx950 in cookbook | `GLM-5.1.mdx`, `glm-51-deployment.jsx` |
+| 2026-06-25 | [#28103](https://github.com/sgl-project/sglang/pull/28103) | Add DeepSeek V4 Pro GB300 nightly and expand Kimi K25 nightly test | `test_glm5_fp8.py`, `test_glm5_nvfp4.py` |
+| 2026-06-22 | [#27893](https://github.com/sgl-project/sglang/pull/27893) | [NPU] [DOC] Create deployment tutorials for mainstream models on Ascend NPU | `ascend_npu_glm5_examples.mdx` |
+| 2026-06-19 | [#28536](https://github.com/sgl-project/sglang/pull/28536) | ci: run GB300 nightly suite in the standard Nvidia nightly workflow | `test_glm5_fp8.py`, `test_glm5_nvfp4.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `glm-5-deployment.jsx` |
+| 2026-06-16 | [#28437](https://github.com/sgl-project/sglang/pull/28437) | docs(cookbook): add GLM-5.2 deployment cookbook | `GLM-5.1.mdx` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `ascend_npu_glm5_examples.mdx`, `test_glm5_fp8.py`, `test_glm5_nvfp4.py` |
+| 2026-06-10 | [#27708](https://github.com/sgl-project/sglang/pull/27708) | [Docs] Add GLM-5.1 NVFP4 to cookbook | `GLM-5.1.mdx`, `glm-51-deployment.jsx` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 6 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/gpt-oss/README.en.md
+++ b/model-pr-optimization-history/sglang/gpt-oss/README.en.md
@@ -1,5 +1,23 @@
 # sglang GPT-OSS Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 8 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `gpt-oss-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `gpt_oss.py` |
+| 2026-06-12 | [#27941](https://github.com/sgl-project/sglang/pull/27941) | Enable PDL for GPT-OSS tinygemm router | `gpt_oss.py` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `GPT-OSS.mdx` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `gpt_oss.py` |
+| 2026-06-08 | [#27528](https://github.com/sgl-project/sglang/pull/27528) | Fix GPT-OSS MXFP4 hidden size reshape on SM10X | `gpt_oss.py` |
+| 2026-06-08 | [#27063](https://github.com/sgl-project/sglang/pull/27063) | [AMD] Optimize gpt-oss-120B performance | `gpt_oss.py` |
+| 2026-06-06 | [#27201](https://github.com/sgl-project/sglang/pull/27201) | [AMD][WA] force to use gate_mode interleaved to fix tp2/tp4/tp8 acc issue | `test_gpt_oss_eval_mi35x.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 7 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/gpt-oss/README.zh.md
+++ b/model-pr-optimization-history/sglang/gpt-oss/README.zh.md
@@ -1,5 +1,23 @@
 # sglang GPT-OSS 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 8 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `gpt-oss-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `gpt_oss.py` |
+| 2026-06-12 | [#27941](https://github.com/sgl-project/sglang/pull/27941) | Enable PDL for GPT-OSS tinygemm router | `gpt_oss.py` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `GPT-OSS.mdx` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `gpt_oss.py` |
+| 2026-06-08 | [#27528](https://github.com/sgl-project/sglang/pull/27528) | Fix GPT-OSS MXFP4 hidden size reshape on SM10X | `gpt_oss.py` |
+| 2026-06-08 | [#27063](https://github.com/sgl-project/sglang/pull/27063) | [AMD] Optimize gpt-oss-120B performance | `gpt_oss.py` |
+| 2026-06-06 | [#27201](https://github.com/sgl-project/sglang/pull/27201) | [AMD][WA] force to use gate_mode interleaved to fix tp2/tp4/tp8 acc issue | `test_gpt_oss_eval_mi35x.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 7 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/intern-s1/README.en.md
+++ b/model-pr-optimization-history/sglang/intern-s1/README.en.md
@@ -1,5 +1,18 @@
 # sglang Intern-S1 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 3 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `Intern-S1.mdx` |
+| 2026-06-18 | [#28629](https://github.com/sgl-project/sglang/pull/28629) | [Bugfix] Fix Intern-S1 FP8 expert count lookup | `interns1.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `interns1pro.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 3 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-02-04). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/intern-s1/README.zh.md
+++ b/model-pr-optimization-history/sglang/intern-s1/README.zh.md
@@ -1,5 +1,18 @@
 # sglang Intern-S1 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 3 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `Intern-S1.mdx` |
+| 2026-06-18 | [#28629](https://github.com/sgl-project/sglang/pull/28629) | [Bugfix] Fix Intern-S1 FP8 expert count lookup | `interns1.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `interns1pro.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-02-04）以来，共有 3 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/internvl35/README.en.md
+++ b/model-pr-optimization-history/sglang/internvl35/README.en.md
@@ -1,5 +1,16 @@
 # sglang InternVL 3.5 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 1 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `internvl.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 9 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-03-15). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/internvl35/README.zh.md
+++ b/model-pr-optimization-history/sglang/internvl35/README.zh.md
@@ -1,5 +1,16 @@
 # sglang InternVL 3.5 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 1 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `internvl.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-03-15）以来，共有 9 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/kimi/README.en.md
+++ b/model-pr-optimization-history/sglang/kimi/README.en.md
@@ -1,5 +1,26 @@
 # sglang Kimi K2/K2.5/Linear/VL Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 11 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#28103](https://github.com/sgl-project/sglang/pull/28103) | Add DeepSeek V4 Pro GB300 nightly and expand Kimi K25 nightly test | `test_kimi_k25.py`, `test_kimi_k25_nvfp4.py` |
+| 2026-06-24 | [#28623](https://github.com/sgl-project/sglang/pull/28623) | [CI] reduce CPU CI scope with base-c suite | `test_kimik2_detector.py` |
+| 2026-06-24 | [#25071](https://github.com/sgl-project/sglang/pull/25071) | kimik2_detector fix the normal text detection before tool call. | `kimik2_detector.py`, `test_kimik2_detector.py` |
+| 2026-06-22 | [#28647](https://github.com/sgl-project/sglang/pull/28647) | Fix Kimi-VL GPU image preprocessing crash on non-RGB images | `kimi_k25.py` |
+| 2026-06-19 | [#28536](https://github.com/sgl-project/sglang/pull/28536) | ci: run GB300 nightly suite in the standard Nvidia nightly workflow | `test_kimi_k25.py`, `test_kimi_k25_nvfp4.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `kimi-k2-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `kimi_linear.py` |
+| 2026-06-18 | [#28201](https://github.com/sgl-project/sglang/pull/28201) | [Docs] Add fp8 kv cache for tokenspeed mla docs | `kimi-k25-deployment.jsx`, `kimi-k26-deployment.jsx` |
+| 2026-06-12 | [#28064](https://github.com/sgl-project/sglang/pull/28064) | [Docs] Add Kimi K2.7 Code cookbook | `Kimi-K2.6.mdx` |
+| 2026-06-10 | [#27714](https://github.com/sgl-project/sglang/pull/27714) | [Docs] Add Kimi-K2.6 NVFP4 and update Kimi-K2.5 cookbook guidance | `Kimi-K2.5.mdx`, `Kimi-K2.6.mdx`, `kimi-k25-deployment.jsx`, `kimi-k26-deployment.jsx` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `kimi_linear.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 14 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/kimi/README.zh.md
+++ b/model-pr-optimization-history/sglang/kimi/README.zh.md
@@ -1,5 +1,26 @@
 # sglang Kimi K2/K2.5/Linear/VL 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 11 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#28103](https://github.com/sgl-project/sglang/pull/28103) | Add DeepSeek V4 Pro GB300 nightly and expand Kimi K25 nightly test | `test_kimi_k25.py`, `test_kimi_k25_nvfp4.py` |
+| 2026-06-24 | [#28623](https://github.com/sgl-project/sglang/pull/28623) | [CI] reduce CPU CI scope with base-c suite | `test_kimik2_detector.py` |
+| 2026-06-24 | [#25071](https://github.com/sgl-project/sglang/pull/25071) | kimik2_detector fix the normal text detection before tool call. | `kimik2_detector.py`, `test_kimik2_detector.py` |
+| 2026-06-22 | [#28647](https://github.com/sgl-project/sglang/pull/28647) | Fix Kimi-VL GPU image preprocessing crash on non-RGB images | `kimi_k25.py` |
+| 2026-06-19 | [#28536](https://github.com/sgl-project/sglang/pull/28536) | ci: run GB300 nightly suite in the standard Nvidia nightly workflow | `test_kimi_k25.py`, `test_kimi_k25_nvfp4.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `kimi-k2-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `kimi_linear.py` |
+| 2026-06-18 | [#28201](https://github.com/sgl-project/sglang/pull/28201) | [Docs] Add fp8 kv cache for tokenspeed mla docs | `kimi-k25-deployment.jsx`, `kimi-k26-deployment.jsx` |
+| 2026-06-12 | [#28064](https://github.com/sgl-project/sglang/pull/28064) | [Docs] Add Kimi K2.7 Code cookbook | `Kimi-K2.6.mdx` |
+| 2026-06-10 | [#27714](https://github.com/sgl-project/sglang/pull/27714) | [Docs] Add Kimi-K2.6 NVFP4 and update Kimi-K2.5 cookbook guidance | `Kimi-K2.5.mdx`, `Kimi-K2.6.mdx`, `kimi-k25-deployment.jsx`, `kimi-k26-deployment.jsx` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `kimi_linear.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 14 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/ling25/README.en.md
+++ b/model-pr-optimization-history/sglang/ling25/README.en.md
@@ -1,5 +1,17 @@
 # sglang Ling 2.5 1T Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 2 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `bailing_moe.py`, `bailing_moe_linear.py`, `bailing_moe_nextn.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `bailing_moe.py`, `bailing_moe_linear.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 5 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/ling25/README.zh.md
+++ b/model-pr-optimization-history/sglang/ling25/README.zh.md
@@ -1,5 +1,17 @@
 # sglang Ling 2.5 1T 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 2 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `bailing_moe.py`, `bailing_moe_linear.py`, `bailing_moe_nextn.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `bailing_moe.py`, `bailing_moe_linear.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 5 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/llada21/README.en.md
+++ b/model-pr-optimization-history/sglang/llada21/README.en.md
@@ -1,5 +1,19 @@
 # sglang LLaDA 2.1 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 4 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29042](https://github.com/sgl-project/sglang/pull/29042) | [NPU] Fix the DeepSeek-V2-Coder model accuracy issue | `llada2.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `llada-21-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `llada2.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `llada2.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; no new PR-numbered merge touched the tracked implementation files between 2026-05-19 and 2026-06-05. The coverage above is current.

--- a/model-pr-optimization-history/sglang/llada21/README.zh.md
+++ b/model-pr-optimization-history/sglang/llada21/README.zh.md
@@ -1,5 +1,19 @@
 # sglang LLaDA 2.1 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 4 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29042](https://github.com/sgl-project/sglang/pull/29042) | [NPU] Fix the DeepSeek-V2-Coder model accuracy issue | `llada2.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `llada-21-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `llada2.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `llada2.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，没有新的带 PR 编号的合并改动到所跟踪的实现文件，上方覆盖信息保持最新。

--- a/model-pr-optimization-history/sglang/llama31/README.en.md
+++ b/model-pr-optimization-history/sglang/llama31/README.en.md
@@ -1,5 +1,16 @@
 # sglang Llama 3.1 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 1 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-09 | [#27342](https://github.com/sgl-project/sglang/pull/27342) | test: fix gemma GSM8K thresholds in nightly text eval | `test_text_models_gsm8k_eval.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; no new PR-numbered merge touched the tracked implementation files between 2026-05-19 and 2026-06-05. The coverage above is current.

--- a/model-pr-optimization-history/sglang/llama31/README.zh.md
+++ b/model-pr-optimization-history/sglang/llama31/README.zh.md
@@ -1,5 +1,16 @@
 # sglang Llama 3.1 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 1 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-09 | [#27342](https://github.com/sgl-project/sglang/pull/27342) | test: fix gemma GSM8K thresholds in nightly text eval | `test_text_models_gsm8k_eval.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，没有新的带 PR 编号的合并改动到所跟踪的实现文件，上方覆盖信息保持最新。

--- a/model-pr-optimization-history/sglang/llama4/README.en.md
+++ b/model-pr-optimization-history/sglang/llama4/README.en.md
@@ -1,5 +1,16 @@
 # sglang Llama 4 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 1 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `llama4.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 3 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/llama4/README.zh.md
+++ b/model-pr-optimization-history/sglang/llama4/README.zh.md
@@ -1,5 +1,16 @@
 # sglang Llama 4 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 1 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `llama4.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 3 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/mimo-v2-flash/README.en.md
+++ b/model-pr-optimization-history/sglang/mimo-v2-flash/README.en.md
@@ -1,5 +1,22 @@
 # sglang MiMo V2 Flash Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 7 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29253](https://github.com/sgl-project/sglang/pull/29253) | Add MiMo V2.5 Blackwell vision FA4 recipe | `MiMo-V2.5.mdx`, `mimo-v25-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `mimo_mtp.py`, `mimo_v2.py`, `mimo_v2_nextn.py` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `MiMo-V2.5.mdx` |
+| 2026-06-11 | [#26278](https://github.com/sgl-project/sglang/pull/26278) | Support MiMo v2 ASR | `mimo_audio.py`, `mimo_v2.py` |
+| 2026-06-10 | [#27668](https://github.com/sgl-project/sglang/pull/27668) | Fix MiMo-V2.5-Pro DP-attention dp size in cookbook deployment snippet | `mimo-v25-deployment.jsx` |
+| 2026-06-10 | [#25455](https://github.com/sgl-project/sglang/pull/25455) | [NPU] MiMo-V2-Flash Adaptation | `mimo_v2.py` |
+| 2026-06-08 | [#27512](https://github.com/sgl-project/sglang/pull/27512) | [Spec] Clamp multimodal pad sentinels in spec-v2 draft prefill embedding | `mimo_v2_nextn.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 5 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/mimo-v2-flash/README.zh.md
+++ b/model-pr-optimization-history/sglang/mimo-v2-flash/README.zh.md
@@ -1,5 +1,22 @@
 # sglang MiMo V2 Flash 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 7 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29253](https://github.com/sgl-project/sglang/pull/29253) | Add MiMo V2.5 Blackwell vision FA4 recipe | `MiMo-V2.5.mdx`, `mimo-v25-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `mimo_mtp.py`, `mimo_v2.py`, `mimo_v2_nextn.py` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `MiMo-V2.5.mdx` |
+| 2026-06-11 | [#26278](https://github.com/sgl-project/sglang/pull/26278) | Support MiMo v2 ASR | `mimo_audio.py`, `mimo_v2.py` |
+| 2026-06-10 | [#27668](https://github.com/sgl-project/sglang/pull/27668) | Fix MiMo-V2.5-Pro DP-attention dp size in cookbook deployment snippet | `mimo-v25-deployment.jsx` |
+| 2026-06-10 | [#25455](https://github.com/sgl-project/sglang/pull/25455) | [NPU] MiMo-V2-Flash Adaptation | `mimo_v2.py` |
+| 2026-06-08 | [#27512](https://github.com/sgl-project/sglang/pull/27512) | [Spec] Clamp multimodal pad sentinels in spec-v2 draft prefill embedding | `mimo_v2_nextn.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 5 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/minimax/README.en.md
+++ b/model-pr-optimization-history/sglang/minimax/README.en.md
@@ -1,5 +1,21 @@
 # sglang MiniMax M2 Series Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 6 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `minimax-m27-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `minimax_m2.py` |
+| 2026-06-12 | [#28060](https://github.com/sgl-project/sglang/pull/28060) | docs | `MiniMax-M2.7.mdx` |
+| 2026-06-11 | [#24465](https://github.com/sgl-project/sglang/pull/24465) | [NVIDIA] Update Minimax-M2.5,M2.7 docs with flags for performance | `minimax-m25-deployment.jsx`, `minimax-m27-deployment.jsx` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `minimax_m2.py` |
+| 2026-06-06 | [#27248](https://github.com/sgl-project/sglang/pull/27248) | [Doc][CPU]Update Cookbook with Xeon support info | `MiniMax-M2.7.mdx`, `minimax-m27-deployment.jsx` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 10 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-30). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/minimax/README.zh.md
+++ b/model-pr-optimization-history/sglang/minimax/README.zh.md
@@ -1,5 +1,21 @@
 # sglang MiniMax M2 Series 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 6 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `minimax-m27-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `minimax_m2.py` |
+| 2026-06-12 | [#28060](https://github.com/sgl-project/sglang/pull/28060) | docs | `MiniMax-M2.7.mdx` |
+| 2026-06-11 | [#24465](https://github.com/sgl-project/sglang/pull/24465) | [NVIDIA] Update Minimax-M2.5,M2.7 docs with flags for performance | `minimax-m25-deployment.jsx`, `minimax-m27-deployment.jsx` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `minimax_m2.py` |
+| 2026-06-06 | [#27248](https://github.com/sgl-project/sglang/pull/27248) | [Doc][CPU]Update Cookbook with Xeon support info | `MiniMax-M2.7.mdx`, `minimax-m27-deployment.jsx` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-04-30）以来，共有 10 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/mistral-small-4/README.en.md
+++ b/model-pr-optimization-history/sglang/mistral-small-4/README.en.md
@@ -1,5 +1,17 @@
 # sglang Mistral Small 4 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 2 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29111](https://github.com/sgl-project/sglang/pull/29111) | [Bugfix] Fix Ministral3 init argument forwarding | `ministral3.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `mistral-small-4-deployment.jsx` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 3 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/mistral-small-4/README.zh.md
+++ b/model-pr-optimization-history/sglang/mistral-small-4/README.zh.md
@@ -1,5 +1,17 @@
 # sglang Mistral Small 4 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 2 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29111](https://github.com/sgl-project/sglang/pull/29111) | [Bugfix] Fix Ministral3 init argument forwarding | `ministral3.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `mistral-small-4-deployment.jsx` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 3 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/mixtral-quark-int4fp8-moe/README.en.md
+++ b/model-pr-optimization-history/sglang/mixtral-quark-int4fp8-moe/README.en.md
@@ -1,5 +1,20 @@
 # sglang Mixtral Quark INT4/FP8 MoE Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 5 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `quark_int4fp8_moe.py`, `mixtral.py`, `mixtral_quant.py` |
+| 2026-06-14 | [#28213](https://github.com/sgl-project/sglang/pull/28213) | Revert "[AMD][Quantization] Online MXFP4 quantization 2/N - FP8 to MXFP4 requantization on AMD GPUs" | `quark.py`, `quark_w4a4_mxfp4.py`, `quark_w4a4_mxfp4_moe.py`, `utils.py` |
+| 2026-06-13 | [#18182](https://github.com/sgl-project/sglang/pull/18182) | [AMD][Quantization] Online MXFP4 quantization 2/N - FP8 to MXFP4 requantization on AMD GPUs | `quark.py`, `quark_w4a4_mxfp4.py`, `quark_w4a4_mxfp4_moe.py`, `utils.py` |
+| 2026-06-13 | [#27057](https://github.com/sgl-project/sglang/pull/27057) | [AMD] move shared expert check function to quark | `quark.py` |
+| 2026-06-07 | [#22299](https://github.com/sgl-project/sglang/pull/22299) | [AMD] Enable Piecewise CUDA Graph for AMD GPUs | `quark_w4a4_mxfp4.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 5 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-01). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/mixtral-quark-int4fp8-moe/README.zh.md
+++ b/model-pr-optimization-history/sglang/mixtral-quark-int4fp8-moe/README.zh.md
@@ -1,5 +1,20 @@
 # sglang Mixtral Quark INT4/FP8 MoE 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 5 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `quark_int4fp8_moe.py`, `mixtral.py`, `mixtral_quant.py` |
+| 2026-06-14 | [#28213](https://github.com/sgl-project/sglang/pull/28213) | Revert "[AMD][Quantization] Online MXFP4 quantization 2/N - FP8 to MXFP4 requantization on AMD GPUs" | `quark.py`, `quark_w4a4_mxfp4.py`, `quark_w4a4_mxfp4_moe.py`, `utils.py` |
+| 2026-06-13 | [#18182](https://github.com/sgl-project/sglang/pull/18182) | [AMD][Quantization] Online MXFP4 quantization 2/N - FP8 to MXFP4 requantization on AMD GPUs | `quark.py`, `quark_w4a4_mxfp4.py`, `quark_w4a4_mxfp4_moe.py`, `utils.py` |
+| 2026-06-13 | [#27057](https://github.com/sgl-project/sglang/pull/27057) | [AMD] move shared expert check function to quark | `quark.py` |
+| 2026-06-07 | [#22299](https://github.com/sgl-project/sglang/pull/22299) | [AMD] Enable Piecewise CUDA Graph for AMD GPUs | `quark_w4a4_mxfp4.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-01）以来，共有 5 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/nemotron-super/README.en.md
+++ b/model-pr-optimization-history/sglang/nemotron-super/README.en.md
@@ -1,5 +1,24 @@
 # sglang Nemotron Super Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 9 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29261](https://github.com/sgl-project/sglang/pull/29261) | [Docs] Fix broken links in cookbook | `Nemotron3-Nano-Omni.mdx` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `nemotron3-nano-deployment.jsx`, `nemotron3-super-deployment.jsx` |
+| 2026-06-19 | [#28346](https://github.com/sgl-project/sglang/pull/28346) | Use Flashinfer allreduce fusion for MNNVL allreduce for Nemotron | `nemotron_h.py`, `nemotron_h_mtp.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `nemotron_h.py`, `nemotron_h_mtp.py` |
+| 2026-06-13 | [#28102](https://github.com/sgl-project/sglang/pull/28102) | Fix DP attention + EP mode of Nemotron | `nemotron_h.py` |
+| 2026-06-12 | [#24955](https://github.com/sgl-project/sglang/pull/24955) | Support Nemotron DP attention and MTP | `nemotron_h.py`, `nemotron_h_mtp.py` |
+| 2026-06-10 | [#27838](https://github.com/sgl-project/sglang/pull/27838) | Disable async assert in Nemotron nightly tests | `test_nvidia_nemotron_3_super_nvfp4.py`, `test_nvidia_nemotron_3_super_nightly.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `nemotron_h.py` |
+| 2026-06-06 | [#26733](https://github.com/sgl-project/sglang/pull/26733) | Nemotron perf changes | `nemotron_h.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 20 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-30). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/nemotron-super/README.zh.md
+++ b/model-pr-optimization-history/sglang/nemotron-super/README.zh.md
@@ -1,5 +1,24 @@
 # sglang Nemotron Super 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 9 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29261](https://github.com/sgl-project/sglang/pull/29261) | [Docs] Fix broken links in cookbook | `Nemotron3-Nano-Omni.mdx` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `nemotron3-nano-deployment.jsx`, `nemotron3-super-deployment.jsx` |
+| 2026-06-19 | [#28346](https://github.com/sgl-project/sglang/pull/28346) | Use Flashinfer allreduce fusion for MNNVL allreduce for Nemotron | `nemotron_h.py`, `nemotron_h_mtp.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `nemotron_h.py`, `nemotron_h_mtp.py` |
+| 2026-06-13 | [#28102](https://github.com/sgl-project/sglang/pull/28102) | Fix DP attention + EP mode of Nemotron | `nemotron_h.py` |
+| 2026-06-12 | [#24955](https://github.com/sgl-project/sglang/pull/24955) | Support Nemotron DP attention and MTP | `nemotron_h.py`, `nemotron_h_mtp.py` |
+| 2026-06-10 | [#27838](https://github.com/sgl-project/sglang/pull/27838) | Disable async assert in Nemotron nightly tests | `test_nvidia_nemotron_3_super_nvfp4.py`, `test_nvidia_nemotron_3_super_nightly.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `nemotron_h.py` |
+| 2026-06-06 | [#26733](https://github.com/sgl-project/sglang/pull/26733) | Nemotron perf changes | `nemotron_h.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-04-30）以来，共有 20 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/qwen-vlm-omni-asr/README.en.md
+++ b/model-pr-optimization-history/sglang/qwen-vlm-omni-asr/README.en.md
@@ -1,5 +1,18 @@
 # sglang Qwen VLM/Omni/ASR Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 3 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29261](https://github.com/sgl-project/sglang/pull/29261) | [Docs] Fix broken links in cookbook | `Nemotron3-Nano-Omni.mdx` |
+| 2026-06-24 | [#28940](https://github.com/sgl-project/sglang/pull/28940) | [VLM] Qwen3-VL / Moss-VL ViT preprocessing optimizations | `qwen3_vl.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `qwen2_5_vl.py`, `qwen3_omni_moe.py`, `qwen3_vl.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 19 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-28). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/qwen-vlm-omni-asr/README.zh.md
+++ b/model-pr-optimization-history/sglang/qwen-vlm-omni-asr/README.zh.md
@@ -1,5 +1,18 @@
 # sglang Qwen VLM/Omni/ASR 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 3 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29261](https://github.com/sgl-project/sglang/pull/29261) | [Docs] Fix broken links in cookbook | `Nemotron3-Nano-Omni.mdx` |
+| 2026-06-24 | [#28940](https://github.com/sgl-project/sglang/pull/28940) | [VLM] Qwen3-VL / Moss-VL ViT preprocessing optimizations | `qwen3_vl.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `qwen2_5_vl.py`, `qwen3_omni_moe.py`, `qwen3_vl.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-04-28）以来，共有 19 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/qwen3-coder/README.en.md
+++ b/model-pr-optimization-history/sglang/qwen3-coder/README.en.md
@@ -1,5 +1,20 @@
 # sglang Qwen3 Coder Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 5 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-20 | [#28810](https://github.com/sgl-project/sglang/pull/28810) | [CI] Remove deprecated test/srt legacy CI setup | `test_qwen3.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `qwen3-coder-next-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `qwen3.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `qwen3.py` |
+| 2026-06-06 | [#27248](https://github.com/sgl-project/sglang/pull/27248) | [Doc][CPU]Update Cookbook with Xeon support info | `Qwen3-Coder-Next.mdx`, `Qwen3-Coder.mdx`, `qwen3-coder-deployment.jsx`, `qwen3-coder-next-deployment.jsx` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 16 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-01). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/qwen3-coder/README.zh.md
+++ b/model-pr-optimization-history/sglang/qwen3-coder/README.zh.md
@@ -1,5 +1,20 @@
 # sglang Qwen3 Coder 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 5 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-20 | [#28810](https://github.com/sgl-project/sglang/pull/28810) | [CI] Remove deprecated test/srt legacy CI setup | `test_qwen3.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `qwen3-coder-next-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `qwen3.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `qwen3.py` |
+| 2026-06-06 | [#27248](https://github.com/sgl-project/sglang/pull/27248) | [Doc][CPU]Update Cookbook with Xeon support info | `Qwen3-Coder-Next.mdx`, `Qwen3-Coder.mdx`, `qwen3-coder-deployment.jsx`, `qwen3-coder-next-deployment.jsx` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-04-01）以来，共有 16 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/qwen3-core/README.en.md
+++ b/model-pr-optimization-history/sglang/qwen3-core/README.en.md
@@ -1,5 +1,20 @@
 # sglang Qwen3 Core Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 5 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-20 | [#28810](https://github.com/sgl-project/sglang/pull/28810) | [CI] Remove deprecated test/srt legacy CI setup | `test_qwen3.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `qwen3-deployment.jsx` |
+| 2026-06-18 | [#28421](https://github.com/sgl-project/sglang/pull/28421) | [3/N][CP] Implement zigzag CP strategy | `qwen3_moe.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `qwen3.py`, `qwen3_moe.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `qwen3.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 9 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-29). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/qwen3-core/README.zh.md
+++ b/model-pr-optimization-history/sglang/qwen3-core/README.zh.md
@@ -1,5 +1,20 @@
 # sglang Qwen3 Core 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 5 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-20 | [#28810](https://github.com/sgl-project/sglang/pull/28810) | [CI] Remove deprecated test/srt legacy CI setup | `test_qwen3.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `qwen3-deployment.jsx` |
+| 2026-06-18 | [#28421](https://github.com/sgl-project/sglang/pull/28421) | [3/N][CP] Implement zigzag CP strategy | `qwen3_moe.py` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `qwen3.py`, `qwen3_moe.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `qwen3.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-04-29）以来，共有 9 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/qwen3-next/README.en.md
+++ b/model-pr-optimization-history/sglang/qwen3-next/README.en.md
@@ -1,5 +1,21 @@
 # sglang Qwen3 Next Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 6 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `qwen3_next.py`, `qwen3_next_mtp.py` |
+| 2026-06-12 | [#23862](https://github.com/sgl-project/sglang/pull/23862) | Fix --mem-fraction-static not accounting for EAGLE draft model KV cache | `qwen3_next_mtp.py` |
+| 2026-06-11 | [#27630](https://github.com/sgl-project/sglang/pull/27630) | [AMD] Fuse sigmoid + mul attention output gate into single Triton kernel | `qwen3_next.py` |
+| 2026-06-11 | [#26204](https://github.com/sgl-project/sglang/pull/26204) | Optimize Qwen3 Next FP8 MoE on H200 | `qwen3_next.py`, `qwen3_next_mtp.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `qwen3_next.py` |
+| 2026-06-08 | [#24689](https://github.com/sgl-project/sglang/pull/24689) | [NPU] Add GitHub test summary and deduplicate test code. Part 2 | `test_npu_deepep_auto_qwen3_next.py`, `test_npu_deepep_low_latency_qwen3_next.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 7 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/qwen3-next/README.zh.md
+++ b/model-pr-optimization-history/sglang/qwen3-next/README.zh.md
@@ -1,5 +1,21 @@
 # sglang Qwen3 Next 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 6 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `qwen3_next.py`, `qwen3_next_mtp.py` |
+| 2026-06-12 | [#23862](https://github.com/sgl-project/sglang/pull/23862) | Fix --mem-fraction-static not accounting for EAGLE draft model KV cache | `qwen3_next_mtp.py` |
+| 2026-06-11 | [#27630](https://github.com/sgl-project/sglang/pull/27630) | [AMD] Fuse sigmoid + mul attention output gate into single Triton kernel | `qwen3_next.py` |
+| 2026-06-11 | [#26204](https://github.com/sgl-project/sglang/pull/26204) | Optimize Qwen3 Next FP8 MoE on H200 | `qwen3_next.py`, `qwen3_next_mtp.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `qwen3_next.py` |
+| 2026-06-08 | [#24689](https://github.com/sgl-project/sglang/pull/24689) | [NPU] Add GitHub test summary and deduplicate test code. Part 2 | `test_npu_deepep_auto_qwen3_next.py`, `test_npu_deepep_low_latency_qwen3_next.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 7 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/qwen35/README.en.md
+++ b/model-pr-optimization-history/sglang/qwen35/README.en.md
@@ -1,5 +1,36 @@
 # sglang Qwen3.5 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 21 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29267](https://github.com/sgl-project/sglang/pull/29267) | [CPU] add indices in chunk_gated_delta_rule | `qwen3_5.py` |
+| 2026-06-25 | [#28320](https://github.com/sgl-project/sglang/pull/28320) | Fused QK GemmaRMSNorm + RoPE + gate kernel for Qwen3.5 | `qwen3_5.py` |
+| 2026-06-25 | [#28103](https://github.com/sgl-project/sglang/pull/28103) | Add DeepSeek V4 Pro GB300 nightly and expand Kimi K25 nightly test | `test_qwen35_fp8.py`, `test_qwen35_nvfp4.py` |
+| 2026-06-24 | [#27870](https://github.com/sgl-project/sglang/pull/27870) | [qwen3.5][XPU]Add XPU support for set_embed_and_head and fused QK RMSNorm kernel | `qwen3_5.py` |
+| 2026-06-22 | [#27893](https://github.com/sgl-project/sglang/pull/27893) | [NPU] [DOC] Create deployment tutorials for mainstream models on Ascend NPU | `ascend_npu_qwen3_5_examples.mdx` |
+| 2026-06-19 | [#28536](https://github.com/sgl-project/sglang/pull/28536) | ci: run GB300 nightly suite in the standard Nvidia nightly workflow | `test_qwen35_fp8.py`, `test_qwen35_nvfp4.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `qwen35-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `qwen3_5.py`, `qwen3_5_mtp.py` |
+| 2026-06-16 | [#28293](https://github.com/sgl-project/sglang/pull/28293) | [NPU] Add NPU fallback for fused Triton gating kernels | `qwen3_5.py` |
+| 2026-06-15 | [#27868](https://github.com/sgl-project/sglang/pull/27868) | fix(qwen3.5): keep CUDA dual-stream overlap (regressed by #25885) | `qwen3_5.py` |
+| 2026-06-13 | [#28129](https://github.com/sgl-project/sglang/pull/28129) | [Spec] Remove deprecated EAGLE v1 DRAFT_EXTEND forward mode | `qwen3_5_mtp.py` |
+| 2026-06-13 | [#26924](https://github.com/sgl-project/sglang/pull/26924) | [4/N] Qwen3.5Opt: Overlap mamba verify update with draft extend | `qwen3_5.py` |
+| 2026-06-13 | [#27057](https://github.com/sgl-project/sglang/pull/27057) | [AMD] move shared expert check function to quark | `qwen3_5.py` |
+| 2026-06-12 | [#23862](https://github.com/sgl-project/sglang/pull/23862) | Fix --mem-fraction-static not accounting for EAGLE draft model KV cache | `qwen3_5_mtp.py` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `ascend_npu_qwen3_5_examples.mdx`, `test_qwen35_fp8.py`, `test_qwen35_nvfp4.py` |
+| 2026-06-11 | [#27846](https://github.com/sgl-project/sglang/pull/27846) | fix: per-sequence last-token embedding in EAGLE3/MTP draft for batched multimodal spec decoding | `qwen3_5_mtp.py` |
+| 2026-06-11 | [#27630](https://github.com/sgl-project/sglang/pull/27630) | [AMD] Fuse sigmoid + mul attention output gate into single Triton kernel | `qwen3_5.py` |
+| 2026-06-10 | [#27656](https://github.com/sgl-project/sglang/pull/27656) | [AMD][Perf] Fuse QK RMSNorm + gate extraction Triton kernel for Qwen3.5 on HIP | `qwen3_5.py` |
+| 2026-06-09 | [#27660](https://github.com/sgl-project/sglang/pull/27660) | [AMD] Update amd qwen3.5 cookbook | `Qwen3.5.mdx`, `qwen35-deployment.jsx` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `qwen3_5.py` |
+| 2026-06-06 | [#27248](https://github.com/sgl-project/sglang/pull/27248) | [Doc][CPU]Update Cookbook with Xeon support info | `Qwen3.5.mdx`, `qwen35-deployment.jsx` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 12 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/qwen35/README.zh.md
+++ b/model-pr-optimization-history/sglang/qwen35/README.zh.md
@@ -1,5 +1,36 @@
 # sglang Qwen3.5 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 21 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#29267](https://github.com/sgl-project/sglang/pull/29267) | [CPU] add indices in chunk_gated_delta_rule | `qwen3_5.py` |
+| 2026-06-25 | [#28320](https://github.com/sgl-project/sglang/pull/28320) | Fused QK GemmaRMSNorm + RoPE + gate kernel for Qwen3.5 | `qwen3_5.py` |
+| 2026-06-25 | [#28103](https://github.com/sgl-project/sglang/pull/28103) | Add DeepSeek V4 Pro GB300 nightly and expand Kimi K25 nightly test | `test_qwen35_fp8.py`, `test_qwen35_nvfp4.py` |
+| 2026-06-24 | [#27870](https://github.com/sgl-project/sglang/pull/27870) | [qwen3.5][XPU]Add XPU support for set_embed_and_head and fused QK RMSNorm kernel | `qwen3_5.py` |
+| 2026-06-22 | [#27893](https://github.com/sgl-project/sglang/pull/27893) | [NPU] [DOC] Create deployment tutorials for mainstream models on Ascend NPU | `ascend_npu_qwen3_5_examples.mdx` |
+| 2026-06-19 | [#28536](https://github.com/sgl-project/sglang/pull/28536) | ci: run GB300 nightly suite in the standard Nvidia nightly workflow | `test_qwen35_fp8.py`, `test_qwen35_nvfp4.py` |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `qwen35-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `qwen3_5.py`, `qwen3_5_mtp.py` |
+| 2026-06-16 | [#28293](https://github.com/sgl-project/sglang/pull/28293) | [NPU] Add NPU fallback for fused Triton gating kernels | `qwen3_5.py` |
+| 2026-06-15 | [#27868](https://github.com/sgl-project/sglang/pull/27868) | fix(qwen3.5): keep CUDA dual-stream overlap (regressed by #25885) | `qwen3_5.py` |
+| 2026-06-13 | [#28129](https://github.com/sgl-project/sglang/pull/28129) | [Spec] Remove deprecated EAGLE v1 DRAFT_EXTEND forward mode | `qwen3_5_mtp.py` |
+| 2026-06-13 | [#26924](https://github.com/sgl-project/sglang/pull/26924) | [4/N] Qwen3.5Opt: Overlap mamba verify update with draft extend | `qwen3_5.py` |
+| 2026-06-13 | [#27057](https://github.com/sgl-project/sglang/pull/27057) | [AMD] move shared expert check function to quark | `qwen3_5.py` |
+| 2026-06-12 | [#23862](https://github.com/sgl-project/sglang/pull/23862) | Fix --mem-fraction-static not accounting for EAGLE draft model KV cache | `qwen3_5_mtp.py` |
+| 2026-06-11 | [#27964](https://github.com/sgl-project/sglang/pull/27964) | [Spec] Retire Spec V1 | `ascend_npu_qwen3_5_examples.mdx`, `test_qwen35_fp8.py`, `test_qwen35_nvfp4.py` |
+| 2026-06-11 | [#27846](https://github.com/sgl-project/sglang/pull/27846) | fix: per-sequence last-token embedding in EAGLE3/MTP draft for batched multimodal spec decoding | `qwen3_5_mtp.py` |
+| 2026-06-11 | [#27630](https://github.com/sgl-project/sglang/pull/27630) | [AMD] Fuse sigmoid + mul attention output gate into single Triton kernel | `qwen3_5.py` |
+| 2026-06-10 | [#27656](https://github.com/sgl-project/sglang/pull/27656) | [AMD][Perf] Fuse QK RMSNorm + gate extraction Triton kernel for Qwen3.5 on HIP | `qwen3_5.py` |
+| 2026-06-09 | [#27660](https://github.com/sgl-project/sglang/pull/27660) | [AMD] Update amd qwen3.5 cookbook | `Qwen3.5.mdx`, `qwen35-deployment.jsx` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `qwen3_5.py` |
+| 2026-06-06 | [#27248](https://github.com/sgl-project/sglang/pull/27248) | [Doc][CPU]Update Cookbook with Xeon support info | `Qwen3.5.mdx`, `qwen35-deployment.jsx` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 12 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/ring25/README.en.md
+++ b/model-pr-optimization-history/sglang/ring25/README.en.md
@@ -1,5 +1,18 @@
 # sglang Ring 2.5 1T Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 3 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `ring-25-1t-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `bailing_moe.py`, `bailing_moe_linear.py`, `bailing_moe_nextn.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `bailing_moe.py`, `bailing_moe_linear.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 5 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/ring25/README.zh.md
+++ b/model-pr-optimization-history/sglang/ring25/README.zh.md
@@ -1,5 +1,18 @@
 # sglang Ring 2.5 1T 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 3 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-19 | [#28697](https://github.com/sgl-project/sglang/pull/28697) | [docs] Add B300 cookbook deployment options | `ring-25-1t-deployment.jsx` |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `bailing_moe.py`, `bailing_moe_linear.py`, `bailing_moe_nextn.py` |
+| 2026-06-10 | [#23906](https://github.com/sgl-project/sglang/pull/23906) | [Refactor] Cuda Graph Runner/Backend Refactor | `bailing_moe.py`, `bailing_moe_linear.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-05-19）以来，共有 5 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/sglang/step35/README.en.md
+++ b/model-pr-optimization-history/sglang/step35/README.en.md
@@ -1,5 +1,16 @@
 # sglang Step 3.5 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked SGLang upstream `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 1 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `step3p5.py`, `step3p5_mtp.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked sglang upstream `origin/main@6cfdc1858` on 2026-06-05; 6 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-29). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/sglang/step35/README.zh.md
+++ b/model-pr-optimization-history/sglang/step35/README.zh.md
@@ -1,5 +1,16 @@
 # sglang Step 3.5 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 SGLang 上游 `sgl-project/sglang@8524678889485801e7a4a12d62015be0c68f7a90` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 1 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#28567](https://github.com/sgl-project/sglang/pull/28567) | Add get_parallel(): a structured accessor for parallel-topology state | `step3p5.py`, `step3p5_mtp.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 sglang 上游 `origin/main@6cfdc1858` 复核；自上次时效基准（2026-04-29）以来，共有 6 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/tensorrt_llm/README.md
+++ b/model-pr-optimization-history/tensorrt_llm/README.md
@@ -1,0 +1,22 @@
+# TensorRT-LLM Model PR Optimization History
+
+Current model families:
+
+- `kimi`
+- `qwen35`
+
+## Current Watch / Landed Items
+
+Refresh: `2026-06-26`. Source head:
+`NVIDIA/TensorRT-LLM@4164b932c6c8a14d1be85d0fd62e44b7d0171980`.
+
+| PR | Model / area | Status | Current signal | Why it matters |
+| --- | --- | --- | --- | --- |
+| [#15543](https://github.com/NVIDIA/TensorRT-LLM/pull/15543) | Qwen3.5 | merged | EPLB support | Changes Qwen3.5 MoE load-balancing behavior and benchmark fairness knobs. |
+| [#15185](https://github.com/NVIDIA/TensorRT-LLM/pull/15185) | Qwen3.5 AutoDeploy | merged | sharding and lm_head sharding | Affects AutoDeploy/PyTorch backend memory and parallelism comparisons. |
+| [#15067](https://github.com/NVIDIA/TensorRT-LLM/pull/15067) | Qwen3.5 | merged | FP8 checkpoint loading | Relevant when comparing dense/MoE Qwen3.5 checkpoints across frameworks. |
+| [#15233](https://github.com/NVIDIA/TensorRT-LLM/pull/15233) | Kimi K2.5 | merged | rejection-sampling embedding mask | Affects speculative decoding / guided decoding comparisons. |
+| [#15180](https://github.com/NVIDIA/TensorRT-LLM/pull/15180) | Kimi K2.5 | merged | guided decoding methods | Relevant when Kimi agentic/tool traces use guided decoding. |
+| [#12788](https://github.com/NVIDIA/TensorRT-LLM/pull/12788) | Kimi K2.5 VLM | merged | multimodal vision support | Establishes TensorRT-LLM Kimi-K2.5 multimodal path and tests. |
+
+Read the per-model files for timelines and diff audit cards.

--- a/model-pr-optimization-history/tensorrt_llm/README.md
+++ b/model-pr-optimization-history/tensorrt_llm/README.md
@@ -8,10 +8,12 @@ Current model families:
 ## Current Watch / Landed Items
 
 Refresh: `2026-06-26`. Source head:
-`NVIDIA/TensorRT-LLM@4164b932c6c8a14d1be85d0fd62e44b7d0171980`.
+`NVIDIA/TensorRT-LLM@0722c5f47d2cae69ac1a237da51e550dd214532c`.
 
 | PR | Model / area | Status | Current signal | Why it matters |
 | --- | --- | --- | --- | --- |
+| [#11685](https://github.com/NVIDIA/TensorRT-LLM/pull/11685) | KV cache runtime | merged | evict empty blocks first | Affects cache pressure and request residency under serving load; stale TensorRT-LLM images can mislead long-context or prefix-heavy rows. |
+| [#15546](https://github.com/NVIDIA/TensorRT-LLM/pull/15546) | PyTorch executor KV cache | merged | fresh host buffer for KV block offsets | Affects race/overlap risk around KV block offset staging in benchmark and profiler traces. |
 | [#15543](https://github.com/NVIDIA/TensorRT-LLM/pull/15543) | Qwen3.5 | merged | EPLB support | Changes Qwen3.5 MoE load-balancing behavior and benchmark fairness knobs. |
 | [#15185](https://github.com/NVIDIA/TensorRT-LLM/pull/15185) | Qwen3.5 AutoDeploy | merged | sharding and lm_head sharding | Affects AutoDeploy/PyTorch backend memory and parallelism comparisons. |
 | [#15067](https://github.com/NVIDIA/TensorRT-LLM/pull/15067) | Qwen3.5 | merged | FP8 checkpoint loading | Relevant when comparing dense/MoE Qwen3.5 checkpoints across frameworks. |

--- a/model-pr-optimization-history/tensorrt_llm/kimi/README.en.md
+++ b/model-pr-optimization-history/tensorrt_llm/kimi/README.en.md
@@ -2,7 +2,12 @@
 
 ## 2026-06-26 PR Backfill Audit
 
-Checked against TensorRT-LLM upstream `HEAD@4164b932c6c8a14d1be85d0fd62e44b7d0171980`. This page provides model implementation coverage, a timeline, and per-PR diff audit cards for Kimi K2 Thinking / Kimi K2.5.
+The per-PR diff audit cards on this page were generated from TensorRT-LLM
+upstream `HEAD@4164b932c6c8a14d1be85d0fd62e44b7d0171980`. The root
+TensorRT-LLM history index tracks the latest 2026-06-26 runtime refresh at
+`0722c5f47d2cae69ac1a237da51e550dd214532c`. This page provides model
+implementation coverage, a timeline, and per-PR diff audit cards for Kimi K2
+Thinking / Kimi K2.5.
 
 Filter used in this pass: merged PRs whose titles or files matched `Kimi`, `kimi_k25`, `KimiK25`, `K2.5`, `K2 Thinking`, `NVFP4`, `multimodal`, `tool_parser`, `reasoning_parser`, `guided decoding`, `spec dec`, `rejection sampling`, or `NIXL`. Formatting-only and unrelated infrastructure PRs were excluded.
 

--- a/model-pr-optimization-history/tensorrt_llm/kimi/README.en.md
+++ b/model-pr-optimization-history/tensorrt_llm/kimi/README.en.md
@@ -1,0 +1,221 @@
+# TensorRT-LLM Kimi Model PR Optimization History
+
+## 2026-06-26 PR Backfill Audit
+
+Checked against TensorRT-LLM upstream `HEAD@4164b932c6c8a14d1be85d0fd62e44b7d0171980`. This page provides model implementation coverage, a timeline, and per-PR diff audit cards for Kimi K2 Thinking / Kimi K2.5.
+
+Filter used in this pass: merged PRs whose titles or files matched `Kimi`, `kimi_k25`, `KimiK25`, `K2.5`, `K2 Thinking`, `NVFP4`, `multimodal`, `tool_parser`, `reasoning_parser`, `guided decoding`, `spec dec`, `rejection sampling`, or `NIXL`. Formatting-only and unrelated infrastructure PRs were excluded.
+
+## Model Implementation File Coverage
+
+| File | Related PRs |
+| --- | --- |
+| `docs/source/deployment-guide/deployment-guide-for-kimi-k2-thinking-on-trtllm.md` | [#9711](https://github.com/NVIDIA/TensorRT-LLM/pull/9711) |
+| `tensorrt_llm/serve/tool_parser/kimi_k2_tool_parser.py` | [#9830](https://github.com/NVIDIA/TensorRT-LLM/pull/9830) |
+| `tensorrt_llm/_torch/models/modeling_deepseekv3.py` | [#11777](https://github.com/NVIDIA/TensorRT-LLM/pull/11777), [#12788](https://github.com/NVIDIA/TensorRT-LLM/pull/12788) |
+| `tensorrt_llm/_torch/auto_deploy/models/custom/modeling_kimi_k2.py` | [#11780](https://github.com/NVIDIA/TensorRT-LLM/pull/11780) |
+| `examples/auto_deploy/model_registry/configs/kimi_k2.yaml` | [#11780](https://github.com/NVIDIA/TensorRT-LLM/pull/11780) |
+| `tensorrt_llm/_torch/models/modeling_kimi_k25.py` | [#12788](https://github.com/NVIDIA/TensorRT-LLM/pull/12788), [#14379](https://github.com/NVIDIA/TensorRT-LLM/pull/14379), [#15180](https://github.com/NVIDIA/TensorRT-LLM/pull/15180) |
+| `tensorrt_llm/llmapi/reasoning_parser.py` | [#13801](https://github.com/NVIDIA/TensorRT-LLM/pull/13801) |
+| `tensorrt_llm/_torch/modules/embedding.py` | [#15233](https://github.com/NVIDIA/TensorRT-LLM/pull/15233) |
+| `tests/unittest/_torch/modeling/test_modeling_kimi_k25.py` | [#12788](https://github.com/NVIDIA/TensorRT-LLM/pull/12788) |
+| `tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_*.yaml` | [#15443](https://github.com/NVIDIA/TensorRT-LLM/pull/15443) |
+
+## PR Coverage Overview
+
+- Reviewed PRs: 10
+- Diff source: `gh pr diff` / GitHub PR patches cached under `/tmp/model_pr_diffs/tensorrt_llm/pr*.diff`
+- Reviewed patch lines: 8,414
+- Main TensorRT-LLM Kimi themes: Blackwell/GB200 deployment guide, OpenAI tool parser, K2.5 text NVFP4, AutoDeploy Kimi K2.5, multimodal vision/video path, reasoning parser, speculative/guided decoding, rejection-sampling embedding mask, and NIXL disaggregated perf lanes.
+
+## Timeline
+
+| Date | PR | State | Title | Main files |
+| --- | --- | --- | --- | --- |
+| 2025-12-05 | [#9711](https://github.com/NVIDIA/TensorRT-LLM/pull/9711) | merged | Deployment Guide for Kimi K2 Thinking on TensorRT LLM - Blackwell | deployment guide |
+| 2025-12-12 | [#9830](https://github.com/NVIDIA/TensorRT-LLM/pull/9830) | merged | Support tool parser for Kimi K2 | OpenAI server/tool parser |
+| 2026-03-04 | [#11777](https://github.com/NVIDIA/TensorRT-LLM/pull/11777) | merged | Add Kimi-K2.5 text model support (NVFP4) | `modeling_deepseekv3.py`, accuracy tests |
+| 2026-03-05 | [#11780](https://github.com/NVIDIA/TensorRT-LLM/pull/11780) | merged | AutoDeploy onboarding agent + Kimi K2.5 AD modeling code | AutoDeploy Kimi model/config/tests |
+| 2026-05-11 | [#13801](https://github.com/NVIDIA/TensorRT-LLM/pull/13801) | merged | Add reasoning parser for kimi-k2.5 and enable auto flow | command/reasoning parser |
+| 2026-05-14 | [#12788](https://github.com/NVIDIA/TensorRT-LLM/pull/12788) | merged | Add Kimi K2.5 multimodal vision support | `modeling_kimi_k25.py`, multimodal eval/tests |
+| 2026-05-22 | [#14379](https://github.com/NVIDIA/TensorRT-LLM/pull/14379) | merged | Fix Kimi_k25 with spec dec | `modeling_kimi_k25.py` |
+| 2026-06-17 | [#15233](https://github.com/NVIDIA/TensorRT-LLM/pull/15233) | merged | Fix embedding vocab mask for rejection sampling in Kimi-K2.5 | `embedding.py` |
+| 2026-06-23 | [#15443](https://github.com/NVIDIA/TensorRT-LLM/pull/15443) | merged | Un-waive K2.5 Thinking FP4 disagg-NIXL tests | waives and perf-sanity YAML |
+| 2026-06-25 | [#15180](https://github.com/NVIDIA/TensorRT-LLM/pull/15180) | merged | Add necessary methods for guided decoding in Kimi K2.5 | `modeling_kimi_k25.py` |
+
+## Per-PR Diff Audit Cards
+
+### PR #9711 - Deployment Guide for Kimi K2 Thinking on TensorRT LLM - Blackwell
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/9711
+- State/time: merged / 2025-12-05
+- Diff coverage: 1 file, +309/-0, 534 cached patch lines.
+- Motivation: provide an official Blackwell/GB200 deployment guide for Kimi K2 Thinking NVFP4.
+- Key implementation: documents Docker, `trtllm-serve`, 8-way EP/attention DP, SLURM wide EP, and disaggregated serving.
+- Code excerpt:
+
+```diff
++trtllm-serve nvidia/Kimi-K2-Thinking-NVFP4 \
++--extra_llm_api_options
+```
+
+- Reviewed files: deployment guide markdown
+- Validation/risk: record Blackwell/GB200 and disaggregation assumptions when using this as competitor evidence.
+
+### PR #9830 - Support tool parser for Kimi K2
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/9830
+- State/time: merged / 2025-12-12
+- Diff coverage: 5 files, +374/-1, 528 cached patch lines.
+- Motivation: Kimi K2 OpenAI-compatible serving needs correct tool-call parsing for agentic workloads.
+- Key implementation: adds a Kimi K2 tool parser and wires it into the OpenAI server postprocess and parser factory.
+- Code excerpt:
+
+```diff
++from .kimi_k2_tool_parser import KimiK2ToolParser
++class KimiK2ToolParser(BaseToolParser):
++        "kimi_k2": KimiK2ToolParser,
+```
+
+- Reviewed files: OpenAI server, postprocess handlers, `kimi_k2_tool_parser.py`, factory, tests
+- Validation/risk: agentic correctness includes parser behavior, not just speed.
+
+### PR #11777 - Add Kimi-K2.5 text model support (NVFP4)
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/11777
+- State/time: merged / 2026-03-04
+- Diff coverage: 2 files, +96/-0, 532 cached patch lines.
+- Motivation: support Kimi-K2.5 text NVFP4 in the PyTorch backend.
+- Key implementation: adapts the DeepSeekV3-style runtime and adds accuracy refs/tests.
+- Code excerpt:
+
+```diff
++MODEL_NAME = "moonshotai/Kimi-K2.5"
++quant_algo: NVFP4
+```
+
+- Reviewed files: `modeling_deepseekv3.py`, accuracy refs/tests
+- Validation/risk: separate text-only Kimi K2.5 from multimodal Kimi paths.
+
+### PR #11780 - AutoDeploy onboarding agent + Kimi K2.5 AD modeling code
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/11780
+- State/time: merged / 2026-03-05
+- Diff coverage: 9 files, +2190/-9, 2,807 cached patch lines.
+- Motivation: add AutoDeploy modeling code for Kimi K2.5.
+- Key implementation: adds `modeling_kimi_k2.py`, registry config, MLA custom ops, and AutoDeploy tests.
+- Code excerpt:
+
+```diff
++model_factory: KimiK2ForCausalLM
++flashinfer_mla
+```
+
+- Reviewed files: agent scaffold, `kimi_k2.yaml`, MLA ops, `modeling_kimi_k2.py`, AD tests
+- Validation/risk: competitor path may be AutoDeploy rather than the plain PyTorch wrapper.
+
+### PR #13801 - Add reasoning parser for Kimi-K2.5 and enable auto flow
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/13801
+- State/time: merged / 2026-05-11
+- Diff coverage: 2 files, +5/-1, 47 cached patch lines.
+- Motivation: auto-select the right reasoning parser for Kimi-K2.5 thinking outputs.
+- Key implementation: adds `kimi_k2/kimi_k25` auto-detect hints and registers `kimi_k25` with `reasoning_at_start=True`.
+- Code excerpt:
+
+```diff
++"kimi_k25": "kimi_k25",
++@register_reasoning_parser("kimi_k25", reasoning_at_start=True)
+```
+
+- Reviewed files: `commands/serve.py`, `reasoning_parser.py`
+- Validation/risk: parser selection affects eval scores.
+
+### PR #12788 - Add Kimi K2.5 multimodal vision support
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/12788
+- State/time: merged / 2026-05-14
+- Diff coverage: 12 files, +2912/-64, 3,536 cached patch lines.
+- Motivation: enable text/image/video Kimi K2.5 multimodal serving.
+- Key implementation: adds `KimiK25ForConditionalGeneration`, vision model, input processor, placeholders, multimodal eval, and tests.
+- Code excerpt:
+
+```diff
++@register_auto_model("KimiK25ForConditionalGeneration")
++class KimiK25ForConditionalGeneration(PreTrainedModel):
++    "video_placeholder": "<|kimi_k25_video_placeholder|>",
+```
+
+- Reviewed files: `modeling_kimi_k25.py`, `modeling_deepseekv3.py`, eval wrappers, multimodal tests
+- Validation/risk: profile vision encoder, placeholder expansion, hashing fallback, and text decode as separate stages.
+
+### PR #14379 - Fix Kimi_k25 with spec dec
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/14379
+- State/time: merged / 2026-05-22
+- Diff coverage: 1 file, +53/-35, 187 cached patch lines.
+- Motivation: speculative decoding missed Kimi K2.5 multimodal params and `lm_head` delegation.
+- Key implementation: threads `multimodal_params` through `forward` and adds an `lm_head` proxy.
+- Code excerpt:
+
+```diff
++multimodal_params: Optional[List[MultimodalParams]] = None
++def lm_head(self): return self.llm.lm_head
+```
+
+- Reviewed files: `modeling_kimi_k25.py`
+- Validation/risk: spec-dec comparisons need to verify context-only multimodal handling.
+
+### PR #15233 - Fix embedding vocab mask for rejection sampling in Kimi-K2.5
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/15233
+- State/time: merged / 2026-06-17
+- Diff coverage: 1 file, +15/-8, 129 cached patch lines.
+- Motivation: FlashInfer rejection sampling can pad rejected tokens with non-vocab values.
+- Key implementation: masks/clamps input before `F.embedding` in `pre_comm_embedding_ops`.
+- Code excerpt:
+
+```diff
++# flashinfer's rejection kernel pads non-accepted tokens
++        input_, input_mask = get_masked_input_and_mask(
++            input_,
++            0,
++            weight.shape[0],
++        )
+```
+
+- Reviewed files: `embedding.py`
+- Validation/risk: correctness risk sits in embedding preprocessing, not a visible hot kernel.
+
+### PR #15443 - Un-waive K2.5 Thinking FP4 disagg-NIXL tests
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/15443
+- State/time: merged / 2026-06-23
+- Diff coverage: 2 files, +2/-3, 86 cached patch lines.
+- Motivation: Kimi K2.5 Thinking FP4 disaggregated NIXL lanes became stable enough to un-waive.
+- Key implementation: removes Kimi NIXL skips and raises KV transfer timeout in perf-sanity YAML.
+- Code excerpt:
+
+```diff
++kv_transfer_timeout_ms: 600000
+```
+
+- Reviewed files: `waives.txt`, Kimi NIXL perf-sanity YAML
+- Validation/risk: disaggregated NIXL is a separate benchmark bucket.
+
+### PR #15180 - Add necessary methods for guided decoding in Kimi K2.5
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/15180
+- State/time: merged / 2026-06-25
+- Diff coverage: 1 file, +3/-0, 28 cached patch lines.
+- Motivation: Kimi K2.5 wrapper missed guided decoding delegation methods.
+- Key implementation: proxies `set_guided_decoder` to the inner LLM.
+- Code excerpt:
+
+```diff
++def set_guided_decoder(self, *args, **kwargs):
++    return self.llm.set_guided_decoder(*args, **kwargs)
+```
+
+- Reviewed files: `modeling_kimi_k25.py`
+- Validation/risk: guided decoding changes decode control flow; record whether it is enabled.

--- a/model-pr-optimization-history/tensorrt_llm/kimi/README.en.md
+++ b/model-pr-optimization-history/tensorrt_llm/kimi/README.en.md
@@ -1,5 +1,12 @@
 # TensorRT-LLM Kimi Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked TensorRT-LLM upstream `NVIDIA/TensorRT-LLM@0722c5f47d2cae69ac1a237da51e550dd214532c` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-26`.
+
+Result: no additional PR-numbered merges touched the tracked files beyond the existing timeline/backfill rows.
+
 ## 2026-06-26 PR Backfill Audit
 
 The per-PR diff audit cards on this page were generated from TensorRT-LLM

--- a/model-pr-optimization-history/tensorrt_llm/kimi/README.zh.md
+++ b/model-pr-optimization-history/tensorrt_llm/kimi/README.zh.md
@@ -1,5 +1,12 @@
 # TensorRT-LLM Kimi 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 TensorRT-LLM 上游 `NVIDIA/TensorRT-LLM@0722c5f47d2cae69ac1a237da51e550dd214532c` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-26`。
+
+结果：除了本文已有 timeline/backfill 行之外，没有额外 PR-numbered merge 命中 tracked files。
+
 ## 2026-06-26 PR 补漏复核
 
 本文的逐 PR diff 审计卡基于 TensorRT-LLM 上游

--- a/model-pr-optimization-history/tensorrt_llm/kimi/README.zh.md
+++ b/model-pr-optimization-history/tensorrt_llm/kimi/README.zh.md
@@ -2,7 +2,12 @@
 
 ## 2026-06-26 PR 补漏复核
 
-已按 TensorRT-LLM 上游 `HEAD@4164b932c6c8a14d1be85d0fd62e44b7d0171980` 复核。本文覆盖 Kimi K2 Thinking / Kimi K2.5 相关 merged PR，并采用 SGLang 风格的模型实现覆盖、时间线和逐 PR diff 审计卡。
+本文的逐 PR diff 审计卡基于 TensorRT-LLM 上游
+`HEAD@4164b932c6c8a14d1be85d0fd62e44b7d0171980` 生成；根目录 TensorRT-LLM
+history index 已跟踪 2026-06-26 最新 runtime refresh
+`0722c5f47d2cae69ac1a237da51e550dd214532c`。本文覆盖 Kimi K2 Thinking /
+Kimi K2.5 相关 merged PR，并采用 SGLang 风格的模型实现覆盖、时间线和逐 PR
+diff 审计卡。
 
 本轮筛选规则：标题/文件命中 `Kimi`、`kimi_k25`、`KimiK25`、`K2.5`、`K2 Thinking`、`NVFP4`、`multimodal`、`tool_parser`、`reasoning_parser`、`guided decoding`、`spec dec`、`rejection sampling`、`NIXL` 的 merged PR；过滤纯格式化和不影响 Kimi runtime/serve/eval lane 的基础设施 PR。
 

--- a/model-pr-optimization-history/tensorrt_llm/kimi/README.zh.md
+++ b/model-pr-optimization-history/tensorrt_llm/kimi/README.zh.md
@@ -1,0 +1,221 @@
+# TensorRT-LLM Kimi 模型 PR 优化历史
+
+## 2026-06-26 PR 补漏复核
+
+已按 TensorRT-LLM 上游 `HEAD@4164b932c6c8a14d1be85d0fd62e44b7d0171980` 复核。本文覆盖 Kimi K2 Thinking / Kimi K2.5 相关 merged PR，并采用 SGLang 风格的模型实现覆盖、时间线和逐 PR diff 审计卡。
+
+本轮筛选规则：标题/文件命中 `Kimi`、`kimi_k25`、`KimiK25`、`K2.5`、`K2 Thinking`、`NVFP4`、`multimodal`、`tool_parser`、`reasoning_parser`、`guided decoding`、`spec dec`、`rejection sampling`、`NIXL` 的 merged PR；过滤纯格式化和不影响 Kimi runtime/serve/eval lane 的基础设施 PR。
+
+## 模型实现文件覆盖
+
+| 文件 | 关联 PR |
+| --- | --- |
+| `docs/source/deployment-guide/deployment-guide-for-kimi-k2-thinking-on-trtllm.md` | [#9711](https://github.com/NVIDIA/TensorRT-LLM/pull/9711) |
+| `tensorrt_llm/serve/tool_parser/kimi_k2_tool_parser.py` | [#9830](https://github.com/NVIDIA/TensorRT-LLM/pull/9830) |
+| `tensorrt_llm/_torch/models/modeling_deepseekv3.py` | [#11777](https://github.com/NVIDIA/TensorRT-LLM/pull/11777), [#12788](https://github.com/NVIDIA/TensorRT-LLM/pull/12788) |
+| `tensorrt_llm/_torch/auto_deploy/models/custom/modeling_kimi_k2.py` | [#11780](https://github.com/NVIDIA/TensorRT-LLM/pull/11780) |
+| `examples/auto_deploy/model_registry/configs/kimi_k2.yaml` | [#11780](https://github.com/NVIDIA/TensorRT-LLM/pull/11780) |
+| `tensorrt_llm/_torch/models/modeling_kimi_k25.py` | [#12788](https://github.com/NVIDIA/TensorRT-LLM/pull/12788), [#14379](https://github.com/NVIDIA/TensorRT-LLM/pull/14379), [#15180](https://github.com/NVIDIA/TensorRT-LLM/pull/15180) |
+| `tensorrt_llm/llmapi/reasoning_parser.py` | [#13801](https://github.com/NVIDIA/TensorRT-LLM/pull/13801) |
+| `tensorrt_llm/_torch/modules/embedding.py` | [#15233](https://github.com/NVIDIA/TensorRT-LLM/pull/15233) |
+| `tests/unittest/_torch/modeling/test_modeling_kimi_k25.py` | [#12788](https://github.com/NVIDIA/TensorRT-LLM/pull/12788) |
+| `tests/scripts/perf-sanity/disaggregated/gb200_kimi-k25-thinking-fp4_*.yaml` | [#15443](https://github.com/NVIDIA/TensorRT-LLM/pull/15443) |
+
+## PR 覆盖总览
+
+- 本轮审计 PR 数: 10
+- diff 来源: `gh pr diff` / GitHub PR patch，本地缓存 `/tmp/model_pr_diffs/tensorrt_llm/pr*.diff`
+- 已读 patch 行数: 8,414
+- TensorRT-LLM Kimi 关键形态: Blackwell/GB200 deployment guide、OpenAI tool parser、K2.5 text NVFP4、AutoDeploy Kimi K2.5、multimodal vision/video path、reasoning parser、speculative/guided decoding、rejection sampling embedding mask、NIXL disaggregated perf lane。
+
+## 时间线
+
+| 日期 | PR | 状态 | 标题 | 主要文件 |
+| --- | --- | --- | --- | --- |
+| 2025-12-05 | [#9711](https://github.com/NVIDIA/TensorRT-LLM/pull/9711) | merged | Deployment Guide for Kimi K2 Thinking on TensorRT LLM - Blackwell | deployment guide |
+| 2025-12-12 | [#9830](https://github.com/NVIDIA/TensorRT-LLM/pull/9830) | merged | Support tool parser for Kimi K2 | OpenAI server/tool parser |
+| 2026-03-04 | [#11777](https://github.com/NVIDIA/TensorRT-LLM/pull/11777) | merged | Add Kimi-K2.5 text model support (NVFP4) | `modeling_deepseekv3.py`, accuracy tests |
+| 2026-03-05 | [#11780](https://github.com/NVIDIA/TensorRT-LLM/pull/11780) | merged | AutoDeploy onboarding agent + Kimi K2.5 AD modeling code | AutoDeploy Kimi model/config/tests |
+| 2026-05-11 | [#13801](https://github.com/NVIDIA/TensorRT-LLM/pull/13801) | merged | Add reasoning parser for kimi-k2.5 and enable auto flow | command/reasoning parser |
+| 2026-05-14 | [#12788](https://github.com/NVIDIA/TensorRT-LLM/pull/12788) | merged | Add Kimi K2.5 multimodal vision support | `modeling_kimi_k25.py`, multimodal eval/tests |
+| 2026-05-22 | [#14379](https://github.com/NVIDIA/TensorRT-LLM/pull/14379) | merged | Fix Kimi_k25 with spec dec | `modeling_kimi_k25.py` |
+| 2026-06-17 | [#15233](https://github.com/NVIDIA/TensorRT-LLM/pull/15233) | merged | Fix embedding vocab mask for rejection sampling in Kimi-K2.5 | `embedding.py` |
+| 2026-06-23 | [#15443](https://github.com/NVIDIA/TensorRT-LLM/pull/15443) | merged | Un-waive K2.5 Thinking FP4 disagg-NIXL tests | waives and perf-sanity YAML |
+| 2026-06-25 | [#15180](https://github.com/NVIDIA/TensorRT-LLM/pull/15180) | merged | Add necessary methods for guided decoding in Kimi K2.5 | `modeling_kimi_k25.py` |
+
+## 逐 PR diff 审计卡
+
+### PR #9711 - Deployment Guide for Kimi K2 Thinking on TensorRT LLM - Blackwell
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/9711
+- 状态/时间: merged / 2025-12-05
+- 代码 diff 已读范围: 1 个文件，+309/-0，本地 patch 534 行。
+- 动机: 给 Kimi K2 Thinking NVFP4 在 DGX B200 与 GB200 NVL72 上的部署提供官方路径。
+- 实现要点: 文档加入 Docker build/run、`trtllm-serve nvidia/Kimi-K2-Thinking-NVFP4`、8-way EP/attention DP、SLURM wide EP 和 disaggregated serving 示例。
+- 关键代码摘录:
+
+```diff
++trtllm-serve nvidia/Kimi-K2-Thinking-NVFP4 \
++--extra_llm_api_options
+```
+
+- 已读文件: `deployment-guide-for-kimi-k2-thinking-on-trtllm.md`
+- 验证与风险: SOTA loop 里 TensorRT-LLM Kimi lane 要标注 Blackwell/GB200 和 disagg 形态；文档命令不是 engine 后端的等价物。
+
+### PR #9830 - Support tool parser for Kimi K2
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/9830
+- 状态/时间: merged / 2025-12-12
+- 代码 diff 已读范围: 5 个文件，+374/-1，本地 patch 528 行。
+- 动机: Kimi K2 OpenAI-compatible serving 需要正确解析 tool call，否则 agentic workload 的功能/评分会偏离。
+- 实现要点: 新增 `kimi_k2_tool_parser.py`，接入 OpenAI server postprocess handler 和 parser factory，并补工具调用测试。
+- 关键代码摘录:
+
+```diff
++from .kimi_k2_tool_parser import KimiK2ToolParser
++class KimiK2ToolParser(BaseToolParser):
++        "kimi_k2": KimiK2ToolParser,
+```
+
+- 已读文件: `openai_server.py`, `postprocess_handlers.py`, `kimi_k2_tool_parser.py`, `tool_parser_factory.py`, tests
+- 验证与风险: 对 agentic benchmark，tool parser 是 correctness surface；不能只比较 tokens/s。
+
+### PR #11777 - Add Kimi-K2.5 text model support (NVFP4)
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/11777
+- 状态/时间: merged / 2026-03-04
+- 代码 diff 已读范围: 2 个文件，+96/-0，本地 patch 532 行。
+- 动机: TensorRT-LLM PyTorch backend 需要把 Kimi-K2.5 text NVFP4 接入已有 DeepSeekV3-style runtime。
+- 实现要点: 在 `modeling_deepseekv3.py` 中适配 Kimi K2.5 text model，并新增 accuracy refs/tests。
+- 关键代码摘录:
+
+```diff
++MODEL_NAME = "moonshotai/Kimi-K2.5"
++quant_algo: NVFP4
+```
+
+- 已读文件: `modeling_deepseekv3.py`, accuracy tests/refs
+- 验证与风险: Kimi K2.5 text 与 Kimi multimodal 不是同一验证面；benchmark 记录要区分 text-only 和 VLM。
+
+### PR #11780 - AutoDeploy onboarding agent + Kimi K2.5 AD modeling code
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/11780
+- 状态/时间: merged / 2026-03-05
+- 代码 diff 已读范围: 9 个文件，+2190/-9，本地 patch 2,807 行。
+- 动机: Kimi K2.5 需要 AutoDeploy modeling code，而不是仅依赖通用 PyTorch model wrapper。
+- 实现要点: 新增 `modeling_kimi_k2.py`、registry config、MLA custom ops 和 AutoDeploy tests，并加入 agent/scaffolding 文件。
+- 关键代码摘录:
+
+```diff
++model_factory: KimiK2ForCausalLM
++flashinfer_mla
+```
+
+- 已读文件: `.claude/agents`, `configs/kimi_k2.yaml`, `flashinfer_mla.py`, `torch_backend_mla.py`, `modeling_kimi_k2.py`, AD tests
+- 验证与风险: TensorRT-LLM Kimi 竞品路径可能是 AutoDeploy，而不是普通 model wrapper；SGLang loop 要记录 backend/API 入口。
+
+### PR #13801 - Add reasoning parser for Kimi-K2.5 and enable auto flow
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/13801
+- 状态/时间: merged / 2026-05-11
+- 代码 diff 已读范围: 2 个文件，+5/-1，本地 patch 47 行。
+- 动机: Kimi-K2.5 thinking output 需要自动选择正确 reasoning parser。
+- 实现要点: `commands/serve.py` 的 auto-detect hint 加入 `kimi_k2/kimi_k25`，`reasoning_parser.py` 注册 `kimi_k25` 且 `reasoning_at_start=True`。
+- 关键代码摘录:
+
+```diff
++"kimi_k25": "kimi_k25",
++@register_reasoning_parser("kimi_k25", reasoning_at_start=True)
+```
+
+- 已读文件: `commands/serve.py`, `llmapi/reasoning_parser.py`
+- 验证与风险: AIME/agentic 输出解析不同会改变分数；公平对比必须记录 reasoning parser。
+
+### PR #12788 - Add Kimi K2.5 multimodal vision support
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/12788
+- 状态/时间: merged / 2026-05-14
+- 代码 diff 已读范围: 12 个文件，+2912/-64，本地 patch 3,536 行。
+- 动机: Kimi K2.5 需要 text/image/video multimodal path，包括 vision encoder、processor、hashing fallback 和 multimodal eval。
+- 实现要点: 新增 `KimiK25ForConditionalGeneration`、`KimiK25VisionModel`、input processor、vision attention/projector 结构，接入 multimodal eval/test。
+- 关键代码摘录:
+
+```diff
++@register_auto_model("KimiK25ForConditionalGeneration")
++class KimiK25ForConditionalGeneration(PreTrainedModel):
++    "video_placeholder": "<|kimi_k25_video_placeholder|>",
+```
+
+- 已读文件: `modeling_kimi_k25.py`, `modeling_deepseekv3.py`, eval wrappers, multimodal tests, `test_modeling_kimi_k25.py`
+- 验证与风险: 多模态 Kimi 比 text-only 多了 vision encoder、placeholder expansion、hashing fallback；profile 要分 stage。
+
+### PR #14379 - Fix Kimi_k25 with spec dec
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/14379
+- 状态/时间: merged / 2026-05-22
+- 代码 diff 已读范围: 1 个文件，+53/-35，本地 patch 187 行。
+- 动机: Kimi K2.5 在 speculative decoding 下 multimodal params 和 `lm_head` 访问不完整。
+- 实现要点: `forward` 显式接收 `multimodal_params`，按 `attn_metadata.num_contexts` 切 context params，并增加 `lm_head` 代理方法。
+- 关键代码摘录:
+
+```diff
++multimodal_params: Optional[List[MultimodalParams]] = None
++def lm_head(self): return self.llm.lm_head
+```
+
+- 已读文件: `tensorrt_llm/_torch/models/modeling_kimi_k25.py`
+- 验证与风险: SGLang 对标 speculative decoding 时，要确认 multimodal context-only 路径是否正确处理。
+
+### PR #15233 - Fix embedding vocab mask for rejection sampling in Kimi-K2.5
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/15233
+- 状态/时间: merged / 2026-06-17
+- 代码 diff 已读范围: 1 个文件，+15/-8，本地 patch 129 行。
+- 动机: FlashInfer rejection kernel 会为未接受 token pad 非 vocab 值，如果 embedding mask 不 clamp，会在 Kimi-K2.5 rejection sampling 中越界。
+- 实现要点: 在 `pre_comm_embedding_ops` 中先 mask/clamp 输入，再做 `F.embedding`。
+- 关键代码摘录:
+
+```diff
++# flashinfer's rejection kernel pads non-accepted tokens
++        input_, input_mask = get_masked_input_and_mask(
++            input_,
++            0,
++            weight.shape[0],
++        )
+```
+
+- 已读文件: `tensorrt_llm/_torch/modules/embedding.py`
+- 验证与风险: speculative/rejection sampling 的 correctness 风险在 embedding 前处理，profile 表很难直接暴露。
+
+### PR #15443 - Un-waive K2.5 Thinking FP4 disagg-NIXL tests
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/15443
+- 状态/时间: merged / 2026-06-23
+- 代码 diff 已读范围: 2 个文件，+2/-3，本地 patch 86 行。
+- 动机: Kimi K2.5 Thinking FP4 disaggregated NIXL e2e/gen_only lane 已足够稳定，可以从 waive 列表移除并拉长 KV transfer timeout。
+- 实现要点: 删除 waives 中三条 Kimi NIXL skip，并在 perf-sanity YAML 设置 `kv_transfer_timeout_ms: 600000`。
+- 关键代码摘录:
+
+```diff
++kv_transfer_timeout_ms: 600000
+```
+
+- 已读文件: `waives.txt`, `gb200_kimi-k25-thinking-fp4_8k1k_con4096_ctx1_dep4_gen1_dep16_eplb0_mtp0_ccb-NIXL.yaml`
+- 验证与风险: disagg/NIXL lane 与单机 serving 完全不同；SOTA loop 要单独建 workload bucket。
+
+### PR #15180 - Add necessary methods for guided decoding in Kimi K2.5
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/15180
+- 状态/时间: merged / 2026-06-25
+- 代码 diff 已读范围: 1 个文件，+3/-0，本地 patch 28 行。
+- 动机: Kimi K2.5 wrapper 缺少 guided decoding 需要的代理方法。
+- 实现要点: 在 `KimiK25ForConditionalGeneration` 上透传 `set_guided_decoder` 到内部 LLM。
+- 关键代码摘录:
+
+```diff
++def set_guided_decoder(self, *args, **kwargs):
++    return self.llm.set_guided_decoder(*args, **kwargs)
+```
+
+- 已读文件: `tensorrt_llm/_torch/models/modeling_kimi_k25.py`
+- 验证与风险: guided decoding 会改变 decode control flow；benchmark 需要标注是否启用。

--- a/model-pr-optimization-history/tensorrt_llm/qwen35/README.en.md
+++ b/model-pr-optimization-history/tensorrt_llm/qwen35/README.en.md
@@ -1,5 +1,18 @@
 # TensorRT-LLM Qwen3.5 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked TensorRT-LLM upstream `NVIDIA/TensorRT-LLM@0722c5f47d2cae69ac1a237da51e550dd214532c` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-26`.
+
+Result: 3 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-26 | [#15481](https://github.com/NVIDIA/TensorRT-LLM/pull/15481) | [https://nvbugs/6239637][fix] Unwaive Qwen3.5 cases on A100 platform | `test_llm_api_pytorch.py` |
+| 2026-06-26 | [#15361](https://github.com/NVIDIA/TensorRT-LLM/pull/15361) | [TRTLLM-12762][test] Add Test coverage for MiniMax Model with multi-node, M2.5 checkpoints eval | `test_llm_api_pytorch.py` |
+| 2026-06-26 | [#14837](https://github.com/NVIDIA/TensorRT-LLM/pull/14837) | [TRTLLM-13712][feat] Add Qwen-Image-Bench evaluator | `qwen3_5_weight_mapper.py` |
+
 ## 2026-06-26 PR Backfill Audit
 
 The per-PR diff audit cards on this page were generated from TensorRT-LLM

--- a/model-pr-optimization-history/tensorrt_llm/qwen35/README.en.md
+++ b/model-pr-optimization-history/tensorrt_llm/qwen35/README.en.md
@@ -1,0 +1,291 @@
+# TensorRT-LLM Qwen3.5 Model PR Optimization History
+
+## 2026-06-26 PR Backfill Audit
+
+Checked against TensorRT-LLM upstream `HEAD@4164b932c6c8a14d1be85d0fd62e44b7d0171980`. This page provides model implementation coverage, a PR timeline, and per-PR diff audit cards.
+
+Filter used in this pass: merged PRs whose titles or files matched `Qwen3.5`, `Qwen3_5`, `qwen3_5`, `AutoDeploy`, `NVFP4`, `FP8`, `DFlash`, `reasoning_parser`, `EPLB`, `MoE backend`, or `model_registry`. Pure reshuffling and unrelated infrastructure PRs were excluded.
+
+## Model Implementation File Coverage
+
+| File | Related PRs |
+| --- | --- |
+| `tensorrt_llm/_torch/models/modeling_qwen3_5.py` | [#12302](https://github.com/NVIDIA/TensorRT-LLM/pull/12302), [#15067](https://github.com/NVIDIA/TensorRT-LLM/pull/15067) |
+| `tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py` | [#12302](https://github.com/NVIDIA/TensorRT-LLM/pull/12302), [#13090](https://github.com/NVIDIA/TensorRT-LLM/pull/13090), [#13716](https://github.com/NVIDIA/TensorRT-LLM/pull/13716), [#15067](https://github.com/NVIDIA/TensorRT-LLM/pull/15067) |
+| `tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py` | [#12114](https://github.com/NVIDIA/TensorRT-LLM/pull/12114), [#14667](https://github.com/NVIDIA/TensorRT-LLM/pull/14667), [#15185](https://github.com/NVIDIA/TensorRT-LLM/pull/15185) |
+| `examples/auto_deploy/model_registry/configs/qwen3.5_moe_*.yaml` | [#12114](https://github.com/NVIDIA/TensorRT-LLM/pull/12114), [#14667](https://github.com/NVIDIA/TensorRT-LLM/pull/14667), [#15185](https://github.com/NVIDIA/TensorRT-LLM/pull/15185) |
+| `examples/auto_deploy/model_registry/models.yaml` | [#12114](https://github.com/NVIDIA/TensorRT-LLM/pull/12114), [#15001](https://github.com/NVIDIA/TensorRT-LLM/pull/15001) |
+| `tensorrt_llm/_torch/auto_deploy/transform/library/mrope_delta_cache.py` | [#12114](https://github.com/NVIDIA/TensorRT-LLM/pull/12114) |
+| `tensorrt_llm/_torch/models/modeling_speculative.py` / `speculative/dflash.py` | [#13782](https://github.com/NVIDIA/TensorRT-LLM/pull/13782), [#13996](https://github.com/NVIDIA/TensorRT-LLM/pull/13996) |
+| `tensorrt_llm/llmapi/reasoning_parser.py` | [#14659](https://github.com/NVIDIA/TensorRT-LLM/pull/14659) |
+| `tensorrt_llm/_torch/modules/fused_moe/moe_load_balancer.py` | [#15543](https://github.com/NVIDIA/TensorRT-LLM/pull/15543) |
+| `tests/integration/defs/accuracy/test_llm_api_pytorch.py` | [#12302](https://github.com/NVIDIA/TensorRT-LLM/pull/12302), [#13090](https://github.com/NVIDIA/TensorRT-LLM/pull/13090), [#15081](https://github.com/NVIDIA/TensorRT-LLM/pull/15081), [#15543](https://github.com/NVIDIA/TensorRT-LLM/pull/15543) |
+
+## PR Coverage Overview
+
+- Reviewed PRs: 14
+- Diff source: `gh pr diff` / GitHub PR patches cached under `/tmp/model_pr_diffs/tensorrt_llm/pr*.diff`
+- Reviewed patch lines: 12,514
+- Main TensorRT-LLM Qwen3.5 themes: AutoDeploy cookbook/registry, mRoPE/3D positions, NVFP4/FP8 weight mapping, dense/MoE wrappers, DFlash speculative decoding, reasoning parser, CUTLASS/DeepGEMM backend selection, and EPLB.
+
+## Timeline
+
+| Date | PR | State | Title | Main files |
+| --- | --- | --- | --- | --- |
+| 2026-02-26 | [#11728](https://github.com/NVIDIA/TensorRT-LLM/pull/11728) | merged | Added Qwen3.5 Cookbook | AutoDeploy cookbook notebook |
+| 2026-03-24 | [#12302](https://github.com/NVIDIA/TensorRT-LLM/pull/12302) | merged | Add Qwen 3.5 supporting (NVFP4) | model wrapper, weight mapper, tests |
+| 2026-03-25 | [#12114](https://github.com/NVIDIA/TensorRT-LLM/pull/12114) | merged | Qwen 3.5 fix 3d position ID handling | AutoDeploy Qwen3.5 MoE, mRoPE cache, registry configs |
+| 2026-04-30 | [#13090](https://github.com/NVIDIA/TensorRT-LLM/pull/13090) | merged | Qwen3.5 dense weight loading | weight mapper, dense tests |
+| 2026-05-04 | [#13716](https://github.com/NVIDIA/TensorRT-LLM/pull/13716) | merged | Fix Qwen3.5 NVFP4 weight loading by preserving weight_scales | HF mapper |
+| 2026-05-12 | [#13782](https://github.com/NVIDIA/TensorRT-LLM/pull/13782) | merged | Qwen3.5 DFlash | speculative/DFlash runtime |
+| 2026-05-16 | [#13996](https://github.com/NVIDIA/TensorRT-LLM/pull/13996) | merged | Perf optimizations for DFlash | DFlash model engine and speculative code |
+| 2026-05-29 | [#14659](https://github.com/NVIDIA/TensorRT-LLM/pull/14659) | merged | Add a reasoning parser for qwen3_5 | `reasoning_parser.py` |
+| 2026-06-02 | [#14667](https://github.com/NVIDIA/TensorRT-LLM/pull/14667) | merged | AutoDeploy: Qwen3.5 400B NVFP4 accuracy regression fix | shared expert sharding, SwiGLU fusion |
+| 2026-06-05 | [#15001](https://github.com/NVIDIA/TensorRT-LLM/pull/15001) | merged | Uncomment Qwen3.5 from model registry | `models.yaml` |
+| 2026-06-09 | [#15081](https://github.com/NVIDIA/TensorRT-LLM/pull/15081) | merged | Select CUTLASS MoE backend on non-Blackwell SMs | accuracy test backend selection |
+| 2026-06-11 | [#15067](https://github.com/NVIDIA/TensorRT-LLM/pull/15067) | merged | Generalize FP8 checkpoint loading for Qwen3.5 | weight mapper, modeling |
+| 2026-06-13 | [#15185](https://github.com/NVIDIA/TensorRT-LLM/pull/15185) | merged | Qwen3.5 whitelist sharding and lm_head sharding | AutoDeploy sharding IR/tests |
+| 2026-06-26 | [#15543](https://github.com/NVIDIA/TensorRT-LLM/pull/15543) | merged | Add EPLB support for Qwen3.5 | MoE load balancer and B200/GB200 tests |
+
+## Per-PR Diff Audit Cards
+
+### PR #11728 - Added Qwen3.5 Cookbook
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/11728
+- State/time: merged / 2026-02-26
+- Diff coverage: 1 file, +385/-0, 402 cached patch lines.
+- Motivation: document how to deploy Qwen3.5-397B and its NVFP4 checkpoint with AutoDeploy.
+- Key implementation: adds a notebook with `trtllm-serve`, AutoDeploy registry config, B200 sizing, and sample OpenAI calls.
+- Code excerpt:
+
+```diff
++trtllm-serve "nvidia/Qwen3.5-397B-A17B-NVFP4" \
++MODEL_ID = "Qwen/Qwen3.5-397B-A17B"
+```
+
+- Reviewed files: `examples/auto_deploy/cookbooks/qwen_3.5_trtllm_cookbook.ipynb`
+- Validation/risk: use this as deployment evidence, not as proof that the PyTorch backend path is identical to SGLang.
+
+### PR #12302 - Add Qwen 3.5 supporting (NVFP4)
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/12302
+- State/time: merged / 2026-03-24
+- Diff coverage: 9 files, +225/-31, 436 cached patch lines.
+- Motivation: support Qwen3.5 dense/MoE and the official NVFP4 checkpoint in the PyTorch backend.
+- Key implementation: registers dense and MoE Qwen3.5 model wrappers, extends the HF mapper, and adds 397B NVFP4 accuracy tests.
+- Code excerpt:
+
+```diff
++@register_auto_model("Qwen3_5ForCausalLM")
++class Qwen3_5ForCausalLM(Qwen3NextForCausalLM):
+```
+
+- Reviewed files: `modeling_qwen3_5.py`, `qwen3_5_weight_mapper.py`, `config_utils.py`, accuracy refs/tests
+- Validation/risk: separate dense and MoE wrapper behavior in comparisons.
+
+### PR #12114 - Qwen 3.5 fix 3D position ID handling
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/12114
+- State/time: merged / 2026-03-25
+- Diff coverage: 15 files, +3448/-275, 7,822 cached patch lines.
+- Motivation: Qwen3.5 VLM/mRoPE needed 3D positions, chunked multimodal positions, video grid normalization, and mRoPE delta cache.
+- Key implementation: extends AutoDeploy Qwen3.5 MoE modeling, mRoPE cache transforms, registry configs, and unit tests.
+- Code excerpt:
+
+```diff
++@TransformRegistry.register("initialize_mrope_delta_cache")
++mm_token_positions: torch.Tensor
+```
+
+- Reviewed files: `modeling_qwen3_5_moe.py`, `mrope_delta_cache.py`, registry YAMLs, `test_qwen3_5_moe.py`, serving utils tests
+- Validation/risk: multimodal correctness depends on position construction and cache resources, not only decode kernels.
+
+### PR #13090 - Qwen3.5 dense weight loading
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/13090
+- State/time: merged / 2026-04-30
+- Diff coverage: 5 files, +85/-1, 225 cached patch lines.
+- Motivation: dense Qwen3.5 4B/FP8 loading needed direct coverage.
+- Key implementation: updates the Qwen3.5 HF mapper and adds dense accuracy refs/tests.
+- Code excerpt:
+
+```diff
++class TestQwen3_5_4B(LlmapiAccuracyTestHarness):
++MODEL_NAME = "Qwen/Qwen3.5-4B"
+```
+
+- Reviewed files: HF mapper, accuracy refs, `test_llm_api_pytorch.py`, test lists
+- Validation/risk: dense Qwen3.5 has different loading risks from 397B MoE.
+
+### PR #13716 - Preserve Qwen3.5 NVFP4 weight_scales
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/13716
+- State/time: merged / 2026-05-04
+- Diff coverage: 1 file, +9/-3, 45 cached patch lines.
+- Motivation: FP8 scale remapping broke NVFP4 weight scale loading.
+- Key implementation: detects NVFP4 prefixes and preserves `weight_scales`.
+- Code excerpt:
+
+```diff
++        nvfp4_prefixes = {
++            key[: -len(".weight_scale_2")] for key in weights if key.endswith(".weight_scale_2")
++        }
++                if prefix not in nvfp4_prefixes:
+```
+
+- Reviewed files: `qwen3_5_weight_mapper.py`
+- Validation/risk: scale key remapping is a first check for NVFP4 loading or accuracy issues.
+
+### PR #13782 - Qwen3.5 DFlash
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/13782
+- State/time: merged / 2026-05-12
+- Diff coverage: 5 files, +144/-55, 413 cached patch lines.
+- Motivation: enable Qwen3.5 hybrid linear-attention models on DFlash/speculative paths.
+- Key implementation: wires GDN/Mamba cache and model engine paths into DFlash runtime.
+- Code excerpt:
+
+```diff
++from tensorrt_llm._torch.speculative import dflash
++mamba_cache_manager
+```
+
+- Reviewed files: `gdn_mixer.py`, `pyexecutor/_util.py`, `mamba_cache_manager.py`, `model_engine.py`, `speculative/dflash.py`
+- Validation/risk: keep DFlash separate from plain decoding and SGLang MTP comparisons.
+
+### PR #13996 - Perf optimizations for DFlash
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/13996
+- State/time: merged / 2026-05-16
+- Diff coverage: 5 files, +455/-285, 1,606 cached patch lines.
+- Motivation: reduce DFlash overhead after the initial Qwen3.5 support.
+- Key implementation: changes speculative modeling, GDN mixer, model engine, DFlash runtime, and `llm_args.py`.
+- Code excerpt:
+
+```diff
++    def _build_fused_kv_buffers(self) -> None:
++        """Stack per-layer KV projection + k_norm weights for a single fused GEMM.
++        return self.max_draft_len + 1
+```
+
+- Reviewed files: `modeling_speculative.py`, `gdn_mixer.py`, `model_engine.py`, `speculative/dflash.py`, `llm_args.py`
+- Validation/risk: if TensorRT-LLM leads through DFlash, attribute the gap to speculative runtime rather than one kernel.
+
+### PR #14659 - Add a reasoning parser for qwen3_5
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/14659
+- State/time: merged / 2026-05-29
+- Diff coverage: 1 file, +9/-0, 30 cached patch lines.
+- Motivation: Qwen3.5 forced-thinking output begins inside the reasoning block.
+- Key implementation: registers `qwen3_5` with `reasoning_at_start=True`.
+- Code excerpt:
+
+```diff
++@register_reasoning_parser("qwen3_5", reasoning_at_start=True)
+```
+
+- Reviewed files: `llmapi/reasoning_parser.py`
+- Validation/risk: output parsing can change benchmark scores independently of runtime speed.
+
+### PR #14667 - AutoDeploy Qwen3.5 400B NVFP4 accuracy regression fix
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/14667
+- State/time: merged / 2026-06-02
+- Diff coverage: 5 files, +72/-35, 464 cached patch lines.
+- Motivation: fix a Qwen3.5 400B NVFP4 AutoDeploy accuracy regression.
+- Key implementation: replicates the shared expert instead of TP-sharding it and expands SwiGLU fusion/sharding hints.
+- Code excerpt:
+
+```diff
++# The shared expert is replicated
++apply_sharding_hints:
+```
+
+- Reviewed files: `qwen3.5_moe_400b.yaml`, `modeling_qwen3_5_moe.py`, `swiglu.py`, `fuse_swiglu.py`, waives
+- Validation/risk: inspect shared expert sharding and SwiGLU fusion before blaming MoE GEMMs.
+
+### PR #15001 - Uncomment Qwen3.5 from model registry
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/15001
+- State/time: merged / 2026-06-05
+- Diff coverage: 1 file, +9/-12, 50 cached patch lines.
+- Motivation: make Qwen3.5 AutoDeploy entries discoverable by default.
+- Key implementation: enables Qwen3.5 35B and 397B entries in `models.yaml`.
+- Code excerpt:
+
+```diff
++- name: Qwen/Qwen3.5-397B-A17B
++  config_id: qwen3_5_moe_400b
+```
+
+- Reviewed files: `examples/auto_deploy/model_registry/models.yaml`
+- Validation/risk: registry entries are official deployment lanes for fair comparison.
+
+### PR #15081 - Select CUTLASS MoE backend on non-Blackwell SMs
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/15081
+- State/time: merged / 2026-06-09
+- Diff coverage: 2 files, +8/-2, 52 cached patch lines.
+- Motivation: DeepGEMM should be used on Blackwell, while non-Blackwell tests need CUTLASS.
+- Key implementation: picks the MoE backend by SM version in Qwen3.5 FP8 tests.
+- Code excerpt:
+
+```diff
++moe_backend = "DEEPGEMM" if get_sm_version() in (100, 103) else "CUTLASS"
+```
+
+- Reviewed files: `test_llm_api_pytorch.py`, `waives.txt`
+- Validation/risk: never mix H100 and B200 MoE backend results without recording backend choice.
+
+### PR #15067 - Generalize FP8 checkpoint loading for Qwen3.5
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/15067
+- State/time: merged / 2026-06-11
+- Diff coverage: 2 files, +68/-48, 220 cached patch lines.
+- Motivation: make FP8 checkpoint loading handle Qwen3.5 naming and exclude-module variants.
+- Key implementation: refactors mapper/modeling normalization around FP8/NVFP4.
+- Code excerpt:
+
+```diff
++    # gdn_mixer uses Linear module for weight management of depthwise conv1d
++    # but conv1d is not a proper linear module and should be excluded from quant
++    normalized.add("*linear_attn.conv1d")
+```
+
+- Reviewed files: `qwen3_5_weight_mapper.py`, `modeling_qwen3_5.py`
+- Validation/risk: check mapper normalization before kernel-level debugging for FP8 loading issues.
+
+### PR #15185 - Qwen3.5 whitelist sharding and lm_head sharding
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/15185
+- State/time: merged / 2026-06-13
+- Diff coverage: 5 files, +193/-118, 735 cached patch lines.
+- Motivation: AutoDeploy needed whitelist sharding and `lm_head` sharding for Qwen3.5.
+- Key implementation: updates registry configs, model sharding hints, SwiGLU fusion, and sharding IR tests.
+- Code excerpt:
+
+```diff
++lm_head:
++apply_sharding_hints
+```
+
+- Reviewed files: registry YAML, `modeling_qwen3_5_moe.py`, `fuse_swiglu.py`, `sharding_ir.py`, tests
+- Validation/risk: inspect `lm_head` and shared-expert sharding separately from expert GEMMs.
+
+### PR #15543 - Add EPLB support for Qwen3.5
+
+- Link: https://github.com/NVIDIA/TensorRT-LLM/pull/15543
+- State/time: merged / 2026-06-26
+- Diff coverage: 3 files, +73/-0, 130 cached patch lines.
+- Motivation: add EPLB coverage for Qwen3.5 MoE on B200/GB200 test lanes.
+- Key implementation: extends the MoE load balancer and test DB entries.
+- Code excerpt:
+
+```diff
++    'Qwen2MoeForCausalLM',
++    'Qwen3MoeForCausalLM',
++    'Qwen3_5MoeForCausalLM',
+```
+
+- Reviewed files: `moe_load_balancer.py`, `test_llm_api_pytorch.py`, B200/GB200 test DB YAMLs
+- Validation/risk: record whether load balancing is enabled when comparing SGLang EP/EPLB behavior.

--- a/model-pr-optimization-history/tensorrt_llm/qwen35/README.en.md
+++ b/model-pr-optimization-history/tensorrt_llm/qwen35/README.en.md
@@ -2,7 +2,11 @@
 
 ## 2026-06-26 PR Backfill Audit
 
-Checked against TensorRT-LLM upstream `HEAD@4164b932c6c8a14d1be85d0fd62e44b7d0171980`. This page provides model implementation coverage, a PR timeline, and per-PR diff audit cards.
+The per-PR diff audit cards on this page were generated from TensorRT-LLM
+upstream `HEAD@4164b932c6c8a14d1be85d0fd62e44b7d0171980`. The root
+TensorRT-LLM history index tracks the latest 2026-06-26 runtime refresh at
+`0722c5f47d2cae69ac1a237da51e550dd214532c`. This page provides model
+implementation coverage, a PR timeline, and per-PR diff audit cards.
 
 Filter used in this pass: merged PRs whose titles or files matched `Qwen3.5`, `Qwen3_5`, `qwen3_5`, `AutoDeploy`, `NVFP4`, `FP8`, `DFlash`, `reasoning_parser`, `EPLB`, `MoE backend`, or `model_registry`. Pure reshuffling and unrelated infrastructure PRs were excluded.
 

--- a/model-pr-optimization-history/tensorrt_llm/qwen35/README.zh.md
+++ b/model-pr-optimization-history/tensorrt_llm/qwen35/README.zh.md
@@ -1,5 +1,18 @@
 # TensorRT-LLM Qwen3.5 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 TensorRT-LLM 上游 `NVIDIA/TensorRT-LLM@0722c5f47d2cae69ac1a237da51e550dd214532c` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-26`。
+
+结果：发现 3 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-26 | [#15481](https://github.com/NVIDIA/TensorRT-LLM/pull/15481) | [https://nvbugs/6239637][fix] Unwaive Qwen3.5 cases on A100 platform | `test_llm_api_pytorch.py` |
+| 2026-06-26 | [#15361](https://github.com/NVIDIA/TensorRT-LLM/pull/15361) | [TRTLLM-12762][test] Add Test coverage for MiniMax Model with multi-node, M2.5 checkpoints eval | `test_llm_api_pytorch.py` |
+| 2026-06-26 | [#14837](https://github.com/NVIDIA/TensorRT-LLM/pull/14837) | [TRTLLM-13712][feat] Add Qwen-Image-Bench evaluator | `qwen3_5_weight_mapper.py` |
+
 ## 2026-06-26 PR 补漏复核
 
 本文的逐 PR diff 审计卡基于 TensorRT-LLM 上游

--- a/model-pr-optimization-history/tensorrt_llm/qwen35/README.zh.md
+++ b/model-pr-optimization-history/tensorrt_llm/qwen35/README.zh.md
@@ -2,7 +2,11 @@
 
 ## 2026-06-26 PR 补漏复核
 
-已按 TensorRT-LLM 上游 `HEAD@4164b932c6c8a14d1be85d0fd62e44b7d0171980` 复核。本文覆盖 Qwen3.5 相关 merged PR，并采用 SGLang 风格的模型实现覆盖、PR 时间线和逐 PR diff 审计卡。
+本文的逐 PR diff 审计卡基于 TensorRT-LLM 上游
+`HEAD@4164b932c6c8a14d1be85d0fd62e44b7d0171980` 生成；根目录 TensorRT-LLM
+history index 已跟踪 2026-06-26 最新 runtime refresh
+`0722c5f47d2cae69ac1a237da51e550dd214532c`。本文覆盖 Qwen3.5 相关 merged
+PR，并采用 SGLang 风格的模型实现覆盖、PR 时间线和逐 PR diff 审计卡。
 
 本轮筛选规则：标题/文件命中 `Qwen3.5`、`Qwen3_5`、`qwen3_5`、`AutoDeploy`、`NVFP4`、`FP8`、`DFlash`、`reasoning_parser`、`EPLB`、`MoE backend`、`model_registry` 的 merged PR；过滤纯重排和不触碰模型/loader/test lane 的基础设施 PR。
 

--- a/model-pr-optimization-history/tensorrt_llm/qwen35/README.zh.md
+++ b/model-pr-optimization-history/tensorrt_llm/qwen35/README.zh.md
@@ -1,0 +1,291 @@
+# TensorRT-LLM Qwen3.5 模型 PR 优化历史
+
+## 2026-06-26 PR 补漏复核
+
+已按 TensorRT-LLM 上游 `HEAD@4164b932c6c8a14d1be85d0fd62e44b7d0171980` 复核。本文覆盖 Qwen3.5 相关 merged PR，并采用 SGLang 风格的模型实现覆盖、PR 时间线和逐 PR diff 审计卡。
+
+本轮筛选规则：标题/文件命中 `Qwen3.5`、`Qwen3_5`、`qwen3_5`、`AutoDeploy`、`NVFP4`、`FP8`、`DFlash`、`reasoning_parser`、`EPLB`、`MoE backend`、`model_registry` 的 merged PR；过滤纯重排和不触碰模型/loader/test lane 的基础设施 PR。
+
+## 模型实现文件覆盖
+
+| 文件 | 关联 PR |
+| --- | --- |
+| `tensorrt_llm/_torch/models/modeling_qwen3_5.py` | [#12302](https://github.com/NVIDIA/TensorRT-LLM/pull/12302), [#15067](https://github.com/NVIDIA/TensorRT-LLM/pull/15067) |
+| `tensorrt_llm/_torch/models/checkpoints/hf/qwen3_5_weight_mapper.py` | [#12302](https://github.com/NVIDIA/TensorRT-LLM/pull/12302), [#13090](https://github.com/NVIDIA/TensorRT-LLM/pull/13090), [#13716](https://github.com/NVIDIA/TensorRT-LLM/pull/13716), [#15067](https://github.com/NVIDIA/TensorRT-LLM/pull/15067) |
+| `tensorrt_llm/_torch/auto_deploy/models/custom/modeling_qwen3_5_moe.py` | [#12114](https://github.com/NVIDIA/TensorRT-LLM/pull/12114), [#14667](https://github.com/NVIDIA/TensorRT-LLM/pull/14667), [#15185](https://github.com/NVIDIA/TensorRT-LLM/pull/15185) |
+| `examples/auto_deploy/model_registry/configs/qwen3.5_moe_*.yaml` | [#12114](https://github.com/NVIDIA/TensorRT-LLM/pull/12114), [#14667](https://github.com/NVIDIA/TensorRT-LLM/pull/14667), [#15185](https://github.com/NVIDIA/TensorRT-LLM/pull/15185) |
+| `examples/auto_deploy/model_registry/models.yaml` | [#12114](https://github.com/NVIDIA/TensorRT-LLM/pull/12114), [#15001](https://github.com/NVIDIA/TensorRT-LLM/pull/15001) |
+| `tensorrt_llm/_torch/auto_deploy/transform/library/mrope_delta_cache.py` | [#12114](https://github.com/NVIDIA/TensorRT-LLM/pull/12114) |
+| `tensorrt_llm/_torch/models/modeling_speculative.py` / `speculative/dflash.py` | [#13782](https://github.com/NVIDIA/TensorRT-LLM/pull/13782), [#13996](https://github.com/NVIDIA/TensorRT-LLM/pull/13996) |
+| `tensorrt_llm/llmapi/reasoning_parser.py` | [#14659](https://github.com/NVIDIA/TensorRT-LLM/pull/14659) |
+| `tensorrt_llm/_torch/modules/fused_moe/moe_load_balancer.py` | [#15543](https://github.com/NVIDIA/TensorRT-LLM/pull/15543) |
+| `tests/integration/defs/accuracy/test_llm_api_pytorch.py` | [#12302](https://github.com/NVIDIA/TensorRT-LLM/pull/12302), [#13090](https://github.com/NVIDIA/TensorRT-LLM/pull/13090), [#15081](https://github.com/NVIDIA/TensorRT-LLM/pull/15081), [#15543](https://github.com/NVIDIA/TensorRT-LLM/pull/15543) |
+
+## PR 覆盖总览
+
+- 本轮审计 PR 数: 14
+- diff 来源: `gh pr diff` / GitHub PR patch，本地缓存 `/tmp/model_pr_diffs/tensorrt_llm/pr*.diff`
+- 已读 patch 行数: 12,514
+- TensorRT-LLM Qwen3.5 关键形态: AutoDeploy cookbook/registry、mRoPE/3D position、NVFP4/FP8 weight mapper、dense/MoE wrappers、DFlash speculative decoding、reasoning parser、CUTLASS/DeepGEMM backend选择、EPLB。
+
+## 时间线
+
+| 日期 | PR | 状态 | 标题 | 主要文件 |
+| --- | --- | --- | --- | --- |
+| 2026-02-26 | [#11728](https://github.com/NVIDIA/TensorRT-LLM/pull/11728) | merged | Added Qwen3.5 Cookbook | AutoDeploy cookbook notebook |
+| 2026-03-24 | [#12302](https://github.com/NVIDIA/TensorRT-LLM/pull/12302) | merged | Add Qwen 3.5 supporting (NVFP4) | model wrapper, weight mapper, tests |
+| 2026-03-25 | [#12114](https://github.com/NVIDIA/TensorRT-LLM/pull/12114) | merged | Qwen 3.5 fix 3d position ID handling | AutoDeploy Qwen3.5 MoE, mRoPE cache, registry configs |
+| 2026-04-30 | [#13090](https://github.com/NVIDIA/TensorRT-LLM/pull/13090) | merged | Qwen3.5 dense weight loading | weight mapper, dense tests |
+| 2026-05-04 | [#13716](https://github.com/NVIDIA/TensorRT-LLM/pull/13716) | merged | Fix Qwen3.5 NVFP4 weight loading by preserving weight_scales | HF mapper |
+| 2026-05-12 | [#13782](https://github.com/NVIDIA/TensorRT-LLM/pull/13782) | merged | Qwen3.5 DFlash | speculative/DFlash runtime |
+| 2026-05-16 | [#13996](https://github.com/NVIDIA/TensorRT-LLM/pull/13996) | merged | Perf optimizations for DFlash | DFlash model engine and speculative code |
+| 2026-05-29 | [#14659](https://github.com/NVIDIA/TensorRT-LLM/pull/14659) | merged | Add a reasoning parser for qwen3_5 | `reasoning_parser.py` |
+| 2026-06-02 | [#14667](https://github.com/NVIDIA/TensorRT-LLM/pull/14667) | merged | AutoDeploy: Qwen3.5 400B NVFP4 accuracy regression fix | shared expert sharding, SwiGLU fusion |
+| 2026-06-05 | [#15001](https://github.com/NVIDIA/TensorRT-LLM/pull/15001) | merged | Uncomment Qwen3.5 from model registry | `models.yaml` |
+| 2026-06-09 | [#15081](https://github.com/NVIDIA/TensorRT-LLM/pull/15081) | merged | Select CUTLASS MoE backend on non-Blackwell SMs | accuracy test backend selection |
+| 2026-06-11 | [#15067](https://github.com/NVIDIA/TensorRT-LLM/pull/15067) | merged | Generalize FP8 checkpoint loading for Qwen3.5 | weight mapper, modeling |
+| 2026-06-13 | [#15185](https://github.com/NVIDIA/TensorRT-LLM/pull/15185) | merged | Qwen3.5 whitelist sharding and lm_head sharding | AutoDeploy sharding IR/tests |
+| 2026-06-26 | [#15543](https://github.com/NVIDIA/TensorRT-LLM/pull/15543) | merged | Add EPLB support for Qwen3.5 | MoE load balancer and B200/GB200 tests |
+
+## 逐 PR diff 审计卡
+
+### PR #11728 - Added Qwen3.5 Cookbook
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/11728
+- 状态/时间: merged / 2026-02-26
+- 代码 diff 已读范围: 1 个文件，+385/-0，本地 patch 402 行。
+- 动机: 给 `Qwen/Qwen3.5-397B-A17B` 和 `nvidia/Qwen3.5-397B-A17B-NVFP4` 提供 AutoDeploy cookbook，明确 TensorRT-LLM 的服务命令和 B200 资源假设。
+- 实现要点: notebook 写入 `trtllm-serve` 命令、AutoDeploy registry 配置、NVFP4 4xB200 说明和示例 OpenAI 请求。
+- 关键代码摘录:
+
+```diff
++trtllm-serve "nvidia/Qwen3.5-397B-A17B-NVFP4" \
++MODEL_ID = "Qwen/Qwen3.5-397B-A17B"
+```
+
+- 已读文件: `examples/auto_deploy/cookbooks/qwen_3.5_trtllm_cookbook.ipynb`
+- 验证与风险: 这是公平 benchmark 的 TensorRT-LLM deployment 证据；需要和 PyTorch backend / AutoDeploy registry 配置一起记录。
+
+### PR #12302 - Add Qwen 3.5 supporting (NVFP4)
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/12302
+- 状态/时间: merged / 2026-03-24
+- 代码 diff 已读范围: 9 个文件，+225/-31，本地 patch 436 行。
+- 动机: TensorRT-LLM PyTorch backend 需要支持 Qwen3.5 dense/MoE 和官方 NVFP4 checkpoint。
+- 实现要点: 注册 `Qwen3_5ForCausalLM` 和 `Qwen3_5MoeForCausalLM`，扩展 HF mapper，normalize exclude modules，并新增 397B A17B NVFP4 accuracy tests。
+- 关键代码摘录:
+
+```diff
++@register_auto_model("Qwen3_5ForCausalLM")
++class Qwen3_5ForCausalLM(Qwen3NextForCausalLM):
+```
+
+- 已读文件: `modeling_qwen3_5.py`, `qwen3_5_weight_mapper.py`, `config_utils.py`, accuracy refs/tests
+- 验证与风险: 与 SGLang 对比时要区分 dense 和 MoE wrapper，以及 NVFP4 exclude module 规则。
+
+### PR #12114 - Qwen 3.5 fix 3D position ID handling
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/12114
+- 状态/时间: merged / 2026-03-25
+- 代码 diff 已读范围: 15 个文件，+3448/-275，本地 patch 7,822 行。
+- 动机: Qwen3.5 VLM/mRoPE 需要 3D position IDs、chunked multimodal positions、video grid normalization 和 mRoPE delta cache，原 AutoDeploy path 不完整。
+- 实现要点: 重写/扩展 `modeling_qwen3_5_moe.py` 的 multimodal input processor、mRoPE delta cache transform、registry configs 和单元测试。
+- 关键代码摘录:
+
+```diff
++@TransformRegistry.register("initialize_mrope_delta_cache")
++mm_token_positions: torch.Tensor
+```
+
+- 已读文件: `modeling_qwen3_5_moe.py`, `mrope_delta_cache.py`, registry YAML, `test_qwen3_5_moe.py`, serving utils tests
+- 验证与风险: 多模态 Qwen3.5 不能只比较 decode kernel；position construction 和 cache resource 命名也会影响 correctness。
+
+### PR #13090 - Qwen3.5 dense weight loading
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/13090
+- 状态/时间: merged / 2026-04-30
+- 代码 diff 已读范围: 5 个文件，+85/-1，本地 patch 225 行。
+- 动机: Qwen3.5 dense 4B/FP8 weight loading 需要独立覆盖，不能只靠 MoE mapper 过关。
+- 实现要点: 扩展 `qwen3_5_weight_mapper.py`，新增 `Qwen/Qwen3.5-4B` accuracy refs 和 `TestQwen3_5_4B`。
+- 关键代码摘录:
+
+```diff
++class TestQwen3_5_4B(LlmapiAccuracyTestHarness):
++MODEL_NAME = "Qwen/Qwen3.5-4B"
+```
+
+- 已读文件: HF mapper, accuracy refs, `test_llm_api_pytorch.py`, test lists
+- 验证与风险: SOTA loop 如果选 dense Qwen3.5，不能直接套 397B MoE 的 mapper 风险结论。
+
+### PR #13716 - Preserve Qwen3.5 NVFP4 weight_scales
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/13716
+- 状态/时间: merged / 2026-05-04
+- 代码 diff 已读范围: 1 个文件，+9/-3，本地 patch 45 行。
+- 动机: mapper 把 `weight_scales` 归一成 `weight_scale_inv` 的 FP8 逻辑会破坏 NVFP4 loader。
+- 实现要点: 在 HF mapper 中识别 NVFP4 prefix，保留 `weight_scales` 给 `NVFP4LinearMethod.load_weight_scales`。
+- 关键代码摘录:
+
+```diff
++        nvfp4_prefixes = {
++            key[: -len(".weight_scale_2")] for key in weights if key.endswith(".weight_scale_2")
++        }
++                if prefix not in nvfp4_prefixes:
+```
+
+- 已读文件: `qwen3_5_weight_mapper.py`
+- 验证与风险: Qwen3.5 NVFP4 对 scale 名称敏感；SGLang 对比 weight loader 时要检查 scale key remap。
+
+### PR #13782 - Qwen3.5 DFlash
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/13782
+- 状态/时间: merged / 2026-05-12
+- 代码 diff 已读范围: 5 个文件，+144/-55，本地 patch 413 行。
+- 动机: Qwen3.5 speculative/DFlash 需要把 GDN/Mamba cache 和 pyexecutor/model engine 接到 DFlash runtime。
+- 实现要点: 修改 `gdn_mixer.py`、`mamba_cache_manager.py`、`model_engine.py` 和 `speculative/dflash.py`，让 hybrid linear-attention 模型能参与 DFlash。
+- 关键代码摘录:
+
+```diff
++from tensorrt_llm._torch.speculative import dflash
++mamba_cache_manager
+```
+
+- 已读文件: `gdn_mixer.py`, `pyexecutor/_util.py`, `mamba_cache_manager.py`, `model_engine.py`, `speculative/dflash.py`
+- 验证与风险: 对 SGLang MTP/speculative 对比时，必须记录 DFlash 是否启用；它会改变 decode state update 形态。
+
+### PR #13996 - Perf optimizations for DFlash
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/13996
+- 状态/时间: merged / 2026-05-16
+- 代码 diff 已读范围: 5 个文件，+455/-285，本地 patch 1,606 行。
+- 动机: DFlash 初始支持后需要减少状态搬运和模型 engine overhead。
+- 实现要点: 调整 speculative modeling、GDN mixer、model engine 和 `llm_args.py`，把 DFlash path 做成更稳定的 perf path。
+- 关键代码摘录:
+
+```diff
++    def _build_fused_kv_buffers(self) -> None:
++        """Stack per-layer KV projection + k_norm weights for a single fused GEMM.
++        return self.max_draft_len + 1
+```
+
+- 已读文件: `modeling_speculative.py`, `gdn_mixer.py`, `model_engine.py`, `speculative/dflash.py`, `llm_args.py`
+- 验证与风险: 如果 TensorRT-LLM 领先来自 DFlash，需要和 SGLang MTP/SpecV2 分开归因。
+
+### PR #14659 - Add a reasoning parser for qwen3_5
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/14659
+- 状态/时间: merged / 2026-05-29
+- 代码 diff 已读范围: 1 个文件，+9/-0，本地 patch 30 行。
+- 动机: Qwen3.5 forced-thinking 模板输出一开始就在 reasoning block 内，旧 `qwen3` parser 的 `reasoning_at_start=False` 不匹配。
+- 实现要点: 注册 `qwen3_5` parser，并设置 `reasoning_at_start=True`。
+- 关键代码摘录:
+
+```diff
++@register_reasoning_parser("qwen3_5", reasoning_at_start=True)
+```
+
+- 已读文件: `tensorrt_llm/llmapi/reasoning_parser.py`
+- 验证与风险: benchmark 输出清洗/CoT 解析不一致会影响评测分数，不能只看吞吐。
+
+### PR #14667 - AutoDeploy Qwen3.5 400B NVFP4 accuracy regression fix
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/14667
+- 状态/时间: merged / 2026-06-02
+- 代码 diff 已读范围: 5 个文件，+72/-35，本地 patch 464 行。
+- 动机: AutoDeploy Qwen3.5 400B NVFP4 出现 accuracy regression，shared expert sharding 与 SwiGLU fusion 需要修正。
+- 实现要点: 将 shared expert 复制而不是 TP sharding，加入 whitelist sharding hints，并扩展 SwiGLU fusion pattern。
+- 关键代码摘录:
+
+```diff
++# The shared expert is replicated
++apply_sharding_hints:
+```
+
+- 已读文件: `qwen3.5_moe_400b.yaml`, `modeling_qwen3_5_moe.py`, `custom_ops/linear/swiglu.py`, `fuse_swiglu.py`, waives
+- 验证与风险: SGLang 若遇到 Qwen3.5 MoE 精度差异，应检查 shared expert 并行策略和 SwiGLU fusion，不要只比较 MoE matmul。
+
+### PR #15001 - Uncomment Qwen3.5 from model registry
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/15001
+- 状态/时间: merged / 2026-06-05
+- 代码 diff 已读范围: 1 个文件，+9/-12，本地 patch 50 行。
+- 动机: Qwen3.5 AutoDeploy registry entry 从注释状态变成默认可发现。
+- 实现要点: 在 `models.yaml` 启用 `Qwen/Qwen3.5-35B-A3B` 和 `Qwen/Qwen3.5-397B-A17B`。
+- 关键代码摘录:
+
+```diff
++- name: Qwen/Qwen3.5-397B-A17B
++  config_id: qwen3_5_moe_400b
+```
+
+- 已读文件: `examples/auto_deploy/model_registry/models.yaml`
+- 验证与风险: SOTA loop 可以把 registry entry 视作 TensorRT-LLM 官方 AutoDeploy lane，而不是临时命令。
+
+### PR #15081 - Select CUTLASS MoE backend on non-Blackwell SMs
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/15081
+- 状态/时间: merged / 2026-06-09
+- 代码 diff 已读范围: 2 个文件，+8/-2，本地 patch 52 行。
+- 动机: Qwen3.5 FP8 test 在非 Blackwell SM 上不应默认使用 DeepGEMM，需要 fallback 到 CUTLASS MoE backend。
+- 实现要点: accuracy test 按 SM 版本选择 `DEEPGEMM` 或 `CUTLASS`。
+- 关键代码摘录:
+
+```diff
++moe_backend = "DEEPGEMM" if get_sm_version() in (100, 103) else "CUTLASS"
+```
+
+- 已读文件: `test_llm_api_pytorch.py`, `waives.txt`
+- 验证与风险: 跨 GPU 比较必须记录 MoE backend；否则 H100/B200 结果不可直接混用。
+
+### PR #15067 - Generalize FP8 checkpoint loading for Qwen3.5
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/15067
+- 状态/时间: merged / 2026-06-11
+- 代码 diff 已读范围: 2 个文件，+68/-48，本地 patch 220 行。
+- 动机: Qwen3.5 FP8 checkpoint 的 scale/exclude module 命名需要更通用的 mapper 处理。
+- 实现要点: 重构 `qwen3_5_weight_mapper.py` 与 `modeling_qwen3_5.py` 中的 FP8/NVFP4 normalization。
+- 关键代码摘录:
+
+```diff
++    # gdn_mixer uses Linear module for weight management of depthwise conv1d
++    # but conv1d is not a proper linear module and should be excluded from quant
++    normalized.add("*linear_attn.conv1d")
+```
+
+- 已读文件: `qwen3_5_weight_mapper.py`, `modeling_qwen3_5.py`
+- 验证与风险: 对 FP8 checkpoint 的 load failure 或精度差异，先查 mapper normalization，而不是 kernel。
+
+### PR #15185 - Qwen3.5 whitelist sharding and lm_head sharding
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/15185
+- 状态/时间: merged / 2026-06-13
+- 代码 diff 已读范围: 5 个文件，+193/-118，本地 patch 735 行。
+- 动机: AutoDeploy Qwen3.5 需要白名单式 sharding，并让 `lm_head` 参与 sharding，以减少单 rank 负载和保持图变换可控。
+- 实现要点: 更新 registry YAML、`modeling_qwen3_5_moe.py` sharding hints、`fuse_swiglu.py` 和 `sharding_ir.py` 测试。
+- 关键代码摘录:
+
+```diff
++lm_head:
++apply_sharding_hints
+```
+
+- 已读文件: `qwen3.5_moe_400b.yaml`, `modeling_qwen3_5_moe.py`, `fuse_swiglu.py`, `sharding_ir.py`, tests
+- 验证与风险: SGLang 对标时应单独观察 lm_head 和 shared expert 的 sharding/communication，而不是只看 MoE expert GEMM。
+
+### PR #15543 - Add EPLB support for Qwen3.5
+
+- 链接: https://github.com/NVIDIA/TensorRT-LLM/pull/15543
+- 状态/时间: merged / 2026-06-26
+- 代码 diff 已读范围: 3 个文件，+73/-0，本地 patch 130 行。
+- 动机: Qwen3.5 MoE 需要 EPLB，尤其是 B200/GB200 perf sanity 和 PyTorch backend test coverage。
+- 实现要点: 在 `moe_load_balancer.py` 增加 Qwen3.5 支持，并把 B200/GB200 test-db lane 接入。
+- 关键代码摘录:
+
+```diff
++    'Qwen2MoeForCausalLM',
++    'Qwen3MoeForCausalLM',
++    'Qwen3_5MoeForCausalLM',
+```
+
+- 已读文件: `moe_load_balancer.py`, `test_llm_api_pytorch.py`, B200/GB200 test-db YAML
+- 验证与风险: 与 SGLang 的 EPLB/DeepEP/EP 对比时，必须记录 load-balancer 是否启用和测试集群拓扑。

--- a/model-pr-optimization-history/tokenspeed/README.md
+++ b/model-pr-optimization-history/tokenspeed/README.md
@@ -1,0 +1,23 @@
+# TokenSpeed Model PR Optimization History
+
+Current model families:
+
+- `kimi`
+- `qwen35`
+
+## Current Watch / Landed Items
+
+Refresh: `2026-06-26`. Source head:
+`lightseekorg/tokenspeed@5aedf69d6b476baa65571011de6ea60fd5a238a8`.
+
+| PR | Model / area | Status | Current signal | Why it matters |
+| --- | --- | --- | --- | --- |
+| [#456](https://github.com/lightseekorg/tokenspeed/pull/456) | Qwen3.5 VLM | merged | packed QKV rotary layout | Optimizes Qwen vision FA4 rotary/QKV path and changes VLM trace shape. |
+| [#354](https://github.com/lightseekorg/tokenspeed/pull/354) | Qwen3.5 + Kimi VLM | merged | generalized multimodal runtime | Adds shared video/multimodal plumbing used by model-specific VLM paths. |
+| [#198](https://github.com/lightseekorg/tokenspeed/pull/198) | Qwen3.5 | merged | gated activation fusion | Fuses sigmoid/mul and removes a reshape copy in Qwen3.5 attention output. |
+| [#196](https://github.com/lightseekorg/tokenspeed/pull/196) | Qwen3.5 | merged | fused q/k GemmaRMSNorm | Collapses two norm launches in Qwen3.5 attention prep. |
+| [#477](https://github.com/lightseekorg/tokenspeed/pull/477) | Kimi VLM | merged | Kimi Vision FA4 QKV + RoPE | Kimi-side counterpart to packed vision QKV rotary work. |
+| [#454](https://github.com/lightseekorg/tokenspeed/pull/454) | Kimi K2.5 | merged | AMD MXFP4 serving | Adds MXFP4 layer/backend path and validation for Kimi serving. |
+| [#126](https://github.com/lightseekorg/tokenspeed/pull/126) | Kimi K2.5 | merged | fused lm_head GEMM | Adds Kimi-gated persistent lm_head GEMM. |
+
+Read the per-model files for timelines and diff audit cards.

--- a/model-pr-optimization-history/tokenspeed/kimi/README.en.md
+++ b/model-pr-optimization-history/tokenspeed/kimi/README.en.md
@@ -1,0 +1,219 @@
+# TokenSpeed Kimi Model PR Optimization History
+
+## 2026-06-26 PR Backfill Audit
+
+Checked against TokenSpeed upstream `HEAD@5aedf69d6b476baa65571011de6ea60fd5a238a8`. This uses a SGLang-style timeline plus per-PR diff audit cards for Kimi K2.5/K2.x.
+
+Filter used in this pass: merged PRs whose titles or files matched `Kimi`, `kimi_k25`, `K2.5`, `NVFP4`, `MXFP4`, `MXINT4`, `lm_head`, `top_k/top_p`, `InstantTensor`, `OCR`, `FA4`, `vision`, or `MLA`. Formatting-only and unrelated infrastructure changes were excluded.
+
+## Model Implementation File Coverage
+
+| File | Related PRs |
+| --- | --- |
+| `python/tokenspeed/runtime/models/kimi_k25.py` | [#354](https://github.com/lightseekorg/tokenspeed/pull/354), [#418](https://github.com/lightseekorg/tokenspeed/pull/418), [#454](https://github.com/lightseekorg/tokenspeed/pull/454), [#477](https://github.com/lightseekorg/tokenspeed/pull/477) |
+| `python/tokenspeed/runtime/layers/logits_processor.py` | [#126](https://github.com/lightseekorg/tokenspeed/pull/126) |
+| `tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/lm_head_gemm.py` | [#126](https://github.com/lightseekorg/tokenspeed/pull/126) |
+| `tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/*` | [#184](https://github.com/lightseekorg/tokenspeed/pull/184) |
+| `python/tokenspeed/runtime/layers/moe/weights/mxint4.py` | [#444](https://github.com/lightseekorg/tokenspeed/pull/444) |
+| `tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_mxint4.py` | [#444](https://github.com/lightseekorg/tokenspeed/pull/444) |
+| `python/tokenspeed/runtime/layers/quantization/*mxfp4*` | [#454](https://github.com/lightseekorg/tokenspeed/pull/454) |
+| `python/tokenspeed/runtime/model_loader/*` | [#418](https://github.com/lightseekorg/tokenspeed/pull/418) |
+| `tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/qkv_rotary.py` | [#477](https://github.com/lightseekorg/tokenspeed/pull/477), [#482](https://github.com/lightseekorg/tokenspeed/pull/482) |
+| `test/ci/eval/kimi-k2.5-*.yaml` | [#29](https://github.com/lightseekorg/tokenspeed/pull/29), [#253](https://github.com/lightseekorg/tokenspeed/pull/253), [#476](https://github.com/lightseekorg/tokenspeed/pull/476), [#482](https://github.com/lightseekorg/tokenspeed/pull/482) |
+
+## PR Coverage Overview
+
+- Reviewed PRs: 10
+- Diff source: `gh pr diff` / GitHub PR patches cached under `/tmp/model_pr_diffs/tokenspeed/pr*.diff`
+- Reviewed patch lines: 11,975
+- Main TokenSpeed Kimi themes: K2.5 agentic/OCR eval lanes, fused lm_head GEMM, TopK+TopP renormalization, InstantTensor loader, MXINT4/MXFP4 MoE/quantization, and FA4 multimodal attention.
+
+## Timeline
+
+| Date | PR | State | Title | Main files |
+| --- | --- | --- | --- | --- |
+| 2026-05-08 | [#29](https://github.com/lightseekorg/tokenspeed/pull/29) | merged | Add Kimi K2.5 agentic perf CI task | perf YAML, CI pipeline |
+| 2026-05-13 | [#126](https://github.com/lightseekorg/tokenspeed/pull/126) | merged | perf(K2.5): Optimize lm_head | `logits_processor.py`, CUDA `lm_head_gemm` |
+| 2026-05-20 | [#184](https://github.com/lightseekorg/tokenspeed/pull/184) | merged | perf(K2.5): optimize top_k_renorm_prob + top_p_renorm_prob | fused sampling CUDA, backend/server args |
+| 2026-05-28 | [#253](https://github.com/lightseekorg/tokenspeed/pull/253) | merged | ci(eval): add Kimi-K2.5-NVFP4 ocr_bench task | OCR eval YAML |
+| 2026-06-15 | [#418](https://github.com/lightseekorg/tokenspeed/pull/418) | merged | Add InstantTensor weight loader | loader, weight utils, `kimi_k25.py`, docs/CI |
+| 2026-06-14 | [#444](https://github.com/lightseekorg/tokenspeed/pull/444) | merged | feat(moe): add trtllm mxint4 MoE path for Kimi-K2.x | MXINT4 weights and FlashInfer TRT-LLM MoE op |
+| 2026-06-16 | [#454](https://github.com/lightseekorg/tokenspeed/pull/454) | merged | [AMD] Support Kimi K2.5 MXFP4 serving | MXFP4 layers, dense path, MLA backend, Kimi model |
+| 2026-06-19 | [#477](https://github.com/lightseekorg/tokenspeed/pull/477) | merged | perf(kernel): Optimize Kimi Vision FA4 QKV + RoPE | Kimi model, mm attention, packed complex rotary |
+| 2026-06-19 | [#482](https://github.com/lightseekorg/tokenspeed/pull/482) | merged | ci: use FA4 mm attention for Kimi OCR eval | OCR eval YAML |
+| 2026-06-26 | [#476](https://github.com/lightseekorg/tokenspeed/pull/476) | merged | Add AMD Kimi MXFP4 CI job | AMD eval YAML, MLA metadata unit test |
+
+## Per-PR Diff Audit Cards
+
+### PR #29 - Add Kimi K2.5 agentic perf CI task
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/29
+- State/time: merged / 2026-05-08
+- Diff coverage: 5 files, +387/-3, 650 cached patch lines.
+- Motivation: make `nvidia/Kimi-K2.5-NVFP4` agentic serving a repeatable perf CI lane.
+- Key implementation: adds a Kimi K2.5 agentic perf YAML using `tokenspeed_mla`, NVFP4, speculative draft, and EvalScope agentic workloads.
+- Code excerpt:
+
+```diff
++--model nvidia/Kimi-K2.5-NVFP4
++--attention-backend tokenspeed_mla
++--quantization nvfp4
+```
+
+- Reviewed files: PR workflow, `kimi-k2.5-nvfp4-evalscope-agentic.yaml`, CI pipeline helpers
+- Validation/risk: keep the agentic perf lane separate from shared synthetic serving workloads.
+
+### PR #126 - perf(K2.5): Optimize lm_head
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/126
+- State/time: merged / 2026-05-13
+- Diff coverage: 6 files, +1173/-3, 1,246 cached patch lines.
+- Motivation: Kimi K2.5 decode spends meaningful time in the final `lm_head` GEMM.
+- Key implementation: gates a fused CUDA `lm_head_gemm` path to Kimi and falls back when shapes are unsupported.
+- Code excerpt:
+
+```diff
++self._use_fused_lm_head = getattr(self.config, "model_type", None) == "kimi_k2"
++logits = _lm_head_matmul(hidden_states, lm_head.weight)
+```
+
+- Reviewed files: `logits_processor.py`, `lm_head_gemm.cu`, binding, Python wrapper, setup
+- Validation/risk: include `lm_head` as its own profiler bucket for Kimi-style models.
+
+### PR #184 - perf(K2.5): optimize top_k_renorm_prob + top_p_renorm_prob
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/184
+- State/time: merged / 2026-05-20
+- Diff coverage: 8 files, +3104/-12, 3,580 cached patch lines.
+- Motivation: back-to-back top-k and deterministic top-p renormalization caused repeated scans and extra launches.
+- Key implementation: adds a fused TopK+TopP renormalization CUDA path and wires it into `flashinfer_full.py`.
+- Code excerpt:
+
+```diff
+-probs = top_k_renorm_prob(probs, top_ks)
+-probs = top_p_renorm_prob(probs, top_ps, is_deterministic=True)
++probs = fused_topk_topp_renorm(probs, top_ks, top_ps)
+```
+
+- Reviewed files: fused sampling CUDA sources, `flashinfer_full.py`, `server_args.py`, tests
+- Validation/risk: sampling can be the bottleneck; also track limits such as `top_k < 128`.
+
+### PR #253 - ci(eval): add Kimi-K2.5-NVFP4 ocr_bench task
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/253
+- State/time: merged / 2026-05-28
+- Diff coverage: 1 file, +48/-0, 72 cached patch lines.
+- Motivation: Kimi K2.5 needs a multimodal OCR regression lane.
+- Key implementation: adds an OCR EvalScope YAML using the Kimi NVFP4 server config.
+- Code excerpt:
+
+```diff
++--model nvidia/Kimi-K2.5-NVFP4
++--datasets ocr_bench
+```
+
+- Reviewed files: `kimi-k2.5-nvfp4-evalscope-ocr-bench.yaml`
+- Validation/risk: text-only throughput does not cover the Kimi K2.5 multimodal path.
+
+### PR #418 - Add InstantTensor weight loader
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/418
+- State/time: merged / 2026-06-15
+- Diff coverage: 25 files, +468/-60, 1,373 cached patch lines.
+- Motivation: Kimi-scale checkpoints need a faster loader path.
+- Key implementation: adds `--load-format instanttensor`, loader utilities, Kimi model integration, and CI/doc updates.
+- Code excerpt:
+
+```diff
++--load-format instanttensor
++        elif self.load_config.load_format == LoadFormat.INSTANTTENSOR:
++            weights_iterator = instanttensor_weights_iterator(hf_weights_files)
+```
+
+- Reviewed files: `model_loader/loader.py`, `weight_utils.py`, `kimi_k25.py`, `server_args.py`, docs and eval configs
+- Validation/risk: separate cold-start loading evidence from steady-state throughput.
+
+### PR #444 - feat(moe): add trtllm mxint4 MoE path for Kimi-K2.x
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/444
+- State/time: merged / 2026-06-14
+- Diff coverage: 8 files, +469/-6, 581 cached patch lines.
+- Motivation: Kimi K2.x needed an INT4 W4A16 group-32 MoE path.
+- Key implementation: adds MXINT4 weight packing, quant config detection, and FlashInfer TRT-LLM MoE process/apply ops.
+- Code excerpt:
+
+```diff
++from tokenspeed.runtime.layers.moe.weights.mxint4 import create_mxint4_weight_pair
++name="flashinfer_trtllm_mxint4_moe_apply"
+```
+
+- Reviewed files: `expert.py`, `weights/mxint4.py`, quantization configs, `trtllm_mxint4.py`
+- Validation/risk: record weight dtype, group size, activation dtype, and MoE backend in benchmark tables.
+
+### PR #454 - [AMD] Support Kimi K2.5 MXFP4 serving
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/454
+- State/time: merged / 2026-06-16
+- Diff coverage: 33 files, +1924/-142, 3,856 cached patch lines.
+- Motivation: serve Kimi K2.5 MXFP4 on AMD.
+- Key implementation: adds MXFP4 quantization/layers/dense support and updates MLA backend, Kimi model code, and tests.
+- Code excerpt:
+
+```diff
++--quantization mxfp4
++model_type == "kimi_k25"
+```
+
+- Reviewed files: MXFP4 layers/quantization, dense paths, attention backends, `kimi_k25.py`, tests
+- Validation/risk: this is hardware-specific and should not be merged with NVIDIA NVFP4 conclusions.
+
+### PR #477 - perf(kernel): Optimize Kimi Vision FA4 QKV + RoPE
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/477
+- State/time: merged / 2026-06-19
+- Diff coverage: 3 files, +195/-7, 304 cached patch lines.
+- Motivation: the Kimi vision FA4 path had extra packed-QKV and complex-RoPE layout movement.
+- Key implementation: adds `packed_qkv_complex_rotary` and wires it into multimodal encoder attention.
+- Code excerpt:
+
+```diff
++        if use_packed_qkv_complex_rotary:
++            q, k, v = packed_qkv_complex_rotary(
++def packed_qkv_complex_rotary(
+```
+
+- Reviewed files: `mm_encoder_attention.py`, `kimi_k25.py`, `qkv_rotary.py`
+- Validation/risk: profile QKV/RoPE layout work before blaming FA4 itself.
+
+### PR #482 - ci: use FA4 mm attention for Kimi OCR eval
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/482
+- State/time: merged / 2026-06-19
+- Diff coverage: 1 file, +1/-0, 22 cached patch lines.
+- Motivation: make OCR eval exercise the FA4 multimodal attention path.
+- Key implementation: adds `--mm-attention-backend fa4` to the Kimi OCR EvalScope YAML.
+- Code excerpt:
+
+```diff
++--mm-attention-backend fa4
+```
+
+- Reviewed files: `kimi-k2.5-nvfp4-evalscope-ocr-bench.yaml`
+- Validation/risk: always record the multimodal attention backend in Kimi OCR comparisons.
+
+### PR #476 - Add AMD Kimi MXFP4 CI job
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/476
+- State/time: merged / 2026-06-26
+- Diff coverage: 3 files, +138/-4, 181 cached patch lines.
+- Motivation: keep AMD Kimi MXFP4 AIME25 and MLA metadata paths covered after #454.
+- Key implementation: adds an AMD MXFP4 eval YAML and `MLAAttnBackend` metadata tests.
+- Code excerpt:
+
+```diff
++--model amd/Kimi-K2.5-MXFP4
++--quantization mxfp4
+```
+
+- Reviewed files: `mla.py`, AMD AIME25 YAML, `test_mla_verify_metadata.py`
+- Validation/risk: treat AMD MXFP4 as a separate lane from NVIDIA Kimi NVFP4.

--- a/model-pr-optimization-history/tokenspeed/kimi/README.en.md
+++ b/model-pr-optimization-history/tokenspeed/kimi/README.en.md
@@ -1,5 +1,17 @@
 # TokenSpeed Kimi Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked TokenSpeed upstream `lightseekorg/tokenspeed@5aedf69d6b476baa65571011de6ea60fd5a238a8` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-26`.
+
+Result: 2 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-26 | [#519](https://github.com/lightseekorg/tokenspeed/pull/519) | feat: distributed argmax for EAGLE greedy sampling | `logits_processor.py` |
+| 2026-06-25 | [#456](https://github.com/lightseekorg/tokenspeed/pull/456) | perf(kernel): optimize Qwen vision QKV rotary layout | `qkv_rotary.py` |
+
 ## 2026-06-26 PR Backfill Audit
 
 Checked against TokenSpeed upstream `HEAD@5aedf69d6b476baa65571011de6ea60fd5a238a8`. This uses a SGLang-style timeline plus per-PR diff audit cards for Kimi K2.5/K2.x.

--- a/model-pr-optimization-history/tokenspeed/kimi/README.zh.md
+++ b/model-pr-optimization-history/tokenspeed/kimi/README.zh.md
@@ -1,0 +1,219 @@
+# TokenSpeed Kimi 模型 PR 优化历史
+
+## 2026-06-26 PR 补漏复核
+
+已按 TokenSpeed 上游 `HEAD@5aedf69d6b476baa65571011de6ea60fd5a238a8` 复核。本文覆盖 Kimi K2.5/K2.x 相关的 merged PR，并采用 SGLang 风格的时间线和逐 PR diff 审计卡。
+
+本轮筛选规则：标题/文件命中 `Kimi`、`kimi_k25`、`K2.5`、`NVFP4`、`MXFP4`、`MXINT4`、`lm_head`、`top_k/top_p`、`InstantTensor`、`OCR`、`FA4`、`vision`、`MLA` 的 merged PR；过滤纯格式化和不影响模型/runtime/CI lane 的基础设施 PR。
+
+## 模型实现文件覆盖
+
+| 文件 | 关联 PR |
+| --- | --- |
+| `python/tokenspeed/runtime/models/kimi_k25.py` | [#354](https://github.com/lightseekorg/tokenspeed/pull/354), [#418](https://github.com/lightseekorg/tokenspeed/pull/418), [#454](https://github.com/lightseekorg/tokenspeed/pull/454), [#477](https://github.com/lightseekorg/tokenspeed/pull/477) |
+| `python/tokenspeed/runtime/layers/logits_processor.py` | [#126](https://github.com/lightseekorg/tokenspeed/pull/126) |
+| `tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/lm_head_gemm.py` | [#126](https://github.com/lightseekorg/tokenspeed/pull/126) |
+| `tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/*` | [#184](https://github.com/lightseekorg/tokenspeed/pull/184) |
+| `python/tokenspeed/runtime/layers/moe/weights/mxint4.py` | [#444](https://github.com/lightseekorg/tokenspeed/pull/444) |
+| `tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/flashinfer/trtllm_mxint4.py` | [#444](https://github.com/lightseekorg/tokenspeed/pull/444) |
+| `python/tokenspeed/runtime/layers/quantization/*mxfp4*` | [#454](https://github.com/lightseekorg/tokenspeed/pull/454) |
+| `python/tokenspeed/runtime/model_loader/*` | [#418](https://github.com/lightseekorg/tokenspeed/pull/418) |
+| `tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/qkv_rotary.py` | [#477](https://github.com/lightseekorg/tokenspeed/pull/477), [#482](https://github.com/lightseekorg/tokenspeed/pull/482) |
+| `test/ci/eval/kimi-k2.5-*.yaml` | [#29](https://github.com/lightseekorg/tokenspeed/pull/29), [#253](https://github.com/lightseekorg/tokenspeed/pull/253), [#476](https://github.com/lightseekorg/tokenspeed/pull/476), [#482](https://github.com/lightseekorg/tokenspeed/pull/482) |
+
+## PR 覆盖总览
+
+- 本轮审计 PR 数: 10
+- diff 来源: `gh pr diff` / GitHub PR patch，本地缓存 `/tmp/model_pr_diffs/tokenspeed/pr*.diff`
+- 已读 patch 行数: 11,975
+- TokenSpeed Kimi 关键形态: K2.5 agentic/OCR eval lane、fused lm_head GEMM、TopK+TopP renorm、InstantTensor loader、MXINT4/MXFP4 MoE/quantization、FA4 multimodal attention。
+
+## 时间线
+
+| 日期 | PR | 状态 | 标题 | 主要文件 |
+| --- | --- | --- | --- | --- |
+| 2026-05-08 | [#29](https://github.com/lightseekorg/tokenspeed/pull/29) | merged | Add Kimi K2.5 agentic perf CI task | perf YAML, CI pipeline |
+| 2026-05-13 | [#126](https://github.com/lightseekorg/tokenspeed/pull/126) | merged | perf(K2.5): Optimize lm_head | `logits_processor.py`, CUDA `lm_head_gemm` |
+| 2026-05-20 | [#184](https://github.com/lightseekorg/tokenspeed/pull/184) | merged | perf(K2.5): optimize top_k_renorm_prob + top_p_renorm_prob | fused sampling CUDA, backend/server args |
+| 2026-05-28 | [#253](https://github.com/lightseekorg/tokenspeed/pull/253) | merged | ci(eval): add Kimi-K2.5-NVFP4 ocr_bench task | OCR eval YAML |
+| 2026-06-15 | [#418](https://github.com/lightseekorg/tokenspeed/pull/418) | merged | Add InstantTensor weight loader | loader, weight utils, `kimi_k25.py`, docs/CI |
+| 2026-06-14 | [#444](https://github.com/lightseekorg/tokenspeed/pull/444) | merged | feat(moe): add trtllm mxint4 MoE path for Kimi-K2.x | MXINT4 weights and FlashInfer TRT-LLM MoE op |
+| 2026-06-16 | [#454](https://github.com/lightseekorg/tokenspeed/pull/454) | merged | [AMD] Support Kimi K2.5 MXFP4 serving | MXFP4 layers, dense path, MLA backend, Kimi model |
+| 2026-06-19 | [#477](https://github.com/lightseekorg/tokenspeed/pull/477) | merged | perf(kernel): Optimize Kimi Vision FA4 QKV + RoPE | Kimi model, mm attention, packed complex rotary |
+| 2026-06-19 | [#482](https://github.com/lightseekorg/tokenspeed/pull/482) | merged | ci: use FA4 mm attention for Kimi OCR eval | OCR eval YAML |
+| 2026-06-26 | [#476](https://github.com/lightseekorg/tokenspeed/pull/476) | merged | Add AMD Kimi MXFP4 CI job | AMD eval YAML, MLA metadata unit test |
+
+## 逐 PR diff 审计卡
+
+### PR #29 - Add Kimi K2.5 agentic perf CI task
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/29
+- 状态/时间: merged / 2026-05-08
+- 代码 diff 已读范围: 5 个文件，+387/-3，本地 patch 650 行。
+- 动机: 把 `nvidia/Kimi-K2.5-NVFP4` 的 agentic workload 变成 perf CI，而不是只靠手工压测。
+- 实现要点: 新增 Kimi K2.5 agentic perf YAML，服务端使用 `python3 -m tokenspeed.api_server`，配套 `tokenspeed_mla`、NVFP4、speculative draft 和 EvalScope agentic workload。
+- 关键代码摘录:
+
+```diff
++--model nvidia/Kimi-K2.5-NVFP4
++--attention-backend tokenspeed_mla
++--quantization nvfp4
+```
+
+- 已读文件: `.github/workflows/pr-test.yml`, `test/ci/perf/kimi-k2.5-nvfp4-evalscope-agentic.yaml`, CI pipeline helper
+- 验证与风险: SOTA loop 里要把 agentic perf lane 和公共 synthetic workload 分开记录；TokenSpeed 的领先可能来自 workload/state 管理，而不是单个 kernel。
+
+### PR #126 - perf(K2.5): Optimize lm_head
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/126
+- 状态/时间: merged / 2026-05-13
+- 代码 diff 已读范围: 6 个文件，+1173/-3，本地 patch 1,246 行。
+- 动机: Kimi K2.5 decode 末端 `lm_head` 大 GEMM 显著影响 TPOT；PR 用专用 CUDA kernel 替换一般 `torch.matmul` 路径。
+- 实现要点: `LogitsProcessor` 里按 `model_type == "kimi_k2"` gate fused path；新增 `lm_head_gemm.cu`、binding 和 Python wrapper，并保留 shape 不匹配时 fallback。
+- 关键代码摘录:
+
+```diff
++self._use_fused_lm_head = getattr(self.config, "model_type", None) == "kimi_k2"
++logits = _lm_head_matmul(hidden_states, lm_head.weight)
+```
+
+- 已读文件: `logits_processor.py`, `lm_head_gemm.cu`, `lm_head_gemm_binding.cu`, `lm_head_gemm.py`, setup files
+- 验证与风险: 对 SGLang Kimi/Qwen 类模型，`lm_head` 需要单独进 profiler 表；不能只优化 attention/MoE 后就宣布收敛。
+
+### PR #184 - perf(K2.5): optimize top_k_renorm_prob + top_p_renorm_prob
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/184
+- 状态/时间: merged / 2026-05-20
+- 代码 diff 已读范围: 8 个文件，+3104/-12，本地 patch 3,580 行。
+- 动机: sampling backend 连续调用 `top_k_renorm_prob` 与 deterministic `top_p_renorm_prob`，在高并发 decode 尾部形成重复扫描和多 launch。
+- 实现要点: 新增 fused TopK+TopP renorm CUDA 路径，按 `top_k` sentinel 切分分支，接入 `flashinfer_full.py` 和 `server_args.py` 的参数限制。
+- 关键代码摘录:
+
+```diff
+-probs = top_k_renorm_prob(probs, top_ks)
+-probs = top_p_renorm_prob(probs, top_ps, is_deterministic=True)
++probs = fused_topk_topp_renorm(probs, top_ks, top_ps)
+```
+
+- 已读文件: `fused_topk_topp/*`, `flashinfer_full.py`, `server_args.py`, sampling tests
+- 验证与风险: 对 SGLang profiler 的采样阶段，若 top-k/top-p 占比高，应把 sampling kernel 当成主优化面；同时检查 `top_k < 128` 这类 kernel contract。
+
+### PR #253 - ci(eval): add Kimi-K2.5-NVFP4 ocr_bench task
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/253
+- 状态/时间: merged / 2026-05-28
+- 代码 diff 已读范围: 1 个文件，+48/-0，本地 patch 72 行。
+- 动机: Kimi K2.5 是强多模态模型，OCR benchmark 需要进入常规 eval lane。
+- 实现要点: 新增 `kimi-k2.5-nvfp4-evalscope-ocr-bench.yaml`，复用 Kimi NVFP4 server config，只把 EvalScope dataset 切到 `ocr_bench`。
+- 关键代码摘录:
+
+```diff
++--model nvidia/Kimi-K2.5-NVFP4
++--datasets ocr_bench
+```
+
+- 已读文件: `test/ci/eval/kimi-k2.5-nvfp4-evalscope-ocr-bench.yaml`
+- 验证与风险: 多模态 SOTA loop 要保留 OCR lane；text-only benchmark 不能代表 Kimi K2.5 全部优化收益。
+
+### PR #418 - Add InstantTensor weight loader
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/418
+- 状态/时间: merged / 2026-06-15
+- 代码 diff 已读范围: 25 个文件，+468/-60，本地 patch 1,373 行。
+- 动机: Kimi K2.5 大模型启动和权重加载成本高，需要 `--load-format instanttensor` 这样的专用 loader。
+- 实现要点: 新增 loader/weight utils 分支，接入 server args、Kimi model 权重路径和 CI eval 文档。
+- 关键代码摘录:
+
+```diff
++--load-format instanttensor
++        elif self.load_config.load_format == LoadFormat.INSTANTTENSOR:
++            weights_iterator = instanttensor_weights_iterator(hf_weights_files)
+```
+
+- 已读文件: `runtime/model_loader/loader.py`, `weight_utils.py`, `runtime/models/kimi_k25.py`, `runtime/utils/server_args.py`, docs and eval configs
+- 验证与风险: 公平 benchmark 要记录冷启动/热启动边界；如果比较 steady-state TPOT，InstantTensor 不应混入吞吐结论。
+
+### PR #444 - feat(moe): add trtllm mxint4 MoE path for Kimi-K2.x
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/444
+- 状态/时间: merged / 2026-06-14
+- 代码 diff 已读范围: 8 个文件，+469/-6，本地 patch 581 行。
+- 动机: Kimi K2.x 需要 INT4 W4A16 group-32 MoE path，现有 NVFP4/MXFP4 path 不能覆盖 MXINT4 checkpoint。
+- 实现要点: 新增 `create_mxint4_weight_pair`、quant config 识别和 `flashinfer_trtllm_mxint4` MoE process/apply op。
+- 关键代码摘录:
+
+```diff
++from tokenspeed.runtime.layers.moe.weights.mxint4 import create_mxint4_weight_pair
++name="flashinfer_trtllm_mxint4_moe_apply"
+```
+
+- 已读文件: `expert.py`, `weights/mxint4.py`, quantization configs, `trtllm_mxint4.py`
+- 验证与风险: SGLang 做 Kimi K2.x 量化路径对比时，要把 weight dtype、group size、activation dtype 和 FlashInfer TRT-LLM op 名称全部记录进结果表。
+
+### PR #454 - [AMD] Support Kimi K2.5 MXFP4 serving
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/454
+- 状态/时间: merged / 2026-06-16
+- 代码 diff 已读范围: 33 个文件，+1924/-142，本地 patch 3,856 行。
+- 动机: AMD 平台需要 Kimi K2.5 MXFP4 serving，包括 attention、dense、MoE、quantization 和模型加载路径。
+- 实现要点: 新增 MXFP4 quantization/layer/dense 支持，调整 MLA backend、Kimi model 和 AMD 相关测试。
+- 关键代码摘录:
+
+```diff
++--quantization mxfp4
++model_type == "kimi_k25"
+```
+
+- 已读文件: MXFP4 layers/quantization, dense kernels, attention backends, `runtime/models/kimi_k25.py`, tests
+- 验证与风险: 这是跨硬件路径，不应把 AMD MXFP4 结论直接外推到 NVIDIA NVFP4；SOTA loop 应按 GPU/backend 分 lane。
+
+### PR #477 - perf(kernel): Optimize Kimi Vision FA4 QKV + RoPE
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/477
+- 状态/时间: merged / 2026-06-19
+- 代码 diff 已读范围: 3 个文件，+195/-7，本地 patch 304 行。
+- 动机: Kimi vision FA4 path 的 complex RoPE 和 packed QKV 拆分存在额外 layout 搬运。
+- 实现要点: 新增 `packed_qkv_complex_rotary` Triton kernel，在 multimodal encoder attention 中走 packed complex-RoPE fast path。
+- 关键代码摘录:
+
+```diff
++        if use_packed_qkv_complex_rotary:
++            q, k, v = packed_qkv_complex_rotary(
++def packed_qkv_complex_rotary(
+```
+
+- 已读文件: `mm_encoder_attention.py`, `runtime/models/kimi_k25.py`, `qkv_rotary.py`
+- 验证与风险: SGLang Kimi/OCR VLM 优化需要关注 FA4 attention 前的 QKV/RoPE layout，而不是只看 FA4 主 kernel。
+
+### PR #482 - ci: use FA4 mm attention for Kimi OCR eval
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/482
+- 状态/时间: merged / 2026-06-19
+- 代码 diff 已读范围: 1 个文件，+1/-0，本地 patch 22 行。
+- 动机: OCR eval 应覆盖新的 FA4 multimodal attention path，否则 #477 的 kernel 优化没有固定回归 lane。
+- 实现要点: 在 Kimi OCR eval YAML 增加 `--mm-attention-backend fa4`。
+- 关键代码摘录:
+
+```diff
++--mm-attention-backend fa4
+```
+
+- 已读文件: `test/ci/eval/kimi-k2.5-nvfp4-evalscope-ocr-bench.yaml`
+- 验证与风险: 多模态 benchmark 需要显式记录 `mm-attention-backend`，否则同一个 Kimi checkpoint 会跑出不同 kernel 形态。
+
+### PR #476 - Add AMD Kimi MXFP4 CI job
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/476
+- 状态/时间: merged / 2026-06-26
+- 代码 diff 已读范围: 3 个文件，+138/-4，本地 patch 181 行。
+- 动机: #454 接入 AMD MXFP4 后，需要持续验证 AIME25 eval 和 MLA metadata 兼容性。
+- 实现要点: 新增 `kimi-k2.5-mxfp4-evalscope-aime25-amd.yaml`，并增加 `MLAAttnBackend` metadata unit test。
+- 关键代码摘录:
+
+```diff
++--model amd/Kimi-K2.5-MXFP4
++--quantization mxfp4
+```
+
+- 已读文件: `mla.py`, `kimi-k2.5-mxfp4-evalscope-aime25-amd.yaml`, `test_mla_verify_metadata.py`
+- 验证与风险: 这条 lane 是 AMD 特化；SGLang 竞品比较时要在结果里标出硬件和 quantization，不要把它当成通用 Kimi lane。

--- a/model-pr-optimization-history/tokenspeed/kimi/README.zh.md
+++ b/model-pr-optimization-history/tokenspeed/kimi/README.zh.md
@@ -1,5 +1,17 @@
 # TokenSpeed Kimi 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 TokenSpeed 上游 `lightseekorg/tokenspeed@5aedf69d6b476baa65571011de6ea60fd5a238a8` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-26`。
+
+结果：发现 2 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-26 | [#519](https://github.com/lightseekorg/tokenspeed/pull/519) | feat: distributed argmax for EAGLE greedy sampling | `logits_processor.py` |
+| 2026-06-25 | [#456](https://github.com/lightseekorg/tokenspeed/pull/456) | perf(kernel): optimize Qwen vision QKV rotary layout | `qkv_rotary.py` |
+
 ## 2026-06-26 PR 补漏复核
 
 已按 TokenSpeed 上游 `HEAD@5aedf69d6b476baa65571011de6ea60fd5a238a8` 复核。本文覆盖 Kimi K2.5/K2.x 相关的 merged PR，并采用 SGLang 风格的时间线和逐 PR diff 审计卡。

--- a/model-pr-optimization-history/tokenspeed/qwen35/README.en.md
+++ b/model-pr-optimization-history/tokenspeed/qwen35/README.en.md
@@ -1,0 +1,188 @@
+# TokenSpeed Qwen3.5 Model PR Optimization History
+
+## 2026-06-26 PR Backfill Audit
+
+Checked against TokenSpeed upstream `HEAD@5aedf69d6b476baa65571011de6ea60fd5a238a8`. This page follows the same structure as the SGLang/vLLM histories: model-relevant PR timeline, reviewed diffs, implementation files, short code excerpts, and validation risks.
+
+Filter used in this pass: merged GitHub PRs whose title or files matched `Qwen3.5`, `qwen3_5`, `Qwen3Moe`, `VLM`, `PD`, `moe`, `activation`, `rotary`, or `flashinfer_trtllm`. Pure formatting and unrelated infrastructure PRs were excluded.
+
+## Model Implementation File Coverage
+
+| File | Related PRs |
+| --- | --- |
+| `python/tokenspeed/runtime/models/qwen3_5.py` | [#196](https://github.com/lightseekorg/tokenspeed/pull/196), [#198](https://github.com/lightseekorg/tokenspeed/pull/198), [#354](https://github.com/lightseekorg/tokenspeed/pull/354), [#456](https://github.com/lightseekorg/tokenspeed/pull/456) |
+| `python/tokenspeed/runtime/configs/qwen3_moe_config.py` | [#181](https://github.com/lightseekorg/tokenspeed/pull/181) |
+| `python/tokenspeed/runtime/models/qwen3_moe.py` | [#181](https://github.com/lightseekorg/tokenspeed/pull/181) |
+| `python/tokenspeed/runtime/layers/vocab_parallel_embedding.py` | [#309](https://github.com/lightseekorg/tokenspeed/pull/309) |
+| `python/tokenspeed/runtime/distributed/comm_manager.py` | [#309](https://github.com/lightseekorg/tokenspeed/pull/309) |
+| `python/tokenspeed/runtime/multimodal/*` | [#354](https://github.com/lightseekorg/tokenspeed/pull/354) |
+| `tokenspeed-kernel/python/tokenspeed_kernel/ops/activation/triton.py` | [#198](https://github.com/lightseekorg/tokenspeed/pull/198) |
+| `tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/qkv_rotary.py` | [#456](https://github.com/lightseekorg/tokenspeed/pull/456) |
+| `tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton.py` | [#189](https://github.com/lightseekorg/tokenspeed/pull/189) |
+| `test/runtime/models/test_qwen35_vlm_e2e.py` | [#456](https://github.com/lightseekorg/tokenspeed/pull/456) |
+| `test/runtime/distributed/test_qwen35_pd_1p1d.py` | [#400](https://github.com/lightseekorg/tokenspeed/pull/400) |
+
+## PR Coverage Overview
+
+- Reviewed PRs: 8
+- Diff source: `gh pr diff` / GitHub PR patches cached under `/tmp/model_pr_diffs/tokenspeed/pr*.diff`
+- Reviewed patch lines: 5,149
+- Main TokenSpeed Qwen3.5 themes: Qwen3/Qwen3.5 MoE runtime, Q/K RMSNorm fusion, attention-gate fusion, multimodal MRoPE/video runtime, packed QKV rotary, and PD disaggregation CI.
+
+## Timeline
+
+| Date | PR | State | Title | Main files |
+| --- | --- | --- | --- | --- |
+| 2026-05-19 | [#181](https://github.com/lightseekorg/tokenspeed/pull/181) | merged | feat(qwen3): add Qwen3 MoE causal LM support | `qwen3_moe.py`, `qwen3_moe_config.py`, HF utils, model tests |
+| 2026-05-20 | [#189](https://github.com/lightseekorg/tokenspeed/pull/189) | merged | Fix Qwen3 FP8 MoE activation scale layout | `ops/moe/triton.py`, `test_moe_triton.py` |
+| 2026-05-22 | [#196](https://github.com/lightseekorg/tokenspeed/pull/196) | merged | perf(qwen3.5): fuse q/k GemmaRMSNorm into one triton launch | `runtime/models/qwen3_5.py`, `test_layernorm.py` |
+| 2026-05-23 | [#198](https://github.com/lightseekorg/tokenspeed/pull/198) | merged | perf(qwen3.5): fuse attn_output_gate sigmoid+mul | `qwen3_5.py`, `activation/triton.py`, `test_activation.py` |
+| 2026-06-01 | [#309](https://github.com/lightseekorg/tokenspeed/pull/309) | merged | fix(dp): fix qwen 3.5 data parallel bug | `comm_manager.py`, `vocab_parallel_embedding.py` |
+| 2026-06-09 | [#400](https://github.com/lightseekorg/tokenspeed/pull/400) | merged | ci(qwen3.5): add qwen3.5 397b pd ci (1p1d) | PD YAML, distributed smoke test |
+| 2026-06-23 | [#354](https://github.com/lightseekorg/tokenspeed/pull/354) | merged | feat(video): generalize multimodal runtime support and add Qwen3.5 video | multimodal runtime, MRoPE, `qwen3_5.py` |
+| 2026-06-25 | [#456](https://github.com/lightseekorg/tokenspeed/pull/456) | merged | perf(kernel): optimize Qwen vision QKV rotary layout | packed rotary kernel, Qwen3.5 VLM E2E test |
+
+## Per-PR Diff Audit Cards
+
+### PR #181 - feat(qwen3): add Qwen3 MoE causal LM support
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/181
+- State/time: merged / 2026-05-19
+- Diff coverage: 5 files, +610/-0, 790 cached patch lines.
+- Motivation: TokenSpeed needed a Qwen3 MoE causal LM runtime. The Qwen3 MoE path is close to Qwen3.5 MoE and exposes reusable sparse-MoE model patterns.
+- Key implementation: adds `Qwen3MoeConfig`, `Qwen3MoeForCausalLM`, HF config mapping, and model tests.
+- Code excerpt:
+
+```diff
++from tokenspeed.runtime.models.qwen3_5 import Qwen3_5MoeSparseMoeBlock
++class Qwen3MoeForCausalLM(nn.Module):
+```
+
+- Reviewed files: `docs/recipes/models.md`, `qwen3_moe_config.py`, `qwen3_moe.py`, `hf_transformers_utils.py`, `test_qwen3_moe_models.py`
+- Validation/risk: useful for SGLang as MoE runtime evidence, especially HF config mapping and weight naming.
+
+### PR #189 - Fix Qwen3 FP8 MoE activation scale layout
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/189
+- State/time: merged / 2026-05-20
+- Diff coverage: 2 files, +107/-14, 174 cached patch lines.
+- Motivation: the FP8 MoE activation scale layout did not match the fused MoE kernel contract.
+- Key implementation: updates scale handling in `fused_moe_kernel` / `invoke_fused_moe_kernel` and extends Triton MoE tests.
+- Code excerpt:
+
+```diff
++def _normalize_fp8_group_scale_layout(
++    A: torch.Tensor,
++    A_scale: torch.Tensor,
++    expected_scale_k: int,
++) -> torch.Tensor:
++            A_scale = _normalize_fp8_group_scale_layout(A, A_scale, expected_scale_k)
+```
+
+- Reviewed files: `ops/moe/triton.py`, `test_moe_triton.py`
+- Validation/risk: compare scale layout before reading MoE profiler wins across SGLang and TokenSpeed.
+
+### PR #196 - perf(qwen3.5): fuse q/k GemmaRMSNorm into one Triton launch
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/196
+- State/time: merged / 2026-05-22
+- Diff coverage: 2 files, +87/-12, 155 cached patch lines.
+- Motivation: the old attention prep normalized Q and K through separate `GemmaRMSNorm` launches.
+- Key implementation: replaces the two-launch path inside `_apply_qk_norm` with `qk_rmsnorm` and adds layernorm tests.
+- Code excerpt:
+
+```diff
+-q = self.q_norm(q)
+-k = self.k_norm(k)
++q, k = qk_rmsnorm(q, k, q_gamma, k_gamma, eps)
+```
+
+- Reviewed files: `runtime/models/qwen3_5.py`, `test_layernorm.py`
+- Validation/risk: a direct competitor clue for SGLang Qwen3.5 norm fusion; check launch count, BF16 rounding order, and Q/K strides.
+
+### PR #198 - perf(qwen3.5): fuse attn_output_gate sigmoid+mul
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/198
+- State/time: merged / 2026-05-23
+- Diff coverage: 3 files, +234/-3, 323 cached patch lines.
+- Motivation: the `attn_output_gate` path used reshape, sigmoid, and multiply as separate work.
+- Key implementation: adds Triton `sigmoid_mul` and consumes the 3D strided gate view produced by `torch.chunk`.
+- Code excerpt:
+
+```diff
+-attn_output = attn_output * torch.sigmoid(gate)
++sigmoid_mul(attn_output, gate)
+```
+
+- Reviewed files: `runtime/models/qwen3_5.py`, `activation/triton.py`, `test_activation.py`
+- Validation/risk: if SGLang traces show a sigmoid/mul/copy cluster, this is the closest TokenSpeed precedent.
+
+### PR #309 - fix(dp): fix qwen 3.5 data parallel bug
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/309
+- State/time: merged / 2026-06-01
+- Diff coverage: 2 files, +13/-1, 46 cached patch lines.
+- Motivation: DP vocab-parallel embedding masking differed from the TP>1 mask path.
+- Key implementation: clamps masked input before embedding lookup and fixes a distributed comm rank path.
+- Code excerpt:
+
+```diff
++masked_input = torch.clamp(masked_input, min=0, max=self.num_embeddings - 1)
+```
+
+- Reviewed files: `comm_manager.py`, `vocab_parallel_embedding.py`
+- Validation/risk: SGLang/TokenSpeed DP comparisons should check token masking and rank layout before blaming kernels.
+
+### PR #400 - ci(qwen3.5): add Qwen3.5 397B PD CI (1p1d)
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/400
+- State/time: merged / 2026-06-09
+- Diff coverage: 2 files, +169/-0, 345 cached patch lines.
+- Motivation: TokenSpeed made `nvidia/Qwen3.5-397B-A17B-NVFP4` prefill/decode disaggregation a fixed CI lane.
+- Key implementation: launches a PD serve script and validates `/v1/models` plus `/v1/chat/completions`.
+- Code excerpt:
+
+```diff
++MODEL = os.environ.get("MODEL", "nvidia/Qwen3.5-397B-A17B-NVFP4")
++pytest test/runtime/distributed/test_qwen35_pd_1p1d.py -v
+```
+
+- Reviewed files: PD CI YAML, `test_qwen35_pd_1p1d.py`
+- Validation/risk: treat PD/disaggregation as a separate workload from monolithic serving in the SOTA loop.
+
+### PR #354 - feat(video): generalize multimodal runtime support and add Qwen3.5 video
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/354
+- State/time: merged / 2026-06-23
+- Diff coverage: 19 files, +982/-266, 2,500 cached patch lines.
+- Motivation: Qwen3.5 video/image serving needed unified multimodal runtime support, encoder budgets, MRoPE decode positions, and CUDA graph capture.
+- Key implementation: introduces multimodal adapters, budget graphs, metadata sequence budgets, and MRoPE position-delta handling.
+- Code excerpt:
+
+```diff
++mrope_position_delta_scalar: Optional[int] = None
++        if not is_prefill:
++            return self._build_decode_mrope_positions_override(
+```
+
+- Reviewed files: generation/output processors, input processor, model executor, `runtime/multimodal/*`, `qwen3_5.py`, `kimi_k25.py`
+- Validation/risk: profile encoder capture, MRoPE construction, output D2H, and LLM decode separately.
+
+### PR #456 - perf(kernel): optimize Qwen vision QKV rotary layout
+
+- Link: https://github.com/lightseekorg/tokenspeed/pull/456
+- State/time: merged / 2026-06-25
+- Diff coverage: 6 files, +452/-35, 816 cached patch lines.
+- Motivation: Qwen3.5 VLM vision attention had packed-QKV rotary split/materialization overhead.
+- Key implementation: adds `packed_qkv_neox_rotary`, wires it into multimodal encoder attention, and adds a Blackwell Qwen3.5 VLM smoke test.
+- Code excerpt:
+
+```diff
++            q, k, v = packed_qkv_neox_rotary(
++                qkv,
++                self.q_size,
++__all__ = ["packed_qkv_complex_rotary", "packed_qkv_neox_rotary"]
+```
+
+- Reviewed files: `mm_encoder_attention.py`, `qwen3_5.py`, `qkv_rotary.py`, `test_qwen35_vlm_e2e.py`, `trtllm_fp8.py`
+- Validation/risk: for SGLang VLM work, first check whether QKV split, rotary, and V copy are already fused.

--- a/model-pr-optimization-history/tokenspeed/qwen35/README.en.md
+++ b/model-pr-optimization-history/tokenspeed/qwen35/README.en.md
@@ -1,5 +1,12 @@
 # TokenSpeed Qwen3.5 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked TokenSpeed upstream `lightseekorg/tokenspeed@5aedf69d6b476baa65571011de6ea60fd5a238a8` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-26`.
+
+Result: no additional PR-numbered merges touched the tracked files beyond the existing timeline/backfill rows.
+
 ## 2026-06-26 PR Backfill Audit
 
 Checked against TokenSpeed upstream `HEAD@5aedf69d6b476baa65571011de6ea60fd5a238a8`. This page follows the same structure as the SGLang/vLLM histories: model-relevant PR timeline, reviewed diffs, implementation files, short code excerpts, and validation risks.

--- a/model-pr-optimization-history/tokenspeed/qwen35/README.zh.md
+++ b/model-pr-optimization-history/tokenspeed/qwen35/README.zh.md
@@ -1,0 +1,188 @@
+# TokenSpeed Qwen3.5 模型 PR 优化历史
+
+## 2026-06-26 PR 补漏复核
+
+已按 TokenSpeed 上游 `HEAD@5aedf69d6b476baa65571011de6ea60fd5a238a8` 复核。这个文件按 SGLang/vLLM 同样的格式记录模型相关 PR、已读 diff、实现文件、代码摘录与验证风险。
+
+本轮筛选规则：GitHub merged PR、标题/文件路径命中 `Qwen3.5`、`qwen3_5`、`Qwen3Moe`、`VLM`、`PD`、`moe`、`activation`、`rotary`、`flashinfer_trtllm` 等；过滤纯格式化和无模型路径的基础设施 PR。
+
+## 模型实现文件覆盖
+
+| 文件 | 关联 PR |
+| --- | --- |
+| `python/tokenspeed/runtime/models/qwen3_5.py` | [#196](https://github.com/lightseekorg/tokenspeed/pull/196), [#198](https://github.com/lightseekorg/tokenspeed/pull/198), [#354](https://github.com/lightseekorg/tokenspeed/pull/354), [#456](https://github.com/lightseekorg/tokenspeed/pull/456) |
+| `python/tokenspeed/runtime/configs/qwen3_moe_config.py` | [#181](https://github.com/lightseekorg/tokenspeed/pull/181) |
+| `python/tokenspeed/runtime/models/qwen3_moe.py` | [#181](https://github.com/lightseekorg/tokenspeed/pull/181) |
+| `python/tokenspeed/runtime/layers/vocab_parallel_embedding.py` | [#309](https://github.com/lightseekorg/tokenspeed/pull/309) |
+| `python/tokenspeed/runtime/distributed/comm_manager.py` | [#309](https://github.com/lightseekorg/tokenspeed/pull/309) |
+| `python/tokenspeed/runtime/multimodal/*` | [#354](https://github.com/lightseekorg/tokenspeed/pull/354) |
+| `tokenspeed-kernel/python/tokenspeed_kernel/ops/activation/triton.py` | [#198](https://github.com/lightseekorg/tokenspeed/pull/198) |
+| `tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/triton/qkv_rotary.py` | [#456](https://github.com/lightseekorg/tokenspeed/pull/456) |
+| `tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton.py` | [#189](https://github.com/lightseekorg/tokenspeed/pull/189) |
+| `test/runtime/models/test_qwen35_vlm_e2e.py` | [#456](https://github.com/lightseekorg/tokenspeed/pull/456) |
+| `test/runtime/distributed/test_qwen35_pd_1p1d.py` | [#400](https://github.com/lightseekorg/tokenspeed/pull/400) |
+
+## PR 覆盖总览
+
+- 本轮审计 PR 数: 8
+- diff 来源: `gh pr diff` / GitHub PR patch，本地缓存 `/tmp/model_pr_diffs/tokenspeed/pr*.diff`
+- 已读 patch 行数: 5,149
+- TokenSpeed Qwen3.5 关键形态: Qwen3/Qwen3.5 MoE runtime、Q/K RMSNorm 融合、attention gate 融合、多模态 MRoPE/视频路径、packed QKV rotary、PD disaggregation CI。
+
+## 时间线
+
+| 日期 | PR | 状态 | 标题 | 主要文件 |
+| --- | --- | --- | --- | --- |
+| 2026-05-19 | [#181](https://github.com/lightseekorg/tokenspeed/pull/181) | merged | feat(qwen3): add Qwen3 MoE causal LM support | `qwen3_moe.py`, `qwen3_moe_config.py`, HF utils, model tests |
+| 2026-05-20 | [#189](https://github.com/lightseekorg/tokenspeed/pull/189) | merged | Fix Qwen3 FP8 MoE activation scale layout | `ops/moe/triton.py`, `test_moe_triton.py` |
+| 2026-05-22 | [#196](https://github.com/lightseekorg/tokenspeed/pull/196) | merged | perf(qwen3.5): fuse q/k GemmaRMSNorm into one triton launch | `runtime/models/qwen3_5.py`, `test_layernorm.py` |
+| 2026-05-23 | [#198](https://github.com/lightseekorg/tokenspeed/pull/198) | merged | perf(qwen3.5): fuse attn_output_gate sigmoid+mul | `qwen3_5.py`, `activation/triton.py`, `test_activation.py` |
+| 2026-06-01 | [#309](https://github.com/lightseekorg/tokenspeed/pull/309) | merged | fix(dp): fix qwen 3.5 data parallel bug | `comm_manager.py`, `vocab_parallel_embedding.py` |
+| 2026-06-09 | [#400](https://github.com/lightseekorg/tokenspeed/pull/400) | merged | ci(qwen3.5): add qwen3.5 397b pd ci (1p1d) | PD YAML, distributed smoke test |
+| 2026-06-23 | [#354](https://github.com/lightseekorg/tokenspeed/pull/354) | merged | feat(video): generalize multimodal runtime support and add Qwen3.5 video | multimodal runtime, MRoPE, `qwen3_5.py` |
+| 2026-06-25 | [#456](https://github.com/lightseekorg/tokenspeed/pull/456) | merged | perf(kernel): optimize Qwen vision QKV rotary layout | packed rotary kernel, Qwen3.5 VLM E2E test |
+
+## 逐 PR diff 审计卡
+
+### PR #181 - feat(qwen3): add Qwen3 MoE causal LM support
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/181
+- 状态/时间: merged / 2026-05-19
+- 代码 diff 已读范围: 5 个文件，+610/-0，本地 patch 790 行。
+- 动机: TokenSpeed 需要 Qwen3 MoE causal LM runtime；这条路径与 Qwen3.5 的 MoE block 复用关系很近，是后续 Qwen3.5 fast path 的可迁移来源。
+- 实现要点: 新增 `Qwen3MoeConfig`、`Qwen3MoeForCausalLM` 和 HF config 映射，并在模型测试里把 Qwen3 MoE 接进 runtime。
+- 关键代码摘录:
+
+```diff
++from tokenspeed.runtime.models.qwen3_5 import Qwen3_5MoeSparseMoeBlock
++class Qwen3MoeForCausalLM(nn.Module):
+```
+
+- 已读文件: `docs/recipes/models.md`, `qwen3_moe_config.py`, `qwen3_moe.py`, `hf_transformers_utils.py`, `test_qwen3_moe_models.py`
+- 验证与风险: 对 SGLang SOTA loop 的价值不是直接复制 Qwen3 模型，而是查看 Qwen3.5 MoE block 复用、权重命名和 HF config adapter 的边界。
+
+### PR #189 - Fix Qwen3 FP8 MoE activation scale layout
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/189
+- 状态/时间: merged / 2026-05-20
+- 代码 diff 已读范围: 2 个文件，+107/-14，本地 patch 174 行。
+- 动机: FP8 MoE activation scale 的内存布局和 fused MoE kernel 预期不一致，会影响 Qwen/Qwen3.5 MoE 后端的精度或错误读取。
+- 实现要点: 调整 `fused_moe_kernel` / `invoke_fused_moe_kernel` 的 scale 参数准备，并在 Triton MoE 测试里覆盖布局。
+- 关键代码摘录:
+
+```diff
++def _normalize_fp8_group_scale_layout(
++    A: torch.Tensor,
++    A_scale: torch.Tensor,
++    expected_scale_k: int,
++) -> torch.Tensor:
++            A_scale = _normalize_fp8_group_scale_layout(A, A_scale, expected_scale_k)
+```
+
+- 已读文件: `tokenspeed-kernel/python/tokenspeed_kernel/ops/moe/triton.py`, `tokenspeed-kernel/test/ops/test_moe_triton.py`
+- 验证与风险: 对比 SGLang 的 FP8/DeepGEMM/MoE 路径时，要把 scale tensor layout 纳入 profiler 前置检查；否则同名 backend 可能走了不同 layout contract。
+
+### PR #196 - perf(qwen3.5): fuse q/k GemmaRMSNorm into one Triton launch
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/196
+- 状态/时间: merged / 2026-05-22
+- 代码 diff 已读范围: 2 个文件，+87/-12，本地 patch 155 行。
+- 动机: Qwen3.5 attention 前处理原来对 Q/K 分别跑 `GemmaRMSNorm`，带来两次 launch 与额外 memory traffic。
+- 实现要点: 在 `Qwen3_5AttentionDecoderLayer._apply_qk_norm` 中改用 `qk_rmsnorm`，同时补 layernorm 单测。
+- 关键代码摘录:
+
+```diff
+-q = self.q_norm(q)
+-k = self.k_norm(k)
++q, k = qk_rmsnorm(q, k, q_gamma, k_gamma, eps)
+```
+
+- 已读文件: `python/tokenspeed/runtime/models/qwen3_5.py`, `tokenspeed-kernel/test/ops/test_layernorm.py`
+- 验证与风险: 这是 SGLang Qwen3.5/Gemma-style norm fusion 的直接竞品证据；需要在 SGLang loop 里同时看 launch 数、BF16 rounding 顺序和 q/k stride。
+
+### PR #198 - perf(qwen3.5): fuse attn_output_gate sigmoid+mul
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/198
+- 状态/时间: merged / 2026-05-23
+- 代码 diff 已读范围: 3 个文件，+234/-3，本地 patch 323 行。
+- 动机: Qwen3.5 `attn_output_gate` 原路径包含 reshape、sigmoid、mul，decode 阶段会表现成小 kernel 与一次 gate contiguous copy。
+- 实现要点: 新增 Triton `sigmoid_mul`，直接读取 `torch.chunk(q_gate, 2, dim=-1)` 产生的 3D strided gate view，并在 `self_attention` 里原地更新 `attn_output`。
+- 关键代码摘录:
+
+```diff
+-attn_output = attn_output * torch.sigmoid(gate)
++sigmoid_mul(attn_output, gate)
+```
+
+- 已读文件: `python/tokenspeed/runtime/models/qwen3_5.py`, `tokenspeed-kernel/python/tokenspeed_kernel/ops/activation/triton.py`, `tokenspeed-kernel/test/ops/test_activation.py`
+- 验证与风险: 对 SGLang 的启发是把 gate layout 当成 kernel API 的一部分测试；如果 SGLang profiler 表里出现 sigmoid/mul/copy 簇，这是优先候选融合。
+
+### PR #309 - fix(dp): fix qwen 3.5 data parallel bug
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/309
+- 状态/时间: merged / 2026-06-01
+- 代码 diff 已读范围: 2 个文件，+13/-1，本地 patch 46 行。
+- 动机: Qwen3.5 data parallel 下 vocab parallel embedding 的 mask/clamp 行为和 TP>1 路径不一致，可能让 padding 或越界 token 进入 embedding lookup。
+- 实现要点: 在 embedding 前按 DP mask 路径 clamp input，并同步修正 distributed comm manager 的 rank 参数。
+- 关键代码摘录:
+
+```diff
++masked_input = torch.clamp(masked_input, min=0, max=self.num_embeddings - 1)
+```
+
+- 已读文件: `python/tokenspeed/runtime/distributed/comm_manager.py`, `python/tokenspeed/runtime/layers/vocab_parallel_embedding.py`
+- 验证与风险: SGLang 对齐 TokenSpeed DP/EP benchmark 时，应检查 vocab mask、padding token 和 TP/DP rank 对齐，不要只看 kernel profile。
+
+### PR #400 - ci(qwen3.5): add Qwen3.5 397B PD CI (1p1d)
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/400
+- 状态/时间: merged / 2026-06-09
+- 代码 diff 已读范围: 2 个文件，+169/-0，本地 patch 345 行。
+- 动机: TokenSpeed 把 `nvidia/Qwen3.5-397B-A17B-NVFP4` 的 prefill/decode disaggregation 变成固定 CI lane，避免 PD 路径只靠人工命令验证。
+- 实现要点: 新增 `test_qwen35_pd_1p1d.py`，启动 PD serve 脚本后通过 OpenAI `/v1/models` 和 `/v1/chat/completions` 做 smoke。
+- 关键代码摘录:
+
+```diff
++MODEL = os.environ.get("MODEL", "nvidia/Qwen3.5-397B-A17B-NVFP4")
++pytest test/runtime/distributed/test_qwen35_pd_1p1d.py -v
+```
+
+- 已读文件: `test/ci/ut/qwen3.5-397b-a17b-nvfp4-pd-1p1d.yaml`, `test/runtime/distributed/test_qwen35_pd_1p1d.py`
+- 验证与风险: SGLang SOTA loop 若比较 PD/disagg 场景，需要把 TokenSpeed 的 1P1D lane 作为独立 workload，不应混到单体 serving 的公平对比里。
+
+### PR #354 - feat(video): generalize multimodal runtime support and add Qwen3.5 video
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/354
+- 状态/时间: merged / 2026-06-23
+- 代码 diff 已读范围: 19 个文件，+982/-266，本地 patch 2,500 行。
+- 动机: Qwen3.5 video/image path 需要统一多模态 runtime、encoder output budget、M-RoPE decode position 以及 CUDA graph capture，而不是每个模型单独处理。
+- 实现要点: 抽象 multimodal adapter、budget graph、metadata sequence budget；在 generation output / input processor / model executor 中加入 MRoPE position delta cache 与 decode override。
+- 关键代码摘录:
+
+```diff
++mrope_position_delta_scalar: Optional[int] = None
++        if not is_prefill:
++            return self._build_decode_mrope_positions_override(
+```
+
+- 已读文件: `generation_output_processor.py`, `input_processor.py`, `model_executor.py`, `runtime/multimodal/*`, `runtime/models/qwen3_5.py`, `runtime/models/kimi_k25.py`
+- 验证与风险: 多模态 profile 要拆 encoder capture、MRoPE build、output D2H、decode forward；单看 LLM decode kernel 会漏掉 TokenSpeed 的实际优化面。
+
+### PR #456 - perf(kernel): optimize Qwen vision QKV rotary layout
+
+- 链接: https://github.com/lightseekorg/tokenspeed/pull/456
+- 状态/时间: merged / 2026-06-25
+- 代码 diff 已读范围: 6 个文件，+452/-35，本地 patch 816 行。
+- 动机: Qwen3.5 VLM vision attention 的 packed QKV + rotary 原路径会拆分、搬运和再 materialize；PR 把 NeoX rotary 也接入 packed rotary kernel。
+- 实现要点: 新增 `packed_qkv_neox_rotary`，在 `mm_encoder_attention.py` 根据 position embedding 模式选择 packed rotary；新增 Blackwell Qwen3.5 VLM E2E smoke。
+- 关键代码摘录:
+
+```diff
++            q, k, v = packed_qkv_neox_rotary(
++                qkv,
++                self.q_size,
++__all__ = ["packed_qkv_complex_rotary", "packed_qkv_neox_rotary"]
+```
+
+- 已读文件: `mm_encoder_attention.py`, `runtime/models/qwen3_5.py`, `qkv_rotary.py`, `test_qwen35_vlm_e2e.py`, `trtllm_fp8.py`
+- 验证与风险: 对 SGLang VLM/vision encoder 优化，优先检查 QKV split + rotary + V copy 是否已经融合；如果没有，TokenSpeed 这里是明确的竞品实现证据。

--- a/model-pr-optimization-history/tokenspeed/qwen35/README.zh.md
+++ b/model-pr-optimization-history/tokenspeed/qwen35/README.zh.md
@@ -1,5 +1,12 @@
 # TokenSpeed Qwen3.5 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 TokenSpeed 上游 `lightseekorg/tokenspeed@5aedf69d6b476baa65571011de6ea60fd5a238a8` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-26`。
+
+结果：除了本文已有 timeline/backfill 行之外，没有额外 PR-numbered merge 命中 tracked files。
+
 ## 2026-06-26 PR 补漏复核
 
 已按 TokenSpeed 上游 `HEAD@5aedf69d6b476baa65571011de6ea60fd5a238a8` 复核。这个文件按 SGLang/vLLM 同样的格式记录模型相关 PR、已读 diff、实现文件、代码摘录与验证风险。

--- a/model-pr-optimization-history/vllm/README.md
+++ b/model-pr-optimization-history/vllm/README.md
@@ -37,7 +37,7 @@ Current model families:
 ## Current Watch / Landed Items
 
 Refresh: `2026-06-26`. Source head:
-`vllm-project/vllm@c2507fb2937aa8c8e74bea15719d04fb6090befe`.
+`vllm-project/vllm@37ce34922f7f5e58241369511130cd99c1c50bfe`.
 
 Keep watch rows close to the relevant model histories;
 landed rows that are already mirrored in per-model docs remain here as
@@ -45,6 +45,7 @@ cross-model navigation hints.
 
 | PR | Model / area | Status | Current signal | Why it matters |
 | --- | --- | --- | --- | --- |
+| [#46735](https://github.com/vllm-project/vllm/pull/46735) | Triton / NVFP4 MoE | merged | CUDA graph capture fix | A stale vLLM image can fail graph capture or fall back around Triton MoE; record this before treating the row as a true SGLang-vs-vLLM performance delta. |
 | [#41455](https://github.com/vllm-project/vllm/pull/41455) | ROCm attention | closed | WMMA paged prefill and split-K decode | New AMD attention kernel family for prefill/decode split traces. |
 | [#41263](https://github.com/vllm-project/vllm/pull/41263) | DeepSeek-V4 | merged | fuse norm/router low latency | Mirrored in `vllm/deepseek-v4`; concrete DSV4 norm-router fusion precedent. |
 | [#41428](https://github.com/vllm-project/vllm/pull/41428) | DeepSeek-V4 | merged | fused indexer Q quant | Mirrored in `vllm/deepseek-v4`; relevant to FP4 indexer-Q quant ladders. |

--- a/model-pr-optimization-history/vllm/README.md
+++ b/model-pr-optimization-history/vllm/README.md
@@ -36,7 +36,10 @@ Current model families:
 
 ## Current Watch / Landed Items
 
-Refresh: `2026-05-26`. Keep watch rows close to the relevant model histories;
+Refresh: `2026-06-26`. Source head:
+`vllm-project/vllm@c2507fb2937aa8c8e74bea15719d04fb6090befe`.
+
+Keep watch rows close to the relevant model histories;
 landed rows that are already mirrored in per-model docs remain here as
 cross-model navigation hints.
 

--- a/model-pr-optimization-history/vllm/README.md
+++ b/model-pr-optimization-history/vllm/README.md
@@ -37,7 +37,7 @@ Current model families:
 ## Current Watch / Landed Items
 
 Refresh: `2026-06-26`. Source head:
-`vllm-project/vllm@37ce34922f7f5e58241369511130cd99c1c50bfe`.
+`vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593`.
 
 Keep watch rows close to the relevant model histories;
 landed rows that are already mirrored in per-model docs remain here as
@@ -45,6 +45,7 @@ cross-model navigation hints.
 
 | PR | Model / area | Status | Current signal | Why it matters |
 | --- | --- | --- | --- | --- |
+| [#44800](https://github.com/vllm-project/vllm/pull/44800) | runtime sync debug | merged | `VLLM_GPU_SYNC_CHECK` env var | Helps distinguish real GPU gaps from accidental synchronization in profiler traces; SOTA loop should check whether a target image has this knob before comparing sync-heavy rows. |
 | [#46735](https://github.com/vllm-project/vllm/pull/46735) | Triton / NVFP4 MoE | merged | CUDA graph capture fix | A stale vLLM image can fail graph capture or fall back around Triton MoE; record this before treating the row as a true SGLang-vs-vLLM performance delta. |
 | [#41455](https://github.com/vllm-project/vllm/pull/41455) | ROCm attention | closed | WMMA paged prefill and split-K decode | New AMD attention kernel family for prefill/decode split traces. |
 | [#41263](https://github.com/vllm-project/vllm/pull/41263) | DeepSeek-V4 | merged | fuse norm/router low latency | Mirrored in `vllm/deepseek-v4`; concrete DSV4 norm-router fusion precedent. |

--- a/model-pr-optimization-history/vllm/deepseek-ocr-2/README.en.md
+++ b/model-pr-optimization-history/vllm/deepseek-ocr-2/README.en.md
@@ -1,5 +1,21 @@
 # vllm DeepSeek OCR 2 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 6 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-22 | [#45993](https://github.com/vllm-project/vllm/pull/45993) | [Model] Remove MiniMaxText01, MiniMaxVL01, MiniMaxForCausalLM | `vision_language_offline.py` |
+| 2026-06-17 | [#41992](https://github.com/vllm-project/vllm/pull/41992) | [MM][Perf][CG] Support ViT full CUDA graph for Kimi-VL | `vision_language_offline.py` |
+| 2026-06-16 | [#43586](https://github.com/vllm-project/vllm/pull/43586) | [MM][Perf][CG] Support dual-path ViT full CUDA graph for DeepSeek-OCR | `vision_language_offline.py`, `deepseek_ocr.py` |
+| 2026-06-12 | [#40660](https://github.com/vllm-project/vllm/pull/40660) | [MM][Perf][CG] Support ViT full cudagraphs for mllama4 | `vision_language_offline.py` |
+| 2026-06-10 | [#45131](https://github.com/vllm-project/vllm/pull/45131) | Deprecated 1st generation Qwen and QwenVL models | `vision_language_offline.py` |
+| 2026-06-09 | [#40576](https://github.com/vllm-project/vllm/pull/40576) | [MM][Perf][CG] Support ViT full CUDA graph for glm4_1v image and video inference | `vision_language_offline.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 1 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/deepseek-ocr-2/README.zh.md
+++ b/model-pr-optimization-history/vllm/deepseek-ocr-2/README.zh.md
@@ -1,5 +1,21 @@
 # vllm DeepSeek OCR 2 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 6 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-22 | [#45993](https://github.com/vllm-project/vllm/pull/45993) | [Model] Remove MiniMaxText01, MiniMaxVL01, MiniMaxForCausalLM | `vision_language_offline.py` |
+| 2026-06-17 | [#41992](https://github.com/vllm-project/vllm/pull/41992) | [MM][Perf][CG] Support ViT full CUDA graph for Kimi-VL | `vision_language_offline.py` |
+| 2026-06-16 | [#43586](https://github.com/vllm-project/vllm/pull/43586) | [MM][Perf][CG] Support dual-path ViT full CUDA graph for DeepSeek-OCR | `vision_language_offline.py`, `deepseek_ocr.py` |
+| 2026-06-12 | [#40660](https://github.com/vllm-project/vllm/pull/40660) | [MM][Perf][CG] Support ViT full cudagraphs for mllama4 | `vision_language_offline.py` |
+| 2026-06-10 | [#45131](https://github.com/vllm-project/vllm/pull/45131) | Deprecated 1st generation Qwen and QwenVL models | `vision_language_offline.py` |
+| 2026-06-09 | [#40576](https://github.com/vllm-project/vllm/pull/40576) | [MM][Perf][CG] Support ViT full CUDA graph for glm4_1v image and video inference | `vision_language_offline.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 1 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/deepseek-ocr/README.en.md
+++ b/model-pr-optimization-history/vllm/deepseek-ocr/README.en.md
@@ -1,5 +1,21 @@
 # vllm DeepSeek OCR Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 6 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-22 | [#45993](https://github.com/vllm-project/vllm/pull/45993) | [Model] Remove MiniMaxText01, MiniMaxVL01, MiniMaxForCausalLM | `vision_language_offline.py` |
+| 2026-06-17 | [#41992](https://github.com/vllm-project/vllm/pull/41992) | [MM][Perf][CG] Support ViT full CUDA graph for Kimi-VL | `vision_language_offline.py` |
+| 2026-06-16 | [#43586](https://github.com/vllm-project/vllm/pull/43586) | [MM][Perf][CG] Support dual-path ViT full CUDA graph for DeepSeek-OCR | `vision_language_offline.py`, `deepseek_ocr.py` |
+| 2026-06-12 | [#40660](https://github.com/vllm-project/vllm/pull/40660) | [MM][Perf][CG] Support ViT full cudagraphs for mllama4 | `vision_language_offline.py` |
+| 2026-06-10 | [#45131](https://github.com/vllm-project/vllm/pull/45131) | Deprecated 1st generation Qwen and QwenVL models | `vision_language_multi_image_offline.py`, `vision_language_offline.py` |
+| 2026-06-09 | [#40576](https://github.com/vllm-project/vllm/pull/40576) | [MM][Perf][CG] Support ViT full CUDA graph for glm4_1v image and video inference | `vision_language_offline.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 1 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/deepseek-ocr/README.zh.md
+++ b/model-pr-optimization-history/vllm/deepseek-ocr/README.zh.md
@@ -1,5 +1,21 @@
 # vllm DeepSeek OCR 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 6 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-22 | [#45993](https://github.com/vllm-project/vllm/pull/45993) | [Model] Remove MiniMaxText01, MiniMaxVL01, MiniMaxForCausalLM | `vision_language_offline.py` |
+| 2026-06-17 | [#41992](https://github.com/vllm-project/vllm/pull/41992) | [MM][Perf][CG] Support ViT full CUDA graph for Kimi-VL | `vision_language_offline.py` |
+| 2026-06-16 | [#43586](https://github.com/vllm-project/vllm/pull/43586) | [MM][Perf][CG] Support dual-path ViT full CUDA graph for DeepSeek-OCR | `vision_language_offline.py`, `deepseek_ocr.py` |
+| 2026-06-12 | [#40660](https://github.com/vllm-project/vllm/pull/40660) | [MM][Perf][CG] Support ViT full cudagraphs for mllama4 | `vision_language_offline.py` |
+| 2026-06-10 | [#45131](https://github.com/vllm-project/vllm/pull/45131) | Deprecated 1st generation Qwen and QwenVL models | `vision_language_multi_image_offline.py`, `vision_language_offline.py` |
+| 2026-06-09 | [#40576](https://github.com/vllm-project/vllm/pull/40576) | [MM][Perf][CG] Support ViT full CUDA graph for glm4_1v image and video inference | `vision_language_offline.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 1 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/deepseek-v3-r1/README.en.md
+++ b/model-pr-optimization-history/vllm/deepseek-v3-r1/README.en.md
@@ -1,5 +1,20 @@
 # vllm DeepSeek V3/R1 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 5 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#46651](https://github.com/vllm-project/vllm/pull/46651) | [Perf] Remove redundant clone for GLM, Deepseek etc | `deepseek_v2.py` |
+| 2026-06-20 | [#46199](https://github.com/vllm-project/vllm/pull/46199) | [Bugfix] Move extract_layer_index back inside is_v32 guard | `deepseek_v2.py` |
+| 2026-06-19 | [#45895](https://github.com/vllm-project/vllm/pull/45895) | [bugfix]Indexer init skip and MTP TopK share for iteration | `deepseek_mtp.py`, `deepseek_v2.py` |
+| 2026-06-12 | [#45003](https://github.com/vllm-project/vllm/pull/45003) | [Frontend]  Support strict mode for tool calling | `deepseekv31_tool_parser.py`, `deepseekv32_tool_parser.py`, `deepseekv3_tool_parser.py` |
+| 2026-06-07 | [#44420](https://github.com/vllm-project/vllm/pull/44420) | [feature] add index share feature for DSA MTP | `deepseek_mtp.py`, `deepseek_v2.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 6 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/deepseek-v3-r1/README.zh.md
+++ b/model-pr-optimization-history/vllm/deepseek-v3-r1/README.zh.md
@@ -1,5 +1,20 @@
 # vllm DeepSeek V3/R1 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 5 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#46651](https://github.com/vllm-project/vllm/pull/46651) | [Perf] Remove redundant clone for GLM, Deepseek etc | `deepseek_v2.py` |
+| 2026-06-20 | [#46199](https://github.com/vllm-project/vllm/pull/46199) | [Bugfix] Move extract_layer_index back inside is_v32 guard | `deepseek_v2.py` |
+| 2026-06-19 | [#45895](https://github.com/vllm-project/vllm/pull/45895) | [bugfix]Indexer init skip and MTP TopK share for iteration | `deepseek_mtp.py`, `deepseek_v2.py` |
+| 2026-06-12 | [#45003](https://github.com/vllm-project/vllm/pull/45003) | [Frontend]  Support strict mode for tool calling | `deepseekv31_tool_parser.py`, `deepseekv32_tool_parser.py`, `deepseekv3_tool_parser.py` |
+| 2026-06-07 | [#44420](https://github.com/vllm-project/vllm/pull/44420) | [feature] add index share feature for DSA MTP | `deepseek_mtp.py`, `deepseek_v2.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 6 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/deepseek-v31/README.en.md
+++ b/model-pr-optimization-history/vllm/deepseek-v31/README.en.md
@@ -1,5 +1,20 @@
 # vllm DeepSeek V3.1 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 5 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#46651](https://github.com/vllm-project/vllm/pull/46651) | [Perf] Remove redundant clone for GLM, Deepseek etc | `deepseek_v2.py` |
+| 2026-06-20 | [#46199](https://github.com/vllm-project/vllm/pull/46199) | [Bugfix] Move extract_layer_index back inside is_v32 guard | `deepseek_v2.py` |
+| 2026-06-19 | [#45895](https://github.com/vllm-project/vllm/pull/45895) | [bugfix]Indexer init skip and MTP TopK share for iteration | `deepseek_mtp.py`, `deepseek_v2.py` |
+| 2026-06-12 | [#45003](https://github.com/vllm-project/vllm/pull/45003) | [Frontend]  Support strict mode for tool calling | `deepseekv31_tool_parser.py` |
+| 2026-06-07 | [#44420](https://github.com/vllm-project/vllm/pull/44420) | [feature] add index share feature for DSA MTP | `deepseek_mtp.py`, `deepseek_v2.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 43 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-01-15). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/deepseek-v31/README.zh.md
+++ b/model-pr-optimization-history/vllm/deepseek-v31/README.zh.md
@@ -1,5 +1,20 @@
 # vllm DeepSeek V3.1 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 5 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#46651](https://github.com/vllm-project/vllm/pull/46651) | [Perf] Remove redundant clone for GLM, Deepseek etc | `deepseek_v2.py` |
+| 2026-06-20 | [#46199](https://github.com/vllm-project/vllm/pull/46199) | [Bugfix] Move extract_layer_index back inside is_v32 guard | `deepseek_v2.py` |
+| 2026-06-19 | [#45895](https://github.com/vllm-project/vllm/pull/45895) | [bugfix]Indexer init skip and MTP TopK share for iteration | `deepseek_mtp.py`, `deepseek_v2.py` |
+| 2026-06-12 | [#45003](https://github.com/vllm-project/vllm/pull/45003) | [Frontend]  Support strict mode for tool calling | `deepseekv31_tool_parser.py` |
+| 2026-06-07 | [#44420](https://github.com/vllm-project/vllm/pull/44420) | [feature] add index share feature for DSA MTP | `deepseek_mtp.py`, `deepseek_v2.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-01-15）以来，共有 43 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/deepseek-v32/README.en.md
+++ b/model-pr-optimization-history/vllm/deepseek-v32/README.en.md
@@ -1,5 +1,20 @@
 # vllm DeepSeek V3.2 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 5 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#46651](https://github.com/vllm-project/vllm/pull/46651) | [Perf] Remove redundant clone for GLM, Deepseek etc | `deepseek_v2.py` |
+| 2026-06-20 | [#46199](https://github.com/vllm-project/vllm/pull/46199) | [Bugfix] Move extract_layer_index back inside is_v32 guard | `deepseek_v2.py` |
+| 2026-06-19 | [#45895](https://github.com/vllm-project/vllm/pull/45895) | [bugfix]Indexer init skip and MTP TopK share for iteration | `deepseek_mtp.py`, `deepseek_v2.py` |
+| 2026-06-12 | [#45003](https://github.com/vllm-project/vllm/pull/45003) | [Frontend]  Support strict mode for tool calling | `deepseekv32_tool_parser.py` |
+| 2026-06-07 | [#44420](https://github.com/vllm-project/vllm/pull/44420) | [feature] add index share feature for DSA MTP | `deepseek_mtp.py`, `deepseek_v2.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 6 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/deepseek-v32/README.zh.md
+++ b/model-pr-optimization-history/vllm/deepseek-v32/README.zh.md
@@ -1,5 +1,20 @@
 # vllm DeepSeek V3.2 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 5 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#46651](https://github.com/vllm-project/vllm/pull/46651) | [Perf] Remove redundant clone for GLM, Deepseek etc | `deepseek_v2.py` |
+| 2026-06-20 | [#46199](https://github.com/vllm-project/vllm/pull/46199) | [Bugfix] Move extract_layer_index back inside is_v32 guard | `deepseek_v2.py` |
+| 2026-06-19 | [#45895](https://github.com/vllm-project/vllm/pull/45895) | [bugfix]Indexer init skip and MTP TopK share for iteration | `deepseek_mtp.py`, `deepseek_v2.py` |
+| 2026-06-12 | [#45003](https://github.com/vllm-project/vllm/pull/45003) | [Frontend]  Support strict mode for tool calling | `deepseekv32_tool_parser.py` |
+| 2026-06-07 | [#44420](https://github.com/vllm-project/vllm/pull/44420) | [feature] add index share feature for DSA MTP | `deepseek_mtp.py`, `deepseek_v2.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 6 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/deepseek-v4/README.en.md
+++ b/model-pr-optimization-history/vllm/deepseek-v4/README.en.md
@@ -1,5 +1,17 @@
 # vllm DeepSeek V4 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 2 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-23 | [#46428](https://github.com/vllm-project/vllm/pull/46428) | [Optimization] Skip DP padding tokens in MoE | `test_deepseek_v4_mega_moe.py` |
+| 2026-06-18 | [#45681](https://github.com/vllm-project/vllm/pull/45681) | [ROCm][DSv4] Functional fixes for DeepSeek V4 on MI300X/MI325X | `test_fused_deepseek_v4_qnorm_rope_kv_insert.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 4 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/deepseek-v4/README.zh.md
+++ b/model-pr-optimization-history/vllm/deepseek-v4/README.zh.md
@@ -1,5 +1,17 @@
 # vllm DeepSeek V4 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 2 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-23 | [#46428](https://github.com/vllm-project/vllm/pull/46428) | [Optimization] Skip DP padding tokens in MoE | `test_deepseek_v4_mega_moe.py` |
+| 2026-06-18 | [#45681](https://github.com/vllm-project/vllm/pull/45681) | [ROCm][DSv4] Functional fixes for DeepSeek V4 on MI300X/MI325X | `test_fused_deepseek_v4_qnorm_rope_kv_insert.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 4 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/ernie45/README.en.md
+++ b/model-pr-optimization-history/vllm/ernie45/README.en.md
@@ -1,5 +1,17 @@
 # vllm ERNIE 4.5 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 2 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#45988](https://github.com/vllm-project/vllm/pull/45988) | [Perf] Remove unused loggers in `reasoning/` | `ernie45_reasoning_parser.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `ernie45_moe.py`, `ernie45_vl_moe.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 5 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-14). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/ernie45/README.zh.md
+++ b/model-pr-optimization-history/vllm/ernie45/README.zh.md
@@ -1,5 +1,17 @@
 # vllm ERNIE 4.5 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 2 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#45988](https://github.com/vllm-project/vllm/pull/45988) | [Perf] Remove unused loggers in `reasoning/` | `ernie45_reasoning_parser.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `ernie45_moe.py`, `ernie45_vl_moe.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-04-14）以来，共有 5 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/gemma4/README.en.md
+++ b/model-pr-optimization-history/vllm/gemma4/README.en.md
@@ -1,5 +1,23 @@
 # vllm Gemma 4 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 8 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-17 | [#45867](https://github.com/vllm-project/vllm/pull/45867) | [Bugfix][Gemma4] Render reasoning on assistant turns without tool_calls | `tool_chat_template_gemma4.jinja` |
+| 2026-06-17 | [#45832](https://github.com/vllm-project/vllm/pull/45832) | [Bugfix][Gemma4] Fix parsing when thinking is disabled | `test_gemma4_responses_adjust_request.py` |
+| 2026-06-16 | [#45795](https://github.com/vllm-project/vllm/pull/45795) | [Bugfix] Gemma4: skip forced JSON for required/named tool choice | `test_gemma4_responses_adjust_request.py` |
+| 2026-06-16 | [#45553](https://github.com/vllm-project/vllm/pull/45553) | [Bugfix][Gemma4] Fix offline parser truncation, adjust_request token leak, and chat template sync | `tool_chat_template_gemma4.jinja`, `test_gemma4_reasoning_parser.py`, `test_gemma4_chat_template.py`, `gemma4_utils.py` |
+| 2026-06-15 | [#45588](https://github.com/vllm-project/vllm/pull/45588) | [Frontend] Replace legacy Gemma4 parsers with engine-based implementation | `test_gemma4_reasoning_parser.py`, `test_gemma4_tool_parser.py`, `test_gemma4_responses_adjust_request.py`, `gemma4_reasoning_parser.py`, ... (+1) |
+| 2026-06-12 | [#45163](https://github.com/vllm-project/vllm/pull/45163) | [Model] Add DiffusionGemma Support | `test_gemma4_tool_parser.py`, `gemma4.py`, `gemma4_tool_parser.py` |
+| 2026-06-08 | [#44828](https://github.com/vllm-project/vllm/pull/44828) | [BugFix] Use served model name in gemma4 audio-tower error message | `gemma4_mm.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `gemma4.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 20 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-30). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/gemma4/README.zh.md
+++ b/model-pr-optimization-history/vllm/gemma4/README.zh.md
@@ -1,5 +1,23 @@
 # vllm Gemma 4 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 8 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-17 | [#45867](https://github.com/vllm-project/vllm/pull/45867) | [Bugfix][Gemma4] Render reasoning on assistant turns without tool_calls | `tool_chat_template_gemma4.jinja` |
+| 2026-06-17 | [#45832](https://github.com/vllm-project/vllm/pull/45832) | [Bugfix][Gemma4] Fix parsing when thinking is disabled | `test_gemma4_responses_adjust_request.py` |
+| 2026-06-16 | [#45795](https://github.com/vllm-project/vllm/pull/45795) | [Bugfix] Gemma4: skip forced JSON for required/named tool choice | `test_gemma4_responses_adjust_request.py` |
+| 2026-06-16 | [#45553](https://github.com/vllm-project/vllm/pull/45553) | [Bugfix][Gemma4] Fix offline parser truncation, adjust_request token leak, and chat template sync | `tool_chat_template_gemma4.jinja`, `test_gemma4_reasoning_parser.py`, `test_gemma4_chat_template.py`, `gemma4_utils.py` |
+| 2026-06-15 | [#45588](https://github.com/vllm-project/vllm/pull/45588) | [Frontend] Replace legacy Gemma4 parsers with engine-based implementation | `test_gemma4_reasoning_parser.py`, `test_gemma4_tool_parser.py`, `test_gemma4_responses_adjust_request.py`, `gemma4_reasoning_parser.py`, ... (+1) |
+| 2026-06-12 | [#45163](https://github.com/vllm-project/vllm/pull/45163) | [Model] Add DiffusionGemma Support | `test_gemma4_tool_parser.py`, `gemma4.py`, `gemma4_tool_parser.py` |
+| 2026-06-08 | [#44828](https://github.com/vllm-project/vllm/pull/44828) | [BugFix] Use served model name in gemma4 audio-tower error message | `gemma4_mm.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `gemma4.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-04-30）以来，共有 20 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/glm-vlm-ocr/README.en.md
+++ b/model-pr-optimization-history/vllm/glm-vlm-ocr/README.en.md
@@ -1,5 +1,17 @@
 # vllm GLM VLM/OCR Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 2 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-16 | [#43586](https://github.com/vllm-project/vllm/pull/43586) | [MM][Perf][CG] Support dual-path ViT full CUDA graph for DeepSeek-OCR | `glm4_1v.py` |
+| 2026-06-09 | [#40576](https://github.com/vllm-project/vllm/pull/40576) | [MM][Perf][CG] Support ViT full CUDA graph for glm4_1v image and video inference | `glm4_1v.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 5 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-03-26). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/glm-vlm-ocr/README.zh.md
+++ b/model-pr-optimization-history/vllm/glm-vlm-ocr/README.zh.md
@@ -1,5 +1,17 @@
 # vllm GLM VLM/OCR 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 2 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-16 | [#43586](https://github.com/vllm-project/vllm/pull/43586) | [MM][Perf][CG] Support dual-path ViT full CUDA graph for DeepSeek-OCR | `glm4_1v.py` |
+| 2026-06-09 | [#40576](https://github.com/vllm-project/vllm/pull/40576) | [MM][Perf][CG] Support ViT full CUDA graph for glm4_1v image and video inference | `glm4_1v.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-03-26）以来，共有 5 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/glm45/README.en.md
+++ b/model-pr-optimization-history/vllm/glm45/README.en.md
@@ -1,5 +1,18 @@
 # vllm GLM-4.5 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 3 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#46651](https://github.com/vllm-project/vllm/pull/46651) | [Perf] Remove redundant clone for GLM, Deepseek etc | `glm4_moe_lite.py` |
+| 2026-06-18 | [#45915](https://github.com/vllm-project/vllm/pull/45915) | [Frontend] Add Streaming Parser Engine and new GLM4.7/GLM5.1/GLM5.2 Parser | `test_glm4_moe_reasoning_parser.py`, `test_glm4_moe_tool_parser.py`, `glm4_moe_tool_parser.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `glm4_moe_lite_mtp.py`, `glm4_moe_mtp.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 39 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2025-11-17). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/glm45/README.zh.md
+++ b/model-pr-optimization-history/vllm/glm45/README.zh.md
@@ -1,5 +1,18 @@
 # vllm GLM-4.5 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 3 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#46651](https://github.com/vllm-project/vllm/pull/46651) | [Perf] Remove redundant clone for GLM, Deepseek etc | `glm4_moe_lite.py` |
+| 2026-06-18 | [#45915](https://github.com/vllm-project/vllm/pull/45915) | [Frontend] Add Streaming Parser Engine and new GLM4.7/GLM5.1/GLM5.2 Parser | `test_glm4_moe_reasoning_parser.py`, `test_glm4_moe_tool_parser.py`, `glm4_moe_tool_parser.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `glm4_moe_lite_mtp.py`, `glm4_moe_mtp.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2025-11-17）以来，共有 39 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/glm46-glm47/README.en.md
+++ b/model-pr-optimization-history/vllm/glm46-glm47/README.en.md
@@ -1,5 +1,19 @@
 # vllm GLM-4.6/4.7 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 4 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#46651](https://github.com/vllm-project/vllm/pull/46651) | [Perf] Remove redundant clone for GLM, Deepseek etc | `glm4_moe_lite.py` |
+| 2026-06-18 | [#45915](https://github.com/vllm-project/vllm/pull/45915) | [Frontend] Add Streaming Parser Engine and new GLM4.7/GLM5.1/GLM5.2 Parser | `test_glm4_moe_reasoning_parser.py`, `test_glm47_moe_tool_parser.py`, `test_glm4_moe_tool_parser.py`, `glm47_moe_tool_parser.py`, ... (+1) |
+| 2026-06-12 | [#45003](https://github.com/vllm-project/vllm/pull/45003) | [Frontend]  Support strict mode for tool calling | `glm47_moe_tool_parser.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `glm4_moe_lite_mtp.py`, `glm4_moe_mtp.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 13 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-03-18). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/glm46-glm47/README.zh.md
+++ b/model-pr-optimization-history/vllm/glm46-glm47/README.zh.md
@@ -1,5 +1,19 @@
 # vllm GLM-4.6/4.7 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 4 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#46651](https://github.com/vllm-project/vllm/pull/46651) | [Perf] Remove redundant clone for GLM, Deepseek etc | `glm4_moe_lite.py` |
+| 2026-06-18 | [#45915](https://github.com/vllm-project/vllm/pull/45915) | [Frontend] Add Streaming Parser Engine and new GLM4.7/GLM5.1/GLM5.2 Parser | `test_glm4_moe_reasoning_parser.py`, `test_glm47_moe_tool_parser.py`, `test_glm4_moe_tool_parser.py`, `glm47_moe_tool_parser.py`, ... (+1) |
+| 2026-06-12 | [#45003](https://github.com/vllm-project/vllm/pull/45003) | [Frontend]  Support strict mode for tool calling | `glm47_moe_tool_parser.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `glm4_moe_lite_mtp.py`, `glm4_moe_mtp.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-03-18）以来，共有 13 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/gpt-oss/README.en.md
+++ b/model-pr-optimization-history/vllm/gpt-oss/README.en.md
@@ -1,5 +1,25 @@
 # vllm GPT-OSS Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 10 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-24 | [#46408](https://github.com/vllm-project/vllm/pull/46408) | [Bugfix] Support -1 (invalid/non-local) slots in topk_ids for Triton MoE | `gpt_oss_triton_kernels_moe.py` |
+| 2026-06-24 | [#46406](https://github.com/vllm-project/vllm/pull/46406) | [Bugfix] Support non-power-of-2 top_k in legacy triton_kernels routing | `gpt_oss_triton_kernels_moe.py` |
+| 2026-06-23 | [#46441](https://github.com/vllm-project/vllm/pull/46441) | fix gpt_oss pp>1 with ep | `gpt_oss.py` |
+| 2026-06-23 | [#46142](https://github.com/vllm-project/vllm/pull/46142) | [AMD][OCP MX][CI] Fix tests to not dispatch on `UNFUSED_TRITON` backend on MI300, improve w_mxfp4_a_fp8 emulation support | `test_gpt_oss.py` |
+| 2026-06-23 | [#45818](https://github.com/vllm-project/vllm/pull/45818) | [Bugfix]: Fix unquantized gpt-oss weight loading broken by FusedMoE r… | `gpt_oss.py` |
+| 2026-06-17 | [#45896](https://github.com/vllm-project/vllm/pull/45896) | [feature] MiniMax-M3-MXFP4 support added | `gpt_oss_triton_kernels_moe.py` |
+| 2026-06-15 | [#45381](https://github.com/vllm-project/vllm/pull/45381) | [Model] Add MiniMax M3 support | `gpt_oss_triton_kernels_moe.py` |
+| 2026-06-11 | [#44992](https://github.com/vllm-project/vllm/pull/44992) | Deprecations for v0.23 and v0.24 | `gpt-oss-20b-marlin.yaml`, `models-b200.txt`, `models-h100.txt` |
+| 2026-06-11 | [#45067](https://github.com/vllm-project/vllm/pull/45067) | [Bugfix]: Fix Quark gpt-oss weight loading broken by FusedMoe refactor | `gpt_oss.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `gpt_oss.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 14 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-14). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/gpt-oss/README.zh.md
+++ b/model-pr-optimization-history/vllm/gpt-oss/README.zh.md
@@ -1,5 +1,25 @@
 # vllm GPT-OSS 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 10 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-24 | [#46408](https://github.com/vllm-project/vllm/pull/46408) | [Bugfix] Support -1 (invalid/non-local) slots in topk_ids for Triton MoE | `gpt_oss_triton_kernels_moe.py` |
+| 2026-06-24 | [#46406](https://github.com/vllm-project/vllm/pull/46406) | [Bugfix] Support non-power-of-2 top_k in legacy triton_kernels routing | `gpt_oss_triton_kernels_moe.py` |
+| 2026-06-23 | [#46441](https://github.com/vllm-project/vllm/pull/46441) | fix gpt_oss pp>1 with ep | `gpt_oss.py` |
+| 2026-06-23 | [#46142](https://github.com/vllm-project/vllm/pull/46142) | [AMD][OCP MX][CI] Fix tests to not dispatch on `UNFUSED_TRITON` backend on MI300, improve w_mxfp4_a_fp8 emulation support | `test_gpt_oss.py` |
+| 2026-06-23 | [#45818](https://github.com/vllm-project/vllm/pull/45818) | [Bugfix]: Fix unquantized gpt-oss weight loading broken by FusedMoE r… | `gpt_oss.py` |
+| 2026-06-17 | [#45896](https://github.com/vllm-project/vllm/pull/45896) | [feature] MiniMax-M3-MXFP4 support added | `gpt_oss_triton_kernels_moe.py` |
+| 2026-06-15 | [#45381](https://github.com/vllm-project/vllm/pull/45381) | [Model] Add MiniMax M3 support | `gpt_oss_triton_kernels_moe.py` |
+| 2026-06-11 | [#44992](https://github.com/vllm-project/vllm/pull/44992) | Deprecations for v0.23 and v0.24 | `gpt-oss-20b-marlin.yaml`, `models-b200.txt`, `models-h100.txt` |
+| 2026-06-11 | [#45067](https://github.com/vllm-project/vllm/pull/45067) | [Bugfix]: Fix Quark gpt-oss weight loading broken by FusedMoe refactor | `gpt_oss.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `gpt_oss.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-04-14）以来，共有 14 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/intern-s1/README.en.md
+++ b/model-pr-optimization-history/vllm/intern-s1/README.en.md
@@ -1,5 +1,16 @@
 # vllm Intern-S1 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 1 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-12 | [#45129](https://github.com/vllm-project/vllm/pull/45129) | [Model] Remove Mono-InternVL (InternLM2VEForCausalLM) | `internlm2_ve.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 15 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-02-04). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/intern-s1/README.zh.md
+++ b/model-pr-optimization-history/vllm/intern-s1/README.zh.md
@@ -1,5 +1,16 @@
 # vllm Intern-S1 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 1 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-12 | [#45129](https://github.com/vllm-project/vllm/pull/45129) | [Model] Remove Mono-InternVL (InternLM2VEForCausalLM) | `internlm2_ve.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-02-04）以来，共有 15 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/internvl35/README.en.md
+++ b/model-pr-optimization-history/vllm/internvl35/README.en.md
@@ -1,5 +1,18 @@
 # vllm InternVL 3.5 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 3 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#42727](https://github.com/vllm-project/vllm/pull/42727) | fix(quantization): Fix AWQ dequantize on Intel XPU and refactor AutoAWQ config | `internvl.py` |
+| 2026-06-16 | [#43586](https://github.com/vllm-project/vllm/pull/43586) | [MM][Perf][CG] Support dual-path ViT full CUDA graph for DeepSeek-OCR | `internvl.py` |
+| 2026-06-12 | [#45129](https://github.com/vllm-project/vllm/pull/45129) | [Model] Remove Mono-InternVL (InternLM2VEForCausalLM) | `internvl.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 5 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-03-26). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/internvl35/README.zh.md
+++ b/model-pr-optimization-history/vllm/internvl35/README.zh.md
@@ -1,5 +1,18 @@
 # vllm InternVL 3.5 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 3 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#42727](https://github.com/vllm-project/vllm/pull/42727) | fix(quantization): Fix AWQ dequantize on Intel XPU and refactor AutoAWQ config | `internvl.py` |
+| 2026-06-16 | [#43586](https://github.com/vllm-project/vllm/pull/43586) | [MM][Perf][CG] Support dual-path ViT full CUDA graph for DeepSeek-OCR | `internvl.py` |
+| 2026-06-12 | [#45129](https://github.com/vllm-project/vllm/pull/45129) | [Model] Remove Mono-InternVL (InternLM2VEForCausalLM) | `internvl.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-03-26）以来，共有 5 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/jina-reranker-m0/README.en.md
+++ b/model-pr-optimization-history/vllm/jina-reranker-m0/README.en.md
@@ -1,5 +1,17 @@
 # vllm Jina Reranker M0 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 2 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-23 | [#46398](https://github.com/vllm-project/vllm/pull/46398) | [Doc] Fix typos, grammar, and broken commands across docs | `scoring.md` |
+| 2026-06-15 | [#45676](https://github.com/vllm-project/vllm/pull/45676) | [Docs] Update the online serving docs. | `scoring.md` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 1 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/jina-reranker-m0/README.zh.md
+++ b/model-pr-optimization-history/vllm/jina-reranker-m0/README.zh.md
@@ -1,5 +1,17 @@
 # vllm Jina Reranker M0 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 2 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-23 | [#46398](https://github.com/vllm-project/vllm/pull/46398) | [Doc] Fix typos, grammar, and broken commands across docs | `scoring.md` |
+| 2026-06-15 | [#45676](https://github.com/vllm-project/vllm/pull/45676) | [Docs] Update the online serving docs. | `scoring.md` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 1 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/kimi/README.en.md
+++ b/model-pr-optimization-history/vllm/kimi/README.en.md
@@ -1,5 +1,18 @@
 # vllm Kimi K2/K2.5/Linear/VL Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 3 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-21 | [#45424](https://github.com/vllm-project/vllm/pull/45424) | [Core] Ensure memory is pinned prior to async h2d copy | `moonvit.py` |
+| 2026-06-17 | [#41992](https://github.com/vllm-project/vllm/pull/41992) | [MM][Perf][CG] Support ViT full CUDA graph for Kimi-VL | `kimi_vl.py`, `moonvit.py` |
+| 2026-06-12 | [#45003](https://github.com/vllm-project/vllm/pull/45003) | [Frontend]  Support strict mode for tool calling | `kimi_k2_tool_parser.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 4 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/kimi/README.zh.md
+++ b/model-pr-optimization-history/vllm/kimi/README.zh.md
@@ -1,5 +1,18 @@
 # vllm Kimi K2/K2.5/Linear/VL 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 3 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-21 | [#45424](https://github.com/vllm-project/vllm/pull/45424) | [Core] Ensure memory is pinned prior to async h2d copy | `moonvit.py` |
+| 2026-06-17 | [#41992](https://github.com/vllm-project/vllm/pull/41992) | [MM][Perf][CG] Support ViT full CUDA graph for Kimi-VL | `kimi_vl.py`, `moonvit.py` |
+| 2026-06-12 | [#45003](https://github.com/vllm-project/vllm/pull/45003) | [Frontend]  Support strict mode for tool calling | `kimi_k2_tool_parser.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 4 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/ling25/README.en.md
+++ b/model-pr-optimization-history/vllm/ling25/README.en.md
@@ -1,5 +1,16 @@
 # vllm Ling 2.5 1T Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 1 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `bailing_moe_linear.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 3 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/ling25/README.zh.md
+++ b/model-pr-optimization-history/vllm/ling25/README.zh.md
@@ -1,5 +1,16 @@
 # vllm Ling 2.5 1T 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 1 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `bailing_moe_linear.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 3 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/llama31/README.en.md
+++ b/model-pr-optimization-history/vllm/llama31/README.en.md
@@ -1,5 +1,16 @@
 # vllm Llama 3.1 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 1 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-11 | [#44992](https://github.com/vllm-project/vllm/pull/44992) | Deprecations for v0.23 and v0.24 | `test_async_tp.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 3 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/llama31/README.zh.md
+++ b/model-pr-optimization-history/vllm/llama31/README.zh.md
@@ -1,5 +1,16 @@
 # vllm Llama 3.1 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 1 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-11 | [#44992](https://github.com/vllm-project/vllm/pull/44992) | Deprecations for v0.23 and v0.24 | `test_async_tp.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 3 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/llama33-70b/README.en.md
+++ b/model-pr-optimization-history/vllm/llama33-70b/README.en.md
@@ -1,5 +1,16 @@
 # vllm Llama 3.3 70B Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 1 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-16 | [#42726](https://github.com/vllm-project/vllm/pull/42726) | [ZenCPU] Add zencpu Platform Runtime Logging and Docs | `cpu.md` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 1 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/llama33-70b/README.zh.md
+++ b/model-pr-optimization-history/vllm/llama33-70b/README.zh.md
@@ -1,5 +1,16 @@
 # vllm Llama 3.3 70B 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 1 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-16 | [#42726](https://github.com/vllm-project/vllm/pull/42726) | [ZenCPU] Add zencpu Platform Runtime Logging and Docs | `cpu.md` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 1 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/llama4/README.en.md
+++ b/model-pr-optimization-history/vllm/llama4/README.en.md
@@ -1,5 +1,21 @@
 # vllm Llama 4 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 6 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-16 | [#43586](https://github.com/vllm-project/vllm/pull/43586) | [MM][Perf][CG] Support dual-path ViT full CUDA graph for DeepSeek-OCR | `mllama4.py` |
+| 2026-06-15 | [#44645](https://github.com/vllm-project/vllm/pull/44645) | [Bugfix] Stream Llama4 weight loading to avoid host-OOM with copy-returning loaders | `llama4.py`, `mllama4.py` |
+| 2026-06-12 | [#39612](https://github.com/vllm-project/vllm/pull/39612) | [Migration] Migrate GGUF quantization support to plugin | `llama4.py` |
+| 2026-06-12 | [#40660](https://github.com/vllm-project/vllm/pull/40660) | [MM][Perf][CG] Support ViT full cudagraphs for mllama4 | `mllama4.py` |
+| 2026-06-10 | [#45047](https://github.com/vllm-project/vllm/pull/45047) | [Bugfix] Fix Llama4 weight loading | `llama4.py`, `mllama4.py` |
+| 2026-06-10 | [#39419](https://github.com/vllm-project/vllm/pull/39419) | [SpecDecode] Reduce TP communication for large-vocab draft models speculative decoding | `llama4_eagle.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 14 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-02-24). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/llama4/README.zh.md
+++ b/model-pr-optimization-history/vllm/llama4/README.zh.md
@@ -1,5 +1,21 @@
 # vllm Llama 4 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 6 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-16 | [#43586](https://github.com/vllm-project/vllm/pull/43586) | [MM][Perf][CG] Support dual-path ViT full CUDA graph for DeepSeek-OCR | `mllama4.py` |
+| 2026-06-15 | [#44645](https://github.com/vllm-project/vllm/pull/44645) | [Bugfix] Stream Llama4 weight loading to avoid host-OOM with copy-returning loaders | `llama4.py`, `mllama4.py` |
+| 2026-06-12 | [#39612](https://github.com/vllm-project/vllm/pull/39612) | [Migration] Migrate GGUF quantization support to plugin | `llama4.py` |
+| 2026-06-12 | [#40660](https://github.com/vllm-project/vllm/pull/40660) | [MM][Perf][CG] Support ViT full cudagraphs for mllama4 | `mllama4.py` |
+| 2026-06-10 | [#45047](https://github.com/vllm-project/vllm/pull/45047) | [Bugfix] Fix Llama4 weight loading | `llama4.py`, `mllama4.py` |
+| 2026-06-10 | [#39419](https://github.com/vllm-project/vllm/pull/39419) | [SpecDecode] Reduce TP communication for large-vocab draft models speculative decoding | `llama4_eagle.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-02-24）以来，共有 14 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/mimo-v2-flash/README.en.md
+++ b/model-pr-optimization-history/vllm/mimo-v2-flash/README.en.md
@@ -1,5 +1,17 @@
 # vllm MiMo V2 Flash Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 2 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-15 | [#45200](https://github.com/vllm-project/vllm/pull/45200) | [Models] Fix MiMo v2.x QKV TP sharding + FP4 support | `mimo_v2.py` |
+| 2026-06-11 | [#41797](https://github.com/vllm-project/vllm/pull/41797) | [Attention] add triton diff-kv backend for mimo | `mimo_v2.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 1 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/mimo-v2-flash/README.zh.md
+++ b/model-pr-optimization-history/vllm/mimo-v2-flash/README.zh.md
@@ -1,5 +1,17 @@
 # vllm MiMo V2 Flash 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 2 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-15 | [#45200](https://github.com/vllm-project/vllm/pull/45200) | [Models] Fix MiMo v2.x QKV TP sharding + FP4 support | `mimo_v2.py` |
+| 2026-06-11 | [#41797](https://github.com/vllm-project/vllm/pull/41797) | [Attention] add triton diff-kv backend for mimo | `mimo_v2.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 1 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/minimax/README.en.md
+++ b/model-pr-optimization-history/vllm/minimax/README.en.md
@@ -1,5 +1,20 @@
 # vllm MiniMax M2 Series Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 5 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-22 | [#45993](https://github.com/vllm-project/vllm/pull/45993) | [Model] Remove MiniMaxText01, MiniMaxVL01, MiniMaxForCausalLM | `tool_chat_template_minimax_m1.jinja`, `test_minimax_vl_01.py`, `test_minimax_tool_parser.py`, `minimax_text_01.py`, ... (+2) |
+| 2026-06-21 | [#45935](https://github.com/vllm-project/vllm/pull/45935) | [Model]Fix MiniMaxM2ForCausalLM perf  regression | `test_minimax_reduce_rms.py` |
+| 2026-06-18 | [#45988](https://github.com/vllm-project/vllm/pull/45988) | [Perf] Remove unused loggers in `reasoning/` | `minimax_m2_reasoning_parser.py` |
+| 2026-06-16 | [#45701](https://github.com/vllm-project/vllm/pull/45701) | [Frontend] Add Streaming Parser Engine and new MinimaxM2 Parser | `test_minimax_m2_reasoning_parser.py`, `test_minimax_m2_tool_parser.py`, `minimax_m2_reasoning_parser.py`, `minimax_m2_tool_parser.py` |
+| 2026-06-12 | [#45003](https://github.com/vllm-project/vllm/pull/45003) | [Frontend]  Support strict mode for tool calling | `minimax_m2_tool_parser.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 5 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/minimax/README.zh.md
+++ b/model-pr-optimization-history/vllm/minimax/README.zh.md
@@ -1,5 +1,20 @@
 # vllm MiniMax M2 Series 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 5 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-22 | [#45993](https://github.com/vllm-project/vllm/pull/45993) | [Model] Remove MiniMaxText01, MiniMaxVL01, MiniMaxForCausalLM | `tool_chat_template_minimax_m1.jinja`, `test_minimax_vl_01.py`, `test_minimax_tool_parser.py`, `minimax_text_01.py`, ... (+2) |
+| 2026-06-21 | [#45935](https://github.com/vllm-project/vllm/pull/45935) | [Model]Fix MiniMaxM2ForCausalLM perf  regression | `test_minimax_reduce_rms.py` |
+| 2026-06-18 | [#45988](https://github.com/vllm-project/vllm/pull/45988) | [Perf] Remove unused loggers in `reasoning/` | `minimax_m2_reasoning_parser.py` |
+| 2026-06-16 | [#45701](https://github.com/vllm-project/vllm/pull/45701) | [Frontend] Add Streaming Parser Engine and new MinimaxM2 Parser | `test_minimax_m2_reasoning_parser.py`, `test_minimax_m2_tool_parser.py`, `minimax_m2_reasoning_parser.py`, `minimax_m2_tool_parser.py` |
+| 2026-06-12 | [#45003](https://github.com/vllm-project/vllm/pull/45003) | [Frontend]  Support strict mode for tool calling | `minimax_m2_tool_parser.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 5 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/mistral-small-4/README.en.md
+++ b/model-pr-optimization-history/vllm/mistral-small-4/README.en.md
@@ -1,5 +1,19 @@
 # vllm Mistral Small 4 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 4 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#45988](https://github.com/vllm-project/vllm/pull/45988) | [Perf] Remove unused loggers in `reasoning/` | `mistral_reasoning_parser.py` |
+| 2026-06-12 | [#45217](https://github.com/vllm-project/vllm/pull/45217) | [Bugfix] Initialize missing attributes in mistral eagle | `mistral_large_3_eagle.py` |
+| 2026-06-11 | [#45161](https://github.com/vllm-project/vllm/pull/45161) | Deprecate Transformers v4 support | `mistral.py` |
+| 2026-06-10 | [#44596](https://github.com/vllm-project/vllm/pull/44596) | [Refactor][Mistral] Extract parsing logic into MistralParser | `test_mistral_tool_parser.py`, `mistral_reasoning_parser.py`, `mistral_tool_parser.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 5 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-28). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/mistral-small-4/README.zh.md
+++ b/model-pr-optimization-history/vllm/mistral-small-4/README.zh.md
@@ -1,5 +1,19 @@
 # vllm Mistral Small 4 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 4 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-18 | [#45988](https://github.com/vllm-project/vllm/pull/45988) | [Perf] Remove unused loggers in `reasoning/` | `mistral_reasoning_parser.py` |
+| 2026-06-12 | [#45217](https://github.com/vllm-project/vllm/pull/45217) | [Bugfix] Initialize missing attributes in mistral eagle | `mistral_large_3_eagle.py` |
+| 2026-06-11 | [#45161](https://github.com/vllm-project/vllm/pull/45161) | Deprecate Transformers v4 support | `mistral.py` |
+| 2026-06-10 | [#44596](https://github.com/vllm-project/vllm/pull/44596) | [Refactor][Mistral] Extract parsing logic into MistralParser | `test_mistral_tool_parser.py`, `mistral_reasoning_parser.py`, `mistral_tool_parser.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-04-28）以来，共有 5 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/mixtral-quark-int4fp8-moe/README.en.md
+++ b/model-pr-optimization-history/vllm/mixtral-quark-int4fp8-moe/README.en.md
@@ -1,5 +1,23 @@
 # vllm Mixtral Quark INT4/FP8 MoE Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 8 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-23 | [#46142](https://github.com/vllm-project/vllm/pull/46142) | [AMD][OCP MX][CI] Fix tests to not dispatch on `UNFUSED_TRITON` backend on MI300, improve w_mxfp4_a_fp8 emulation support | `test_quark.py`, `quark_moe.py` |
+| 2026-06-22 | [#43721](https://github.com/vllm-project/vllm/pull/43721) | [ROCm][Quantization][4/N] refactor quark_moe fp8 w/ oracle | `quark_moe.py` |
+| 2026-06-17 | [#45896](https://github.com/vllm-project/vllm/pull/45896) | [feature] MiniMax-M3-MXFP4 support added | `quark_moe.py` |
+| 2026-06-17 | [#44626](https://github.com/vllm-project/vllm/pull/44626) | [ROCm][AITER][Quark] Tag per-channel FP8 weights as PER_CHANNEL so AITER pre-shuffled GEMM is selected | `quark_w8a8_fp8.py` |
+| 2026-06-15 | [#43981](https://github.com/vllm-project/vllm/pull/43981) | [AMD][Bugfix][Quantization] Honor fused-name match in is_layer_skipped | `test_quark.py` |
+| 2026-06-10 | [#39498](https://github.com/vllm-project/vllm/pull/39498) | [Bugfix] Add deepseek_v32 to Quark dynamic MXFP4 model type check | `quark.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `test_quark.py` |
+| 2026-06-05 | [#44635](https://github.com/vllm-project/vllm/pull/44635) | Speed up docs build | `quark.py`, `quark_scheme.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 14 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-29). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/mixtral-quark-int4fp8-moe/README.zh.md
+++ b/model-pr-optimization-history/vllm/mixtral-quark-int4fp8-moe/README.zh.md
@@ -1,5 +1,23 @@
 # vllm Mixtral Quark INT4/FP8 MoE 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 8 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-23 | [#46142](https://github.com/vllm-project/vllm/pull/46142) | [AMD][OCP MX][CI] Fix tests to not dispatch on `UNFUSED_TRITON` backend on MI300, improve w_mxfp4_a_fp8 emulation support | `test_quark.py`, `quark_moe.py` |
+| 2026-06-22 | [#43721](https://github.com/vllm-project/vllm/pull/43721) | [ROCm][Quantization][4/N] refactor quark_moe fp8 w/ oracle | `quark_moe.py` |
+| 2026-06-17 | [#45896](https://github.com/vllm-project/vllm/pull/45896) | [feature] MiniMax-M3-MXFP4 support added | `quark_moe.py` |
+| 2026-06-17 | [#44626](https://github.com/vllm-project/vllm/pull/44626) | [ROCm][AITER][Quark] Tag per-channel FP8 weights as PER_CHANNEL so AITER pre-shuffled GEMM is selected | `quark_w8a8_fp8.py` |
+| 2026-06-15 | [#43981](https://github.com/vllm-project/vllm/pull/43981) | [AMD][Bugfix][Quantization] Honor fused-name match in is_layer_skipped | `test_quark.py` |
+| 2026-06-10 | [#39498](https://github.com/vllm-project/vllm/pull/39498) | [Bugfix] Add deepseek_v32 to Quark dynamic MXFP4 model type check | `quark.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `test_quark.py` |
+| 2026-06-05 | [#44635](https://github.com/vllm-project/vllm/pull/44635) | Speed up docs build | `quark.py`, `quark_scheme.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-04-29）以来，共有 14 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/nemotron-super/README.en.md
+++ b/model-pr-optimization-history/vllm/nemotron-super/README.en.md
@@ -1,5 +1,21 @@
 # vllm Nemotron Super Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 6 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-24 | [#46495](https://github.com/vllm-project/vllm/pull/46495) | [Bugfix] Fix NemotronLayerNorm1P hardcoded cuda device type | `nemotron.py` |
+| 2026-06-18 | [#42727](https://github.com/vllm-project/vllm/pull/42727) | fix(quantization): Fix AWQ dequantize on Intel XPU and refactor AutoAWQ config | `nemotron_vl.py` |
+| 2026-06-16 | [#45755](https://github.com/vllm-project/vllm/pull/45755) | [Frontend] [Parser] Migrate Nemotron V3 to streaming parser engine | `test_nemotron_v3_reasoning_parser.py`, `nemotron_v3_reasoning_parser.py` |
+| 2026-06-11 | [#45128](https://github.com/vllm-project/vllm/pull/45128) | [Model] Remove InternLMForCausalLM registry alias | `nemotron.py`, `nemotron_nas.py` |
+| 2026-06-10 | [#39091](https://github.com/vllm-project/vllm/pull/39091) | [Bugfix][Reasoning] Nemotron V3: surface reasoning as content when thinking is unterminated | `test_nemotron_v3_reasoning_parser.py`, `nemotron_v3_reasoning_parser.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `nemotron_h.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 4 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/nemotron-super/README.zh.md
+++ b/model-pr-optimization-history/vllm/nemotron-super/README.zh.md
@@ -1,5 +1,21 @@
 # vllm Nemotron Super 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 6 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-24 | [#46495](https://github.com/vllm-project/vllm/pull/46495) | [Bugfix] Fix NemotronLayerNorm1P hardcoded cuda device type | `nemotron.py` |
+| 2026-06-18 | [#42727](https://github.com/vllm-project/vllm/pull/42727) | fix(quantization): Fix AWQ dequantize on Intel XPU and refactor AutoAWQ config | `nemotron_vl.py` |
+| 2026-06-16 | [#45755](https://github.com/vllm-project/vllm/pull/45755) | [Frontend] [Parser] Migrate Nemotron V3 to streaming parser engine | `test_nemotron_v3_reasoning_parser.py`, `nemotron_v3_reasoning_parser.py` |
+| 2026-06-11 | [#45128](https://github.com/vllm-project/vllm/pull/45128) | [Model] Remove InternLMForCausalLM registry alias | `nemotron.py`, `nemotron_nas.py` |
+| 2026-06-10 | [#39091](https://github.com/vllm-project/vllm/pull/39091) | [Bugfix][Reasoning] Nemotron V3: surface reasoning as content when thinking is unterminated | `test_nemotron_v3_reasoning_parser.py`, `nemotron_v3_reasoning_parser.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `nemotron_h.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 4 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/qwen-vlm-omni-asr/README.en.md
+++ b/model-pr-optimization-history/vllm/qwen-vlm-omni-asr/README.en.md
@@ -1,5 +1,26 @@
 # vllm Qwen VLM/Omni/ASR Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 11 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-24 | [#46535](https://github.com/vllm-project/vllm/pull/46535) | [Model Runner V2][MM] Support EVS | `qwen2_5_vl.py`, `qwen3_vl.py` |
+| 2026-06-21 | [#46305](https://github.com/vllm-project/vllm/pull/46305) | [Bugfix][Qwen3-VL] Fix multi-video crash with list-valued fps/num_frames | `test_qwen3_vl.py`, `qwen3_vl.py` |
+| 2026-06-20 | [#46026](https://github.com/vllm-project/vllm/pull/46026) | [Perf] Optimize Qwen3-VL multi-video prompt processing | `test_qwen3_vl.py`, `qwen3_vl.py` |
+| 2026-06-21 | [#45424](https://github.com/vllm-project/vllm/pull/45424) | [Core] Ensure memory is pinned prior to async h2d copy | `qwen2_5_vl.py` |
+| 2026-06-16 | [#43586](https://github.com/vllm-project/vllm/pull/43586) | [MM][Perf][CG] Support dual-path ViT full CUDA graph for DeepSeek-OCR | `qwen2_5_vl.py`, `qwen2_vl.py`, `qwen3_vl.py` |
+| 2026-06-13 | [#42700](https://github.com/vllm-project/vllm/pull/42700) | [Bugfix] Replace deprecated Qwen2VLImageProcessorFast with Qwen2VLImageProcessor | `qwen3_vl.py` |
+| 2026-06-11 | [#45161](https://github.com/vllm-project/vllm/pull/45161) | Deprecate Transformers v4 support | `qwen3_omni_moe_thinker.py` |
+| 2026-06-10 | [#45131](https://github.com/vllm-project/vllm/pull/45131) | Deprecated 1st generation Qwen and QwenVL models | `qwen_vl.py` |
+| 2026-06-10 | [#45054](https://github.com/vllm-project/vllm/pull/45054) | [Bugfix] Fix weight loading issues caused by #41184 | `qwen3_vl_moe.py` |
+| 2026-06-10 | [#35415](https://github.com/vllm-project/vllm/pull/35415) | feat(qwen3-asr): support prompt parameter in v1/audio/transcriptions | `qwen3_asr.py` |
+| 2026-06-09 | [#44264](https://github.com/vllm-project/vllm/pull/44264) | [Bugfix][Model] Qwen3-Omni: move cu_seqlens to GPU before VIT attention | `qwen3_omni_moe_thinker.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 18 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-27). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/qwen-vlm-omni-asr/README.zh.md
+++ b/model-pr-optimization-history/vllm/qwen-vlm-omni-asr/README.zh.md
@@ -1,5 +1,26 @@
 # vllm Qwen VLM/Omni/ASR 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 11 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-24 | [#46535](https://github.com/vllm-project/vllm/pull/46535) | [Model Runner V2][MM] Support EVS | `qwen2_5_vl.py`, `qwen3_vl.py` |
+| 2026-06-21 | [#46305](https://github.com/vllm-project/vllm/pull/46305) | [Bugfix][Qwen3-VL] Fix multi-video crash with list-valued fps/num_frames | `test_qwen3_vl.py`, `qwen3_vl.py` |
+| 2026-06-20 | [#46026](https://github.com/vllm-project/vllm/pull/46026) | [Perf] Optimize Qwen3-VL multi-video prompt processing | `test_qwen3_vl.py`, `qwen3_vl.py` |
+| 2026-06-21 | [#45424](https://github.com/vllm-project/vllm/pull/45424) | [Core] Ensure memory is pinned prior to async h2d copy | `qwen2_5_vl.py` |
+| 2026-06-16 | [#43586](https://github.com/vllm-project/vllm/pull/43586) | [MM][Perf][CG] Support dual-path ViT full CUDA graph for DeepSeek-OCR | `qwen2_5_vl.py`, `qwen2_vl.py`, `qwen3_vl.py` |
+| 2026-06-13 | [#42700](https://github.com/vllm-project/vllm/pull/42700) | [Bugfix] Replace deprecated Qwen2VLImageProcessorFast with Qwen2VLImageProcessor | `qwen3_vl.py` |
+| 2026-06-11 | [#45161](https://github.com/vllm-project/vllm/pull/45161) | Deprecate Transformers v4 support | `qwen3_omni_moe_thinker.py` |
+| 2026-06-10 | [#45131](https://github.com/vllm-project/vllm/pull/45131) | Deprecated 1st generation Qwen and QwenVL models | `qwen_vl.py` |
+| 2026-06-10 | [#45054](https://github.com/vllm-project/vllm/pull/45054) | [Bugfix] Fix weight loading issues caused by #41184 | `qwen3_vl_moe.py` |
+| 2026-06-10 | [#35415](https://github.com/vllm-project/vllm/pull/35415) | feat(qwen3-asr): support prompt parameter in v1/audio/transcriptions | `qwen3_asr.py` |
+| 2026-06-09 | [#44264](https://github.com/vllm-project/vllm/pull/44264) | [Bugfix][Model] Qwen3-Omni: move cu_seqlens to GPU before VIT attention | `qwen3_omni_moe_thinker.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-04-27）以来，共有 18 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/qwen3-core/README.en.md
+++ b/model-pr-optimization-history/vllm/qwen3-core/README.en.md
@@ -1,5 +1,18 @@
 # vllm Qwen3 Core Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 3 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-26 | [#46761](https://github.com/vllm-project/vllm/pull/46761) | [DFlash] Fuse precompute kv per-layer rmsnorms | `qwen3_dflash.py` |
+| 2026-06-25 | [#44029](https://github.com/vllm-project/vllm/pull/44029) | [CPU][Spec Decode] Enable DFlash SD for CPU | `qwen3_dflash.py` |
+| 2026-06-10 | [#39419](https://github.com/vllm-project/vllm/pull/39419) | [SpecDecode] Reduce TP communication for large-vocab draft models speculative decoding | `qwen3.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 5 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-23). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/qwen3-core/README.zh.md
+++ b/model-pr-optimization-history/vllm/qwen3-core/README.zh.md
@@ -1,5 +1,18 @@
 # vllm Qwen3 Core 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 3 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-26 | [#46761](https://github.com/vllm-project/vllm/pull/46761) | [DFlash] Fuse precompute kv per-layer rmsnorms | `qwen3_dflash.py` |
+| 2026-06-25 | [#44029](https://github.com/vllm-project/vllm/pull/44029) | [CPU][Spec Decode] Enable DFlash SD for CPU | `qwen3_dflash.py` |
+| 2026-06-10 | [#39419](https://github.com/vllm-project/vllm/pull/39419) | [SpecDecode] Reduce TP communication for large-vocab draft models speculative decoding | `qwen3.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-04-23）以来，共有 5 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/qwen3-next/README.en.md
+++ b/model-pr-optimization-history/vllm/qwen3-next/README.en.md
@@ -1,5 +1,21 @@
 # vllm Qwen3 Next Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 6 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#46316](https://github.com/vllm-project/vllm/pull/46316) | [Bugfix] Fix NVFP4+MTP crash: force unquantized mtp.fc for Qwen3Next | `qwen3_next_mtp.py` |
+| 2026-06-23 | [#44434](https://github.com/vllm-project/vllm/pull/44434) | [ROCm][Bugfix][Perf] enable shared expert fusion for Qwen3.5 | `qwen3_next.py` |
+| 2026-06-22 | [#46108](https://github.com/vllm-project/vllm/pull/46108) | [Model] ColQwen3.5: fix retrieval correctness (bias + bidirectional) | `qwen3_next.py` |
+| 2026-06-12 | [#45319](https://github.com/vllm-project/vllm/pull/45319) | [Model][Dflash] Enable Dflash support for Qwen3NextForCausalLM targets | `qwen3_next.py` |
+| 2026-06-11 | [#45161](https://github.com/vllm-project/vllm/pull/45161) | Deprecate Transformers v4 support | `qwen3_next.py` |
+| 2026-06-09 | [#44176](https://github.com/vllm-project/vllm/pull/44176) | [Perf] fuse qk rmsnorm rope gate for qwen3.5 | `qwen3_next.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 5 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-04-08). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/qwen3-next/README.zh.md
+++ b/model-pr-optimization-history/vllm/qwen3-next/README.zh.md
@@ -1,5 +1,21 @@
 # vllm Qwen3 Next 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 6 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-25 | [#46316](https://github.com/vllm-project/vllm/pull/46316) | [Bugfix] Fix NVFP4+MTP crash: force unquantized mtp.fc for Qwen3Next | `qwen3_next_mtp.py` |
+| 2026-06-23 | [#44434](https://github.com/vllm-project/vllm/pull/44434) | [ROCm][Bugfix][Perf] enable shared expert fusion for Qwen3.5 | `qwen3_next.py` |
+| 2026-06-22 | [#46108](https://github.com/vllm-project/vllm/pull/46108) | [Model] ColQwen3.5: fix retrieval correctness (bias + bidirectional) | `qwen3_next.py` |
+| 2026-06-12 | [#45319](https://github.com/vllm-project/vllm/pull/45319) | [Model][Dflash] Enable Dflash support for Qwen3NextForCausalLM targets | `qwen3_next.py` |
+| 2026-06-11 | [#45161](https://github.com/vllm-project/vllm/pull/45161) | Deprecate Transformers v4 support | `qwen3_next.py` |
+| 2026-06-09 | [#44176](https://github.com/vllm-project/vllm/pull/44176) | [Perf] fuse qk rmsnorm rope gate for qwen3.5 | `qwen3_next.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-04-08）以来，共有 5 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/qwen35/README.en.md
+++ b/model-pr-optimization-history/vllm/qwen35/README.en.md
@@ -1,5 +1,21 @@
 # vllm Qwen3.5 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 6 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-23 | [#44434](https://github.com/vllm-project/vllm/pull/44434) | [ROCm][Bugfix][Perf] enable shared expert fusion for Qwen3.5 | `qwen3_5.py` |
+| 2026-06-22 | [#46108](https://github.com/vllm-project/vllm/pull/46108) | [Model] ColQwen3.5: fix retrieval correctness (bias + bidirectional) | `colqwen3_5_rerank_online.py`, `test_colqwen3_5.py`, `colqwen3_5.py` |
+| 2026-06-11 | [#45161](https://github.com/vllm-project/vllm/pull/45161) | Deprecate Transformers v4 support | `qwen3_5.py`, `qwen3_5_moe.py` |
+| 2026-06-10 | [#39419](https://github.com/vllm-project/vllm/pull/39419) | [SpecDecode] Reduce TP communication for large-vocab draft models speculative decoding | `qwen3_5_mtp.py` |
+| 2026-06-09 | [#45002](https://github.com/vllm-project/vllm/pull/45002) | [Bugfix] fix qwen3.5 ep weight loading | `Qwen3.5-35B-A3B-DEP2.yaml`, `qwen3_5.py`, `qwen3_5_mtp.py` |
+| 2026-06-06 | [#44700](https://github.com/vllm-project/vllm/pull/44700) | [PERF] [Qwen3.5] Split mixed prefill+decode batches: route decodes to the recurrent kernel | `models-qwen35-blackwell.txt` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 3 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/qwen35/README.zh.md
+++ b/model-pr-optimization-history/vllm/qwen35/README.zh.md
@@ -1,5 +1,21 @@
 # vllm Qwen3.5 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 6 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-23 | [#44434](https://github.com/vllm-project/vllm/pull/44434) | [ROCm][Bugfix][Perf] enable shared expert fusion for Qwen3.5 | `qwen3_5.py` |
+| 2026-06-22 | [#46108](https://github.com/vllm-project/vllm/pull/46108) | [Model] ColQwen3.5: fix retrieval correctness (bias + bidirectional) | `colqwen3_5_rerank_online.py`, `test_colqwen3_5.py`, `colqwen3_5.py` |
+| 2026-06-11 | [#45161](https://github.com/vllm-project/vllm/pull/45161) | Deprecate Transformers v4 support | `qwen3_5.py`, `qwen3_5_moe.py` |
+| 2026-06-10 | [#39419](https://github.com/vllm-project/vllm/pull/39419) | [SpecDecode] Reduce TP communication for large-vocab draft models speculative decoding | `qwen3_5_mtp.py` |
+| 2026-06-09 | [#45002](https://github.com/vllm-project/vllm/pull/45002) | [Bugfix] fix qwen3.5 ep weight loading | `Qwen3.5-35B-A3B-DEP2.yaml`, `qwen3_5.py`, `qwen3_5_mtp.py` |
+| 2026-06-06 | [#44700](https://github.com/vllm-project/vllm/pull/44700) | [PERF] [Qwen3.5] Split mixed prefill+decode batches: route decodes to the recurrent kernel | `models-qwen35-blackwell.txt` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 3 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/ring25/README.en.md
+++ b/model-pr-optimization-history/vllm/ring25/README.en.md
@@ -1,5 +1,16 @@
 # vllm Ring 2.5 1T Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 1 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `bailing_moe_linear.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 3 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/ring25/README.zh.md
+++ b/model-pr-optimization-history/vllm/ring25/README.zh.md
@@ -1,5 +1,16 @@
 # vllm Ring 2.5 1T 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 1 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `bailing_moe_linear.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 3 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/model-pr-optimization-history/vllm/step35/README.en.md
+++ b/model-pr-optimization-history/vllm/step35/README.en.md
@@ -1,5 +1,19 @@
 # vllm Step 3.5 Model PR Optimization History
 
+## 2026-06-26 Latest Source Scan
+
+Rechecked vLLM upstream `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` against the tracked files listed below.
+The file-level match used a GitHub mirror `git log --name-only`; PR titles, links, and merge times were batch-verified through the GitHub GraphQL Pull Request API. Previous freshness anchor: `2026-06-05`.
+
+Result: 4 additional PR-numbered merge(s) touched tracked files and are not yet promoted into full per-PR diff audit cards below. Treat this section as a freshness index; promote any row into a full card only after manual diff review.
+
+| Merged | PR | Title | Tracked files touched |
+| --- | --- | --- | --- |
+| 2026-06-16 | [#43586](https://github.com/vllm-project/vllm/pull/43586) | [MM][Perf][CG] Support dual-path ViT full CUDA graph for DeepSeek-OCR | `step3_vl.py` |
+| 2026-06-10 | [#45054](https://github.com/vllm-project/vllm/pull/45054) | [Bugfix] Fix weight loading issues caused by #41184 | `step3_text.py`, `step3p5.py` |
+| 2026-06-08 | [#44484](https://github.com/vllm-project/vllm/pull/44484) | [MM][CG] Simplify ViT CUDA graph interfaces | `step3_vl.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `step3p5.py` |
+
 ## 2026-06-05 PR Backfill Audit
 
 Rechecked vllm upstream `origin/main@c66b19800` on 2026-06-05; 5 additional PR-numbered merge(s) touched the tracked implementation files after the previous freshness cutoff (2026-05-19). These are not yet reflected in the timeline / diff-audit cards below and should be folded in on the next full regeneration.

--- a/model-pr-optimization-history/vllm/step35/README.zh.md
+++ b/model-pr-optimization-history/vllm/step35/README.zh.md
@@ -1,5 +1,19 @@
 # vllm Step 3.5 模型 PR 优化历史
 
+## 2026-06-26 最新源码扫描
+
+已按 vLLM 上游 `vllm-project/vllm@abc71548ef029132c3316b902207f254a246d593` 重新扫描本文下方列出的 tracked files。
+文件级匹配使用 GitHub mirror 的 `git log --name-only`；PR 标题、链接和合并时间通过 GitHub GraphQL Pull Request API 批量复核。上一时效锚点：`2026-06-05`。
+
+结果：发现 4 个额外 PR-numbered merge 触及 tracked files，但尚未提升为下方完整逐 PR diff audit card。此节只作为 freshness index；需要引用实现细节时，仍应先人工阅读 PR diff 再补完整卡片。
+
+| 合并日期 | PR | 标题 | 命中的 tracked files |
+| --- | --- | --- | --- |
+| 2026-06-16 | [#43586](https://github.com/vllm-project/vllm/pull/43586) | [MM][Perf][CG] Support dual-path ViT full CUDA graph for DeepSeek-OCR | `step3_vl.py` |
+| 2026-06-10 | [#45054](https://github.com/vllm-project/vllm/pull/45054) | [Bugfix] Fix weight loading issues caused by #41184 | `step3_text.py`, `step3p5.py` |
+| 2026-06-08 | [#44484](https://github.com/vllm-project/vllm/pull/44484) | [MM][CG] Simplify ViT CUDA graph interfaces | `step3_vl.py` |
+| 2026-06-08 | [#41184](https://github.com/vllm-project/vllm/pull/41184) | [MoE Refactor] FusedMoE/MoERunner inversion refactor | `step3p5.py` |
+
 ## 2026-06-05 PR 补漏复核
 
 已于 2026-06-05 按 vllm 上游 `origin/main@c66b19800` 复核；自上次时效基准（2026-05-19）以来，共有 5 个带 PR 编号的合并改动到所跟踪的实现文件，这些 PR 尚未并入下方时间线 / 逐 PR diff 审计卡，应在下次完整重生成时补齐。

--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -166,10 +166,13 @@ before starting a long sweep.
 - vLLM `--max-num-partial-prefills > 1` is model- and runtime-gated. Keep `1`
   in the default pass; raise only after a preflight with the actual model.
 - vLLM current mainline was refreshed on 2026-06-26 at
-  `37ce34922f7f5e58241369511130cd99c1c50bfe` and includes PR `#46735`
+  `abc71548ef029132c3316b902207f254a246d593` and includes PR `#46735`
   fixing CUDA graph capture in Triton / NVFP4-emulation MoE. If a target image
   predates it, treat Triton-MoE graph-capture failures or eager fallback as an
   image/runtime issue before scoring it against SGLang.
+- The same vLLM refresh includes PR `#44800` (`VLLM_GPU_SYNC_CHECK`). For
+  sync-heavy profiler rows, record whether the target image exposes this debug
+  knob before labeling the gap as kernel-local.
 - TensorRT-LLM mainline was refreshed on 2026-06-26 at
   `0722c5f47d2cae69ac1a237da51e550dd214532c`. Keep
   `kv_cache_free_gpu_memory_fraction` in shipped configs until the target

--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: llm-serving-auto-benchmark
-description: Framework-independent LLM serving benchmark skill for comparing SGLang, vLLM, TensorRT-LLM, or another serving framework. Use when a user wants to find the best deployment command for one model across multiple serving frameworks under the same workload, GPU budget, and latency SLA.
+description: Framework-independent LLM serving benchmark skill for comparing SGLang, vLLM, TensorRT-LLM, TokenSpeed, or another serving framework. Use when a user wants to find the best deployment command for one model across multiple serving frameworks under the same workload, GPU budget, and latency SLA.
 ---
 
 # LLM Serving Auto Benchmark
 
 ## Overview
 
-Use this skill to compare LLM serving frameworks such as SGLang, vLLM, and
-TensorRT-LLM for the same model and workload.
+Use this skill to compare LLM serving frameworks such as SGLang, vLLM,
+TensorRT-LLM, and TokenSpeed for the same model and workload.
 
 Use a config-driven workflow:
 
@@ -23,7 +23,8 @@ Use a config-driven workflow:
 For model-specific starting points, prefer the shipped configs in
 `configs/cookbook-llm/`. They define a framework-neutral LLM serving cookbook
 model set and translate each entry into framework-native SGLang, vLLM, and
-TensorRT-LLM server flags. Validate those configs before a real run:
+TensorRT-LLM, and TokenSpeed server flags. Validate those configs before a real
+run:
 
 ```bash
 python skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py \
@@ -44,6 +45,9 @@ Prefer native tooling when it gives better coverage:
 - TensorRT-LLM: `trtllm-serve` for the OpenAI-compatible server plus the
   TensorRT-LLM serving benchmark client or a common OpenAI-compatible benchmark
   client
+- TokenSpeed: `tokenspeed serve` for the OpenAI-compatible server plus
+  `tokenspeed bench serve` or the same OpenAI-compatible benchmark client used
+  for the other frameworks
 
 TensorRT-LLM has one hard scope rule in this skill: the server backend is fixed
 to `trtllm-serve serve --backend pytorch`. Do not search TensorRT-LLM backend
@@ -55,6 +59,11 @@ OpenAI-compatible modes such as `--backend openai` or `--backend openai-chat`.
 
 Only pick a winner after each requested framework has had its main serving knobs
 tuned.
+
+Framework selection is caller-controlled. If the caller explicitly supplies a
+framework list, benchmark only those enabled frameworks. Do not silently add
+TensorRT-LLM or TokenSpeed just because cookbook configs or history docs exist;
+record omitted frameworks as user-excluded, not unsupported.
 
 The parameter lists in this skill are not a compatibility contract. They are
 version-sensitive candidate knob families. Before every real run, record the
@@ -79,8 +88,8 @@ available, and nothing more:
 Do not assume a specific operator host name inside this skill's own workflow.
 The concrete SSH wiring, container names, workspace paths, and HF token plumbing
 for a given box live in operator-side per-host skills; this skill only requires
-that the caller can reach a shell inside a container with `sglang`, `vllm`, or
-`tensorrt_llm` installed.
+that the caller can reach a shell inside a container with the requested
+framework installed.
 
 Reference files are optional and version-sensitive. Treat historical flag notes
 as evidence from one image, not as a compatibility guarantee for the next run.
@@ -156,14 +165,10 @@ before starting a long sweep.
   the operator has verified the image.
 - vLLM `--max-num-partial-prefills > 1` is model- and runtime-gated. Keep `1`
   in the default pass; raise only after a preflight with the actual model.
-- TensorRT-LLM current mainline was rechecked at `7021547` on 2026-05-15, and
-  the serving flag evidence from `b9e1945` still applies because newer commits
-  only touched CI/test-waive files. That evidence accepts both
-  `--kv_cache_free_gpu_memory_fraction` and `--free_gpu_memory_fraction` as
-  server aliases. Keep
-  `kv_cache_free_gpu_memory_fraction` in shipped configs because it maps
-  directly to the `KvCacheConfig` field and remains compatible with the older
-  validation image that rejected the shorter alias.
+- TensorRT-LLM mainline was refreshed on 2026-06-26 at
+  `4164b932c6c8a14d1be85d0fd62e44b7d0171980`. Keep
+  `kv_cache_free_gpu_memory_fraction` in shipped configs until the target
+  `trtllm-serve serve --help` proves a shorter alias is accepted.
 - The historical TensorRT-LLM 1.0.0 multi-GPU PyTorch-backend validation used
   `--ipc=host`, `--ulimit memlock=-1`, `--ulimit stack=67108864`,
   `--shm-size=16g`, and `NCCL_IB_DISABLE=1` (for single-node) or an equivalent
@@ -174,6 +179,22 @@ before starting a long sweep.
   backend, which is pinned to `pytorch` by this skill.
 - `trtllm` `benchmark_serving --dataset-name random` silently falls back to
   ShareGPT sampling without `--random-ids` (or `--download-path`).
+- TokenSpeed is a fast-moving engine. Current mainline checked on 2026-06-26 at
+  `5aedf69d6b476baa65571011de6ea60fd5a238a8` exposes `tokenspeed serve`,
+  `tokenspeed bench`, `tokenspeed env`, and `tokenspeed version`. Its server
+  command is `tokenspeed serve <model>`, not a `python -m tokenspeed`
+  entrypoint.
+- TokenSpeed's SGLang/vLLM-compatible parameter names are not always identical
+  in meaning. Prefer `--max-model-len`, `--max-num-seqs`,
+  `--chunked-prefill-size`, `--max-prefill-tokens`, `--max-total-tokens`,
+  `--tensor-parallel-size`, `--attn-tp-size`, `--moe-tp-size`,
+  `--enable-expert-parallel`, `--attention-backend`, `--moe-backend`,
+  `--kv-cache-dtype`, and speculative flags only after confirming the target
+  `tokenspeed serve --help` output.
+- TokenSpeed has an agentic benchmark path in-tree. When the workload is
+  multi-turn or tool-heavy, add a TokenSpeed-native `tokenspeed bench serve` or
+  EvalScope-style run beside the common OpenAI-compatible client and record both
+  result files in the same normalized row set.
 - `max_seq_len` / `max_model_len` / `context_length` candidates must cover
   `max(input_len + output_len)` across every scenario, including values inside
   `search_space`, not just the baseline. The validator checks this; do not
@@ -208,7 +229,8 @@ Use these rules throughout the benchmark:
 
 ### 1. Preflight
 
-Verify all requested frameworks before starting a search:
+Verify SGLang plus all requested comparison frameworks before starting a search.
+Run only the commands for the requested framework set:
 
 ```bash
 python -m sglang.launch_server --help
@@ -220,6 +242,9 @@ vllm bench serve --help=all
 vllm bench sweep serve --help=all
 trtllm-serve serve --help
 python -m tensorrt_llm.serve.scripts.benchmark_serving --help
+tokenspeed serve --help
+tokenspeed bench --help
+tokenspeed bench serve --help
 ```
 
 Use the framework-specific `--help` output in the target environment as the
@@ -236,6 +261,10 @@ running the benchmark. Do not silently pass unknown flags.
 For TensorRT-LLM, also confirm that `trtllm-serve serve --help` accepts
 `--backend pytorch`. If it does not, mark TensorRT-LLM unsupported in that
 environment rather than falling back to a different server backend.
+
+For TokenSpeed, confirm both the server and benchmark entrypoints because some
+installations alias the binary as `ts`. Record the exact binary used in
+`server_command`.
 
 For each framework, launch a minimal server, confirm `/v1/models` or the native
 model-info endpoint, send one streaming request, run one tiny benchmark with at
@@ -301,8 +330,9 @@ the slow bucket rather than profiling an unrelated synthetic shape.
 
 Before searching any sequence-length limit, compute the largest
 `input_len + output_len` in the dataset. SGLang `context_length`, vLLM
-`max_model_len`, and TensorRT-LLM `max_seq_len` must be at least that value for
-every candidate that is expected to run all scenarios.
+`max_model_len`, TensorRT-LLM `max_seq_len`, and TokenSpeed `max_model_len`
+must be at least that value for every candidate that is expected to run all
+scenarios.
 
 ### 3. Pick A Search Tier
 
@@ -332,6 +362,7 @@ or memory study:
 - SGLang `schedule_policy`
 - vLLM `gpu_memory_utilization`
 - TensorRT-LLM `kv_cache_free_gpu_memory_fraction`
+- TokenSpeed `gpu_memory_utilization`
 
 These are real knobs, but they widen the search quickly and often turn a serving
 comparison into a memory-limit study.
@@ -450,11 +481,9 @@ pass `--random-ids`, then confirm the behavior on the target TensorRT-LLM image.
 TensorRT-LLM flag names are especially version-sensitive. In the validated
 TensorRT-LLM 1.0.0 image, the KV-cache memory flag accepted by
 `trtllm-serve serve` was `--kv_cache_free_gpu_memory_fraction`, not
-`--free_gpu_memory_fraction`. Current mainline was rechecked at `7021547` on
-2026-05-15; the newer commits did not touch serving code, so the `b9e1945`
-serving flag evidence still applies: both aliases are accepted and
-`trtllm-serve` still defaults to the PyTorch backend. Always verify flags with
-`trtllm-serve serve --help` before running a search on any GPU target.
+`--free_gpu_memory_fraction`. Current mainline was rechecked at
+`4164b932c6c8a14d1be85d0fd62e44b7d0171980` on 2026-06-26. Always verify flags
+with `trtllm-serve serve --help` before running a search on any GPU target.
 
 TensorRT-LLM backend policy for this skill:
 
@@ -481,7 +510,80 @@ Search `max_batch_size`, `max_num_tokens`, `max_seq_len`, and validated
 PyTorch-backend config options first. The server backend remains fixed to
 `pytorch`.
 
-### 7. Normalize Results
+### 7. Tune TokenSpeed
+
+Use TokenSpeed as a first-class comparison framework, especially for agentic or
+multi-turn workloads where it may be the strongest non-SGLang baseline:
+
+```bash
+tokenspeed serve <model> \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --tensor-parallel-size <tp> \
+  --gpu-memory-utilization 0.90 \
+  --max-model-len 12288 \
+  --max-num-seqs 64 \
+  --chunked-prefill-size 8192 \
+  --kv-cache-dtype auto \
+  --trust-remote-code
+```
+
+Benchmark either with TokenSpeed's native online serving benchmark:
+
+```bash
+tokenspeed bench serve \
+  --base-url http://127.0.0.1:8000 \
+  --model <model> \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 256 \
+  --num-prompts 80
+```
+
+or with the same OpenAI-compatible client used for the other frameworks.
+When TokenSpeed is a likely leader and profiler handoff will be needed, the
+native benchmark can also arm torch profiling for the same request shape:
+
+```bash
+tokenspeed bench serve \
+  --base-url http://127.0.0.1:8000 \
+  --model <model> \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 256 \
+  --num-prompts 80 \
+  --profile \
+  --profile-num-steps 5 \
+  --extra-body '{"output_dir":"/data/bbuf/profiles/tokenspeed","activities":["CPU","GPU"],"with_stack":true,"profile_id":"ts-bench"}'
+```
+
+If `output_dir` is not supplied, TokenSpeed writes under
+`TOKENSPEED_PROFILER_DIR`, defaulting to `/tmp`.
+
+For large MoE or agentic checkpoints, validate these TokenSpeed knobs before
+adding them to the search:
+
+- `tensor_parallel_size`, `attn_tp_size`, `moe_tp_size`, and
+  `enable_expert_parallel`
+- `attention_backend`, `drafter_attention_backend`, `moe_backend`, and
+  `draft_moe_backend`
+- `max_num_seqs`, `chunked_prefill_size`, `max_prefill_tokens`, and
+  `max_total_tokens`
+- `kv_cache_dtype`, `quantization`, and prefix-cache controls
+- speculative flags such as `speculative_algorithm`, `speculative_num_steps`,
+  and `speculative_num_draft_tokens`
+- `comm_fusion_max_num_tokens`, `enable_allreduce_fusion`, and related
+  communication-fusion flags only after a target-image smoke run
+
+If a TokenSpeed-native agentic config exists for the same model family, run it
+as an additional workload lane rather than replacing the common cross-framework
+scenario. Normalize its result rows with the same schema and mark
+`workload.kind` accordingly.
+
+Keep `gpu_memory_utilization` pinned in the default pass. Search it only when
+the user explicitly wants a capacity study.
+
+### 8. Normalize Results
 
 Write one JSONL row per candidate using the schema in
 [references/result-schema.md](references/result-schema.md). Then run:
@@ -516,6 +618,11 @@ workload, raw/normalized results, CSV or markdown summary, and server logs.
 When SGLang is not the winner, include a profiler handoff note with the slow
 SGLang scenario name and the exact input/output lengths or percentile bucket to
 pass to `llm-torch-profiler-analysis`.
+
+When a candidate uses speculative decoding, prefix cache, offload, or an
+agentic workload, record the optional normalized fields for accept length,
+pre-scheduler time, cache hit rate, and memory residency. The summary script
+will display those columns when present.
 
 Include failed or excluded candidates with reasons. Explain that this table is a
 record of tried configs that were not selected: candidates that failed, were

--- a/skills/llm-serving-auto-benchmark/SKILL.md
+++ b/skills/llm-serving-auto-benchmark/SKILL.md
@@ -165,10 +165,19 @@ before starting a long sweep.
   the operator has verified the image.
 - vLLM `--max-num-partial-prefills > 1` is model- and runtime-gated. Keep `1`
   in the default pass; raise only after a preflight with the actual model.
+- vLLM current mainline was refreshed on 2026-06-26 at
+  `37ce34922f7f5e58241369511130cd99c1c50bfe` and includes PR `#46735`
+  fixing CUDA graph capture in Triton / NVFP4-emulation MoE. If a target image
+  predates it, treat Triton-MoE graph-capture failures or eager fallback as an
+  image/runtime issue before scoring it against SGLang.
 - TensorRT-LLM mainline was refreshed on 2026-06-26 at
-  `4164b932c6c8a14d1be85d0fd62e44b7d0171980`. Keep
+  `0722c5f47d2cae69ac1a237da51e550dd214532c`. Keep
   `kv_cache_free_gpu_memory_fraction` in shipped configs until the target
   `trtllm-serve serve --help` proves a shorter alias is accepted.
+- TensorRT-LLM current mainline includes PR `#11685` and PR `#15546`, which
+  affect KV block eviction and KV block-offset host staging. If a target image
+  predates them, record stale-runtime risk when cache pressure, block-offset
+  races, or prefix/KV residency affect benchmark rows.
 - The historical TensorRT-LLM 1.0.0 multi-GPU PyTorch-backend validation used
   `--ipc=host`, `--ulimit memlock=-1`, `--ulimit stack=67108864`,
   `--shm-size=16g`, and `NCCL_IB_DISABLE=1` (for single-node) or an equivalent
@@ -482,7 +491,7 @@ TensorRT-LLM flag names are especially version-sensitive. In the validated
 TensorRT-LLM 1.0.0 image, the KV-cache memory flag accepted by
 `trtllm-serve serve` was `--kv_cache_free_gpu_memory_fraction`, not
 `--free_gpu_memory_fraction`. Current mainline was rechecked at
-`4164b932c6c8a14d1be85d0fd62e44b7d0171980` on 2026-06-26. Always verify flags
+`0722c5f47d2cae69ac1a237da51e550dd214532c` on 2026-06-26. Always verify flags
 with `trtllm-serve serve --help` before running a search on any GPU target.
 
 TensorRT-LLM backend policy for this skill:

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/README.md
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/README.md
@@ -1,11 +1,12 @@
 # Cookbook LLM Configs
 
-These configs define a framework-neutral LLM serving cookbook model set and translate each model into a three-framework run plan for SGLang, vLLM, and TensorRT-LLM.
+These configs define a framework-neutral LLM serving cookbook model set and translate each model into a four-framework run plan for SGLang, vLLM, TensorRT-LLM, and TokenSpeed.
 
 Scope:
 - SGLang can preserve source-recipe `base_flags` and `search_space` where applicable; if a sequence limit is smaller than the default synthetic scenario, the config raises that limit so the shipped workload can run.
 - vLLM uses framework-native `vllm serve` flags. The translation keeps the same model, tokenizer, dataset shape, GPU count, and high-impact batching/prefix-cache knobs; it does not copy SGLang-only parser or scheduler flags.
 - TensorRT-LLM uses `trtllm-serve serve` with `backend: pytorch` fixed in `base_server_flags`. Backend choice is never searched.
+- TokenSpeed uses `tokenspeed serve <model>` with framework-native TP, memory, max sequence, batching, chunked-prefill, and prefix-cache knobs. Treat these sections as first-pass candidates and validate them against the target `tokenspeed serve --help`.
 - The two default random scenarios remain aligned pairs: `chat` uses `1000 -> 1000`, and `summarization` uses `8000 -> 1000`.
 
 Before a real run, capture the target framework `--help` output and validate the configs:

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-math-v2.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-math-v2.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: deepseek-math-v2.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: deepseek-ai/DeepSeek-Math-V2
   tokenizer: deepseek-ai/DeepSeek-Math-V2
@@ -128,3 +130,23 @@ frameworks:
       - 1
       - 4
       - 8
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-r1-0528.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-r1-0528.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: deepseek-r1-0528.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: deepseek-ai/DeepSeek-R1-0528
   tokenizer: deepseek-ai/DeepSeek-R1-0528
@@ -131,3 +133,23 @@ frameworks:
       - 1
       - 4
       - 8
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.1.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.1.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: deepseek-v3.1.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: deepseek-ai/DeepSeek-V3.1
   tokenizer: deepseek-ai/DeepSeek-V3.1
@@ -130,3 +132,23 @@ frameworks:
       - 1
       - 4
       - 8
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.2.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.2.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: deepseek-v3.2.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: deepseek-ai/DeepSeek-V3.2
   tokenizer: deepseek-ai/DeepSeek-V3.2
@@ -130,3 +132,23 @@ frameworks:
       - 1
       - 4
       - 8
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/deepseek-v3.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: deepseek-v3.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: deepseek-ai/DeepSeek-V3
   tokenizer: deepseek-ai/DeepSeek-V3
@@ -131,3 +133,23 @@ frameworks:
       - 1
       - 4
       - 8
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/devstral-small-2-24b-instruct-2512.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/devstral-small-2-24b-instruct-2512.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: devstral-small-2-24b-instruct-2512.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: mistralai/Devstral-Small-2-24B-Instruct-2512
   tokenizer: mistralai/Devstral-Small-2-24B-Instruct-2512
@@ -121,3 +123,23 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ernie-4.5-21b-a3b-pt.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ernie-4.5-21b-a3b-pt.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: ernie-4.5-21b-a3b-pt.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: baidu/ERNIE-4.5-21B-A3B-PT
   tokenizer: baidu/ERNIE-4.5-21B-A3B-PT
@@ -115,3 +117,23 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.5.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.5.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: glm-4.5.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: zai-org/GLM-4.5
   tokenizer: zai-org/GLM-4.5
@@ -120,3 +122,24 @@ frameworks:
       max_seq_len:
       - 9000
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 9000
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.6.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.6.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: glm-4.6.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: zai-org/GLM-4.6
   tokenizer: zai-org/GLM-4.6
@@ -133,3 +135,24 @@ frameworks:
       - 1
       - 4
       - 8
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7-flash.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7-flash.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: glm-4.7-flash.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: zai-org/GLM-4.7-Flash
   tokenizer: zai-org/GLM-4.7-Flash
@@ -124,3 +126,24 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-4.7.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: glm-4.7.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: zai-org/GLM-4.7
   tokenizer: zai-org/GLM-4.7
@@ -128,3 +130,24 @@ frameworks:
       - 1
       - 2
       - 4
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 9000
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-5-fp8.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glm-5-fp8.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: glm-5-fp8.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: zai-org/GLM-5-FP8
   tokenizer: zai-org/GLM-5-FP8
@@ -130,3 +132,23 @@ frameworks:
       - 1
       - 4
       - 8
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glyph.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/glyph.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: glyph.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: zai-org/Glyph
   tokenizer: zai-org/Glyph
@@ -124,3 +126,23 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/gpt-oss-120b.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/gpt-oss-120b.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: gpt-oss-120b.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: openai/gpt-oss-120b
   tokenizer: openai/gpt-oss-120b
@@ -130,3 +132,23 @@ frameworks:
       - 1
       - 4
       - 8
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/intern-s1.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/intern-s1.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: intern-s1.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: internlm/Intern-S1
   tokenizer: internlm/Intern-S1
@@ -133,3 +135,24 @@ frameworks:
       - 1
       - 4
       - 8
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-k2-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-k2-instruct.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: kimi-k2-instruct.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: moonshotai/Kimi-K2-Instruct
   tokenizer: moonshotai/Kimi-K2-Instruct
@@ -131,3 +133,24 @@ frameworks:
       ep_size:
       - 1
       - 4
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-k2.5.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-k2.5.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: kimi-k2.5.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: moonshotai/Kimi-K2.5
   tokenizer: moonshotai/Kimi-K2.5
@@ -125,3 +127,24 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-k2.6.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-k2.6.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: kimi-k2.6.yaml
-  translation: SGLang flags follow the current Kimi-K2.6 cookbook command generator; vLLM and TensorRT-LLM use framework-native generic translations for the same model and synthetic dataset shape.
+  translation: SGLang flags follow the current Kimi-K2.6 cookbook command generator;
+    vLLM and TensorRT-LLM use framework-native generic translations for the same model
+    and synthetic dataset shape.
 model:
   name: moonshotai/Kimi-K2.6
   tokenizer: moonshotai/Kimi-K2.6
@@ -127,3 +129,24 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-linear-48b-a3b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/kimi-linear-48b-a3b-instruct.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: kimi-linear-48b-a3b-instruct.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: moonshotai/Kimi-Linear-48B-A3B-Instruct
   tokenizer: moonshotai/Kimi-Linear-48B-A3B-Instruct
@@ -119,3 +121,24 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ling-2.5-1t.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ling-2.5-1t.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: ling-2.5-1t.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: inclusionAI/Ling-2.5-1T
   tokenizer: inclusionAI/Ling-2.5-1T
@@ -132,3 +134,24 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llada2-1-mini.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llada2-1-mini.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: llada2-1-mini.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: inclusionAI/LLaDA2.1-mini
   tokenizer: inclusionAI/LLaDA2.1-mini
@@ -128,3 +130,24 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 1
+      - 2
+      - 4
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-3.1-70b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-3.1-70b-instruct.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: llama-3.1-70b-instruct.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: meta-llama/Llama-3.1-70B-Instruct
   tokenizer: meta-llama/Llama-3.1-70B-Instruct
@@ -122,3 +124,23 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-3.3-70b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-3.3-70b-instruct.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: llama-3.3-70b-instruct.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: meta-llama/Llama-3.3-70B-Instruct
   tokenizer: meta-llama/Llama-3.3-70B-Instruct
@@ -116,3 +118,23 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-4-maverick-17b-128e-instruct-fp8.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-4-maverick-17b-128e-instruct-fp8.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: llama-4-maverick-17b-128e-instruct-fp8.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
   tokenizer: meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8
@@ -120,3 +122,24 @@ frameworks:
       - 16384
       max_seq_len:
       - 1000000
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 1000000
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 4
+      - 8
+      - 12
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-4-scout-17b-16e-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/llama-4-scout-17b-16e-instruct.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: llama-4-scout-17b-16e-instruct.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: meta-llama/Llama-4-Scout-17B-16E-Instruct
   tokenizer: meta-llama/Llama-4-Scout-17B-16E-Instruct
@@ -127,3 +129,24 @@ frameworks:
       - 16384
       max_seq_len:
       - 65536
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 65536
+      dtype: bfloat16
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 8
+      - 16
+      - 24
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/mimo-v2-flash.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/mimo-v2-flash.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: mimo-v2-flash.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: XiaomiMiMo/MiMo-V2-Flash
   tokenizer: XiaomiMiMo/MiMo-V2-Flash
@@ -56,7 +58,8 @@ frameworks:
       trust_remote_code: true
       max_running_requests: 128
       chunked_prefill_size: 16384
-      model_loader_extra_config: '{"enable_multithread_load": "true","num_threads": 64}'
+      model_loader_extra_config: '{"enable_multithread_load": "true","num_threads":
+        64}'
       attention_backend: fa3
       reasoning_parser: qwen3
       tool_call_parser: mimo
@@ -131,3 +134,24 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/minimax-m2.1.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/minimax-m2.1.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: minimax-m2.1.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: MiniMaxAI/MiniMax-M2.1
   tokenizer: MiniMaxAI/MiniMax-M2.1
@@ -119,3 +121,24 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/minimax-m2.5.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/minimax-m2.5.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: minimax-m2.5.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: MiniMaxAI/MiniMax-M2.5
   tokenizer: MiniMaxAI/MiniMax-M2.5
@@ -131,3 +133,24 @@ frameworks:
       ep_size:
       - 1
       - 4
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ministral-3-8b-instruct-2512.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ministral-3-8b-instruct-2512.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: ministral-3-8b-instruct-2512.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: mistralai/Ministral-3-8B-Instruct-2512
   tokenizer: mistralai/Ministral-3-8B-Instruct-2512
@@ -119,3 +121,24 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/mistral-small-4-119b-2603.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/mistral-small-4-119b-2603.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: mistral-small-4-119b-2603.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: mistralai/Mistral-Small-4-119B-2603
   tokenizer: mistralai/Mistral-Small-4-119B-2603
@@ -122,3 +124,23 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 2
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/nemotron-3-nano-30b-a3b-bf16.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/nemotron-3-nano-30b-a3b-bf16.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: nemotron-3-nano-30b-a3b-bf16.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
   tokenizer: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
@@ -126,3 +128,24 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 1
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: fp8_e4m3
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/nemotron-3-super-120b-a12b-bf16.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/nemotron-3-super-120b-a12b-bf16.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: nemotron-3-super-120b-a12b-bf16.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
   tokenizer: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
@@ -126,3 +128,24 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: fp8_e4m3
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-235b-a22b.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-235b-a22b.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: qwen3-235b-a22b.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: Qwen/Qwen3-235B-A22B
   tokenizer: Qwen/Qwen3-235B-A22B
@@ -130,3 +132,23 @@ frameworks:
       - 1
       - 4
       - 8
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-coder-480b-a35b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-coder-480b-a35b-instruct.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: qwen3-coder-480b-a35b-instruct.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: Qwen/Qwen3-Coder-480B-A35B-Instruct
   tokenizer: Qwen/Qwen3-Coder-480B-A35B-Instruct
@@ -129,3 +131,23 @@ frameworks:
       ep_size:
       - 1
       - 2
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-coder-next.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-coder-next.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: qwen3-coder-next.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: Qwen/Qwen3-Coder-Next
   tokenizer: Qwen/Qwen3-Coder-Next
@@ -122,3 +124,23 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 2
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-next-80b-a3b-instruct.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen3-next-80b-a3b-instruct.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: qwen3-next-80b-a3b-instruct.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: Qwen/Qwen3-Next-80B-A3B-Instruct
   tokenizer: Qwen/Qwen3-Next-80B-A3B-Instruct
@@ -128,3 +130,23 @@ frameworks:
       ep_size:
       - 1
       - 2
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 2
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen35-397b-a17b-fp8.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/qwen35-397b-a17b-fp8.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: qwen35-397b-a17b-fp8.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: Qwen/Qwen3.5-397B-A17B-FP8
   tokenizer: Qwen/Qwen3.5-397B-A17B-FP8
@@ -130,3 +132,23 @@ frameworks:
       - 1
       - 4
       - 8
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ring-2.5-1t.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/ring-2.5-1t.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: ring-2.5-1t.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: inclusionAI/Ring-2.5-1T
   tokenizer: inclusionAI/Ring-2.5-1T
@@ -122,3 +124,23 @@ frameworks:
       max_seq_len:
       - 12288
       - 16384
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 8
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      max_num_seqs:
+      - 32
+      - 48
+      - 64
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/configs/cookbook-llm/step-3.5-flash.yaml
+++ b/skills/llm-serving-auto-benchmark/configs/cookbook-llm/step-3.5-flash.yaml
@@ -2,7 +2,9 @@ schema_version: 1
 source:
   kind: llm_serving_cookbook
   source_recipe_file: step-3.5-flash.yaml
-  translation: SGLang flags preserve the source recipe where applicable, with sequence limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native serving flags for the same model and dataset shape.
+  translation: SGLang flags preserve the source recipe where applicable, with sequence
+    limits raised when needed for the default dataset; vLLM and TensorRT-LLM use framework-native
+    serving flags for the same model and dataset shape.
 model:
   name: stepfun-ai/Step-3.5-Flash
   tokenizer: stepfun-ai/Step-3.5-Flash
@@ -131,3 +133,24 @@ frameworks:
       ep_size:
       - 1
       - 4
+  tokenspeed:
+    enabled: true
+    server_command: tokenspeed serve
+    config_source: tokenspeed_latest_generic_translation
+    base_server_flags:
+      tensor_parallel_size: 4
+      gpu_memory_utilization: 0.9
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+      trust_remote_code: true
+    search_space:
+      max_num_seqs:
+      - 64
+      - 96
+      - 128
+      chunked_prefill_size:
+      - 8192
+      - 16384
+      enable_prefix_caching:
+      - true

--- a/skills/llm-serving-auto-benchmark/references/container-runbook.md
+++ b/skills/llm-serving-auto-benchmark/references/container-runbook.md
@@ -19,6 +19,10 @@ Pull the images that will be used:
 docker pull lmsysorg/sglang:dev
 docker pull vllm/vllm-openai:latest
 docker pull nvcr.io/nvidia/tensorrt-llm/release:latest
+# TokenSpeed images are environment-specific; set this to the image or local
+# build that contains the target TokenSpeed commit.
+export TOKENSPEED_IMAGE=<tokenspeed-image-with-current-source>
+docker pull "$TOKENSPEED_IMAGE"
 ```
 
 Use quoted Docker GPU device lists:
@@ -83,6 +87,8 @@ vllm bench sweep serve --help=all > artifacts/help/vllm_bench_sweep_serve_all.tx
 trtllm-serve serve --help > artifacts/help/trtllm_serve.txt
 python -m tensorrt_llm.serve.scripts.benchmark_serving --help \
   > artifacts/help/trtllm_benchmark_serving.txt
+tokenspeed serve --help > artifacts/help/tokenspeed_serve.txt
+tokenspeed bench serve --help > artifacts/help/tokenspeed_bench_serve.txt
 ```
 
 ## SGLang
@@ -216,6 +222,83 @@ vllm bench serve \
 
 Use `vllm bench sweep serve` when the target image supports it and the search
 can be described with serve/bench parameter JSON files.
+
+## TokenSpeed
+
+Server template:
+
+```bash
+docker run -d --name llmbench-tokenspeed \
+  --gpus "$GPU_ARG" \
+  --network host \
+  --ipc=host \
+  -v /data/.cache:/root/.cache \
+  -e MODEL \
+  -e TP \
+  -e PORT \
+  -e HF_TOKEN \
+  -e HUGGINGFACE_HUB_TOKEN \
+  --entrypoint bash \
+  "$TOKENSPEED_IMAGE" -lc '
+tokenspeed serve "$MODEL" \
+  --host 0.0.0.0 \
+  --port "$PORT" \
+  --tensor-parallel-size "$TP" \
+  --dtype auto \
+  --gpu-memory-utilization 0.90 \
+  --max-model-len 4096 \
+  --max-num-seqs 64 \
+  --chunked-prefill-size 8192 \
+  --kv-cache-dtype auto \
+  --enable-prefix-caching \
+  --trust-remote-code
+'
+```
+
+Benchmark template:
+
+```bash
+docker run --rm \
+  --network host \
+  -v /data/.cache:/root/.cache \
+  -v "$RUN_DIR:/artifacts" \
+  -e MODEL \
+  -e PORT \
+  --entrypoint bash \
+  "$TOKENSPEED_IMAGE" -lc '
+tokenspeed bench serve \
+  --base-url "http://127.0.0.1:$PORT" \
+  --model "$MODEL" \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 256 \
+  --num-prompts 80 \
+  --request-rate 8 \
+  --max-concurrency 64 \
+  --save-result \
+  --result-dir /artifacts/tokenspeed
+'
+```
+
+For a profiler handoff run after the plain benchmark is complete, add a writable
+profile mount and pass TokenSpeed's profile payload through `--extra-body`:
+
+```bash
+tokenspeed bench serve \
+  --base-url "http://127.0.0.1:$PORT" \
+  --model "$MODEL" \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 256 \
+  --num-prompts 80 \
+  --profile \
+  --profile-num-steps 5 \
+  --extra-body '{"output_dir":"/artifacts/tokenspeed_profile","activities":["CPU","GPU"],"with_stack":true,"profile_id":"ts-bench"}'
+```
+
+Some TokenSpeed images expose the binary as `ts`. If so, use `ts serve` and
+`ts bench serve`, then record that exact spelling in the normalized
+`server_command` and `benchmark_command`.
 
 ## TensorRT-LLM
 

--- a/skills/llm-serving-auto-benchmark/references/example-plan.yaml
+++ b/skills/llm-serving-auto-benchmark/references/example-plan.yaml
@@ -33,6 +33,12 @@ version_manifest:
     git_commit: null
     server_help: artifacts/help/trtllm_serve.txt
     benchmark_help: artifacts/help/trtllm_benchmark_serving.txt
+  tokenspeed:
+    container_image: <tokenspeed-image-with-current-source>
+    package_version: null
+    git_commit: null
+    server_help: artifacts/help/tokenspeed_serve.txt
+    benchmark_help: artifacts/help/tokenspeed_bench_serve.txt
 
 hardware:
   # Example values; replace with the actual target GPU (A100, H100, H200,
@@ -53,6 +59,10 @@ dataset:
 benchmark:
   endpoint: /v1/chat/completions
   backend: auto
+  # Caller-controlled set. For an SGLang-vs-vLLM-only SOTA loop, keep only
+  # [sglang, vllm] enabled and mark TensorRT-LLM/TokenSpeed as user-excluded in
+  # fairness diagnostics.
+  framework_set: [sglang, vllm, tensorrt_llm, tokenspeed]
   request_rates: null
   max_concurrency: [null, 16, 32]
   qps:
@@ -131,3 +141,21 @@ frameworks:
       # options via --extra_llm_api_options. A single [null] value contributes
       # no dimension to the search.
       # extra_llm_api_options: [null, /path/to/trt_llm_config_A.yaml]
+
+  tokenspeed:
+    enabled: true
+    base_server_flags:
+      tensor_parallel_size: 4
+      trust_remote_code: true
+      gpu_memory_utilization: 0.90
+      max_model_len: 12288
+      dtype: auto
+      kv_cache_dtype: auto
+    search_space:
+      # Verify these names against `tokenspeed serve --help`.
+      max_num_seqs: [64, 128]
+      chunked_prefill_size: [8192, 16384]
+      max_prefill_tokens: [8192, 16384]
+      enable_prefix_caching: [true]
+      # Add backend/speculative/communication-fusion choices only after a
+      # target-image smoke run confirms the concrete TokenSpeed CLI values.

--- a/skills/llm-serving-auto-benchmark/references/framework-reference.md
+++ b/skills/llm-serving-auto-benchmark/references/framework-reference.md
@@ -164,7 +164,7 @@ Framework CLIs move quickly. For every real run:
 Historical validation from April 2026 used SGLang `0.5.10rc0`, vLLM `0.19.1`,
 and TensorRT-LLM `1.0.0`. A source refresh on 2026-06-26 checked SGLang
 `8524678889485801e7a4a12d62015be0c68f7a90`, vLLM
-`37ce34922f7f5e58241369511130cd99c1c50bfe`, TensorRT-LLM
+`abc71548ef029132c3316b902207f254a246d593`, TensorRT-LLM
 `0722c5f47d2cae69ac1a237da51e550dd214532c`, and TokenSpeed
 `5aedf69d6b476baa65571011de6ea60fd5a238a8`. Treat these as source evidence,
 not as a substitute for target-image `--help`. Since the prior refresh, vLLM PR

--- a/skills/llm-serving-auto-benchmark/references/framework-reference.md
+++ b/skills/llm-serving-auto-benchmark/references/framework-reference.md
@@ -1,8 +1,8 @@
 # Framework Reference
 
 Use this file when choosing native framework commands or translating tuning
-knobs across SGLang, vLLM, and TensorRT-LLM. Always verify the concrete CLI in
-the target container with `--help` before a long run.
+knobs across SGLang, vLLM, TensorRT-LLM, and TokenSpeed. Always verify the
+concrete CLI in the target container with `--help` before a long run.
 
 ## Native Entry Points
 
@@ -11,6 +11,7 @@ the target container with `--help` before a long run.
 | SGLang | `python -m sglang.launch_server` | `python -m sglang.auto_benchmark` or `python -m sglang.bench_serving` | Use `auto_benchmark` when available for server-flag search. Use `bench_serving` for direct native or OpenAI-compatible endpoint checks. |
 | vLLM | `vllm serve` | `vllm bench sweep serve` or `vllm bench serve` | Prefer `bench sweep serve` when sweeping server and benchmark parameter JSON files. |
 | TensorRT-LLM | `trtllm-serve serve --backend pytorch` | TensorRT-LLM serving benchmark client or a common OpenAI-compatible client | This skill does not cover engine-backed serving or non-PyTorch server backends. |
+| TokenSpeed | `tokenspeed serve` | `tokenspeed bench serve` or a common OpenAI-compatible client | Use as a first-class baseline for agentic workloads. Some images may also expose the binary as `ts`; record the actual command. |
 
 Common source docs:
 
@@ -19,6 +20,7 @@ Common source docs:
 - vLLM `bench sweep serve`: <https://docs.vllm.ai/en/latest/cli/bench/sweep/serve.html>
 - TensorRT-LLM `trtllm-serve`: <https://nvidia.github.io/TensorRT-LLM/commands/trtllm-serve/trtllm-serve.html>
 - TensorRT-LLM deployment guide: <https://nvidia.github.io/TensorRT-LLM/deployment-guide/index.html>
+- TokenSpeed repository and docs: <https://github.com/lightseekorg/tokenspeed>
 
 ## Command Templates
 
@@ -82,27 +84,72 @@ trtllm-serve serve <model> \
 
 Benchmark the OpenAI-compatible endpoint with the TensorRT-LLM serving benchmark
 client or the same OpenAI-compatible client used for the other frameworks. Keep
-server backend choice fixed to `pytorch`. On TensorRT-LLM current mainline
-checked at `b9e1945` on 2026-05-14, `--backend` choices are `pytorch`,
-`tensorrt`/`trt`, and `_autodeploy`, with `pytorch` as the default; this skill
-still rejects non-PyTorch server candidates. `--config` is the current alias for
-extra LLM API options, and `--kv_cache_free_gpu_memory_fraction` /
-`--free_gpu_memory_fraction` are both accepted aliases.
+server backend choice fixed to `pytorch`. Recheck `--backend`, extra options,
+and KV-cache memory aliases on the target `trtllm-serve serve --help`; this
+skill still rejects non-PyTorch server candidates even when the CLI exposes
+other backend choices.
+
+### TokenSpeed
+
+```bash
+tokenspeed serve <model> \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --tensor-parallel-size <tp> \
+  --gpu-memory-utilization 0.90 \
+  --max-model-len 12288 \
+  --max-num-seqs 64 \
+  --chunked-prefill-size 8192 \
+  --kv-cache-dtype auto \
+  --trust-remote-code
+
+tokenspeed bench serve \
+  --base-url http://127.0.0.1:8000 \
+  --model <model> \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 256 \
+  --num-prompts 80
+```
+
+For profiler handoff, TokenSpeed's benchmark can drive the same server
+profiler endpoints:
+
+```bash
+tokenspeed bench serve \
+  --base-url http://127.0.0.1:8000 \
+  --model <model> \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 256 \
+  --num-prompts 80 \
+  --profile \
+  --profile-num-steps 5 \
+  --extra-body '{"output_dir":"/data/bbuf/profiles/tokenspeed","activities":["CPU","GPU"],"with_stack":true,"profile_id":"ts-bench"}'
+```
+
+For TokenSpeed-native production-style runs, keep the server command as
+`tokenspeed serve <model>` and then add only flags confirmed by the target
+`tokenspeed serve --help`. Current docs show Kimi-style production knobs such as
+`--kv-cache-dtype fp8`, `--quantization nvfp4`,
+`--enable-expert-parallel`, `--chunked-prefill-size`,
+`--attention-backend trtllm_mla`, and `--moe-backend flashinfer_trtllm`; do not
+copy those backend choices to unrelated models without a smoke run.
 
 ## Knob Family Mapping
 
 Do not copy flag names across frameworks. Compare knob families, then translate
 to the target CLI.
 
-| Family | SGLang | vLLM | TensorRT-LLM |
-| --- | --- | --- | --- |
-| Parallelism | `--tp-size`, `--pp-size`, `--dp-size`, `--ep-size`, `--expert-parallel-size` | `--tensor-parallel-size`, `--pipeline-parallel-size`, `--data-parallel-size`, `--enable-expert-parallel` | `--tp_size`, `--pp_size`, `--ep_size`, `--gpus_per_node`, `--cluster_size` |
-| Memory and KV cache | `--mem-fraction-static`, `--max-total-tokens`, `--kv-cache-dtype`, `--page-size`, `--cpu-offload-gb` | `--gpu-memory-utilization`, `--kv-cache-memory-bytes`, `--kv-cache-dtype`, `--block-size`, `--cpu-offload-gb` | `--kv_cache_free_gpu_memory_fraction`, plus `--max_num_tokens`, `--max_seq_len`, `--max_batch_size` |
-| Batching and scheduler | `--max-running-requests`, `--schedule-policy`, `--chunked-prefill-size`, `--max-prefill-tokens`, `--prefill-max-requests` | `--max-num-seqs`, `--max-num-batched-tokens`, `--enable-chunked-prefill`, partial-prefill and DBO flags | `--max_batch_size`, `--max_num_tokens`, `--max_seq_len`; extra scheduler knobs may require `--extra_llm_api_options` |
-| Attention/backend | `--attention-backend`, `--prefill-attention-backend`, `--decode-attention-backend`, `--sampling-backend` | `--attention-backend`, `--gdn-prefill-backend`, `--mm-encoder-attn-backend` | `--backend pytorch` is fixed; do not search backend choice |
-| CUDA graph and compile | `--disable-cuda-graph`, `--cuda-graph-bs`, `--cuda-graph-max-bs`, `--disable-piecewise-cuda-graph`, `--enable-torch-compile` | `--enforce-eager`, `--compilation-config`, `--cudagraph-capture-sizes`, `--max-cudagraph-capture-size` | use direct flags or `--extra_llm_api_options`; record resolved PyTorch config from logs |
-| Prefix/speculative | `--disable-radix-cache`, `--disable-chunked-prefix-cache`, speculative decoding flags | `--enable-prefix-caching`, `--speculative-config` | only use PyTorch-backend options accepted by the target image |
-| Dtype, quantization, loading | `--dtype`, `--quantization`, `--load-format`, `--model-loader-extra-config`, `--trust-remote-code` | `--dtype`, `--quantization`, `--load-format`, `--model-loader-extra-config`, `--trust-remote-code`, `--hf-token` | `--trust_remote_code`, `--tokenizer`; engine build and non-PyTorch quantization flows are out of scope |
+| Family | SGLang | vLLM | TensorRT-LLM | TokenSpeed |
+| --- | --- | --- | --- | --- |
+| Parallelism | `--tp-size`, `--pp-size`, `--dp-size`, `--ep-size`, `--expert-parallel-size` | `--tensor-parallel-size`, `--pipeline-parallel-size`, `--data-parallel-size`, `--enable-expert-parallel` | `--tp_size`, `--pp_size`, `--ep_size`, `--gpus_per_node`, `--cluster_size` | `--tensor-parallel-size`, `--attn-tp-size`, `--dense-tp-size`, `--moe-tp-size`, `--enable-expert-parallel`, data-parallel flags |
+| Memory and KV cache | `--mem-fraction-static`, `--max-total-tokens`, `--kv-cache-dtype`, `--page-size`, `--cpu-offload-gb` | `--gpu-memory-utilization`, `--kv-cache-memory-bytes`, `--kv-cache-dtype`, `--block-size`, `--cpu-offload-gb` | `--kv_cache_free_gpu_memory_fraction`, plus `--max_num_tokens`, `--max_seq_len`, `--max_batch_size` | `--gpu-memory-utilization`, `--kv-cache-dtype`, `--max-total-tokens`, `--max-model-len`, `--max-prefill-tokens` |
+| Batching and scheduler | `--max-running-requests`, `--schedule-policy`, `--chunked-prefill-size`, `--max-prefill-tokens`, `--prefill-max-requests` | `--max-num-seqs`, `--max-num-batched-tokens`, `--enable-chunked-prefill`, partial-prefill and DBO flags | `--max_batch_size`, `--max_num_tokens`, `--max_seq_len`; extra scheduler knobs may require `--extra_llm_api_options` | `--max-num-seqs`, `--chunked-prefill-size`, `--max-prefill-tokens`, `--max-total-tokens` |
+| Attention/backend | `--attention-backend`, `--prefill-attention-backend`, `--decode-attention-backend`, `--sampling-backend` | `--attention-backend`, `--gdn-prefill-backend`, `--mm-encoder-attn-backend` | `--backend pytorch` is fixed; do not search backend choice | `--attention-backend`, `--drafter-attention-backend`, `--moe-backend`, `--draft-moe-backend` |
+| CUDA graph and compile | `--disable-cuda-graph`, `--cuda-graph-bs`, `--cuda-graph-max-bs`, `--disable-piecewise-cuda-graph`, `--enable-torch-compile` | `--enforce-eager`, `--compilation-config`, `--cudagraph-capture-sizes`, `--max-cudagraph-capture-size` | use direct flags or `--extra_llm_api_options`; record resolved PyTorch config from logs | CUDA graph padding flags, runtime graph settings, and communication-fusion flags accepted by the target image |
+| Prefix/speculative | `--disable-radix-cache`, `--disable-chunked-prefix-cache`, speculative decoding flags | `--enable-prefix-caching`, `--speculative-config` | only use PyTorch-backend options accepted by the target image | `--enable-prefix-caching`, `--speculative-config`, `--speculative-algorithm`, `--speculative-num-steps`, `--speculative-num-draft-tokens` |
+| Dtype, quantization, loading | `--dtype`, `--quantization`, `--load-format`, `--model-loader-extra-config`, `--trust-remote-code` | `--dtype`, `--quantization`, `--load-format`, `--model-loader-extra-config`, `--trust-remote-code`, `--hf-token` | `--trust_remote_code`, `--tokenizer`; engine build and non-PyTorch quantization flows are out of scope | `--dtype`, `--quantization`, `--trust-remote-code`, tokenizer/model loader flags accepted by `tokenspeed serve --help` |
 
 ## Version Rules
 
@@ -115,8 +162,9 @@ Framework CLIs move quickly. For every real run:
 4. Record which frameworks were model-smoked and which only passed preflight.
 
 Historical validation from April 2026 used SGLang `0.5.10rc0`, vLLM `0.19.1`,
-and TensorRT-LLM `1.0.0`. A source refresh on 2026-05-15 checked SGLang
-`50f405816`, vLLM `f3d536059`, and TensorRT-LLM `7021547`; the TensorRT-LLM
-serving flag evidence still comes from `b9e1945` because the newer commits did
-not touch serving code. Treat these as version evidence, not as a substitute
-for target-image `--help`.
+and TensorRT-LLM `1.0.0`. A source refresh on 2026-06-26 checked SGLang
+`b91348071e6ca21f9357fd8b1adc83a18781df30`, vLLM
+`c2507fb2937aa8c8e74bea15719d04fb6090befe`, TensorRT-LLM
+`4164b932c6c8a14d1be85d0fd62e44b7d0171980`, and TokenSpeed
+`5aedf69d6b476baa65571011de6ea60fd5a238a8`. Treat these as source evidence,
+not as a substitute for target-image `--help`.

--- a/skills/llm-serving-auto-benchmark/references/framework-reference.md
+++ b/skills/llm-serving-auto-benchmark/references/framework-reference.md
@@ -163,8 +163,11 @@ Framework CLIs move quickly. For every real run:
 
 Historical validation from April 2026 used SGLang `0.5.10rc0`, vLLM `0.19.1`,
 and TensorRT-LLM `1.0.0`. A source refresh on 2026-06-26 checked SGLang
-`b91348071e6ca21f9357fd8b1adc83a18781df30`, vLLM
-`c2507fb2937aa8c8e74bea15719d04fb6090befe`, TensorRT-LLM
-`4164b932c6c8a14d1be85d0fd62e44b7d0171980`, and TokenSpeed
+`8524678889485801e7a4a12d62015be0c68f7a90`, vLLM
+`37ce34922f7f5e58241369511130cd99c1c50bfe`, TensorRT-LLM
+`0722c5f47d2cae69ac1a237da51e550dd214532c`, and TokenSpeed
 `5aedf69d6b476baa65571011de6ea60fd5a238a8`. Treat these as source evidence,
-not as a substitute for target-image `--help`.
+not as a substitute for target-image `--help`. Since the prior refresh, vLLM PR
+`#46735` changed Triton/NVFP4 MoE CUDA graph capture behavior, and
+TensorRT-LLM PR `#11685` / `#15546` changed KV eviction and KV block-offset host
+staging behavior; record stale-image risk when these surfaces affect a row.

--- a/skills/llm-serving-auto-benchmark/references/result-schema.md
+++ b/skills/llm-serving-auto-benchmark/references/result-schema.md
@@ -79,6 +79,40 @@ values; this schema is not tied to H100.
     "p99_e2e_ms": 19000.0,
     "success_rate": 0.995
   },
+  "spec_decode": {
+    "enabled": false,
+    "algorithm": null,
+    "num_steps": null,
+    "num_draft_tokens": null,
+    "mean_accept_length": null,
+    "acceptance_rate": null
+  },
+  "phase_metrics": {
+    "pre_scheduler_ms": null,
+    "scheduler_ms": null,
+    "tokenizer_ms": null,
+    "detokenizer_ms": null,
+    "queue_ms": null
+  },
+  "cache": {
+    "prefix_cache_enabled": null,
+    "prefix_cache_hit_rate": null,
+    "kv_cache_tokens": null,
+    "kv_cache_utilization": null
+  },
+  "memory": {
+    "gpu_memory_utilization": null,
+    "kv_cache_dtype": null,
+    "cpu_offload_gb": null,
+    "gpu_resident_weight_gb": null
+  },
+  "normalization": {
+    "same_gpu_count": true,
+    "same_model_weights": true,
+    "same_tokenizer": true,
+    "same_endpoint": true,
+    "notes": ""
+  },
   "server_command": "python -m sglang.launch_server ...",
   "benchmark_command": "python -m sglang.bench_serving ...",
   "validated_cli_flags": {
@@ -104,6 +138,18 @@ also include p50/p95 buckets when available. These fields let the
   `--prefill-output-len 1`
 - decode profile: `--decode-input-len 1` and
   `--decode-output-len <slow output len>`
+
+Optional blocks:
+
+- `spec_decode`: speculative decoding settings and observed accept length. Use
+  this for SGLang, vLLM, TensorRT-LLM, and TokenSpeed when a candidate enables a
+  drafter/MTP/EAGLE-style path.
+- `phase_metrics`: non-kernel overheads that may explain a gap even when kernel
+  tables look similar, especially pre-scheduler and queue time.
+- `cache`: prefix/KV cache state that can bias repeated workload results.
+- `memory`: memory-residency settings that affect capacity and offload.
+- `normalization`: explicit fairness checks for same model, tokenizer, endpoint,
+  and GPU count.
 
 ## Status Values
 
@@ -157,8 +203,8 @@ The markdown summary must include these sections:
    per workload scenario and includes the best candidate, SLA result, throughput,
    latency metrics, GPU count, exact server command, and artifacts.
 2. `Cross-Framework Best Comparison`: one table that compares the best SGLang,
-   vLLM, and TensorRT-LLM command for each scenario. Sort each scenario by the
-   ranking rule above so the best deployment choice is first.
+   vLLM, TensorRT-LLM, and TokenSpeed command for each scenario. Sort each
+   scenario by the ranking rule above so the best deployment choice is first.
 3. `Failed Or SLA-Failing Candidates`: include this table when any candidate
    failed, was skipped, or completed without passing SLA. This table records
    tried configs that were not selected. Keep each reason concrete enough to

--- a/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
+++ b/skills/llm-serving-auto-benchmark/scripts/compare_benchmark_results.py
@@ -115,6 +115,14 @@ def _artifact_summary(row: dict[str, Any]) -> str:
     return "<br>".join(parts)
 
 
+def _optional_metric(row: dict[str, Any], *paths: str) -> Any:
+    for path in paths:
+        value = _get(row, path)
+        if value is not None:
+            return value
+    return None
+
+
 def load_rows(path: Path) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     with path.open(encoding="utf-8") as f:
@@ -160,6 +168,9 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         "mean_tpot_ms",
         "p99_ttft_ms",
         "p99_tpot_ms",
+        "mean_accept_length",
+        "pre_scheduler_ms",
+        "prefix_cache_hit_rate",
         "gpu_count",
         "server_command",
         "failure_reason",
@@ -185,6 +196,24 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
                     "mean_tpot_ms": _get(row, "metrics.mean_tpot_ms", ""),
                     "p99_ttft_ms": _get(row, "metrics.p99_ttft_ms", ""),
                     "p99_tpot_ms": _get(row, "metrics.p99_tpot_ms", ""),
+                    "mean_accept_length": _optional_metric(
+                        row,
+                        "spec_decode.mean_accept_length",
+                        "metrics.mean_accept_length",
+                    )
+                    or "",
+                    "pre_scheduler_ms": _optional_metric(
+                        row,
+                        "phase_metrics.pre_scheduler_ms",
+                        "metrics.pre_scheduler_ms",
+                    )
+                    or "",
+                    "prefix_cache_hit_rate": _optional_metric(
+                        row,
+                        "cache.prefix_cache_hit_rate",
+                        "metrics.prefix_cache_hit_rate",
+                    )
+                    or "",
                     "gpu_count": _get(row, "hardware.gpu_count", ""),
                     "server_command": _server_command(row),
                     "failure_reason": _get(row, "failure_reason", ""),
@@ -204,14 +233,14 @@ def _append_best_commands_by_framework(
             [
                 f"### `{framework}`",
                 "",
-                "| Scenario | Candidate | Status | SLA | Req/s | Output tok/s | Total tok/s | P50 TTFT ms | P50 TPOT ms | Success rate | GPUs | Server command | Artifacts |",
-                "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |",
+                "| Scenario | Candidate | Status | SLA | Req/s | Output tok/s | Total tok/s | P50 TTFT ms | P50 TPOT ms | Success rate | Accept len | Pre-scheduler ms | Cache hit | GPUs | Server command | Artifacts |",
+                "| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |",
             ]
         )
         rows = [row for row in scenario_winners if _get(row, "framework") == framework]
         for row in sorted(rows, key=_scenario):
             lines.append(
-                "| {scenario} | {candidate} | {status} | {sla} | {rps} | {otps} | {ttps} | {ttft} | {tpot} | {success} | {gpus} | {command} | {artifacts} |".format(
+                "| {scenario} | {candidate} | {status} | {sla} | {rps} | {otps} | {ttps} | {ttft} | {tpot} | {success} | {accept} | {sched} | {cache} | {gpus} | {command} | {artifacts} |".format(
                     scenario=_cell(_scenario(row)),
                     candidate=_cell(_get(row, "candidate_id", "")),
                     status=_cell(_get(row, "status", "")),
@@ -222,6 +251,27 @@ def _append_best_commands_by_framework(
                     ttft=_cell(_p50_or_mean_value(row, "ttft")),
                     tpot=_cell(_p50_or_mean_value(row, "tpot")),
                     success=_cell(_get(row, "metrics.success_rate")),
+                    accept=_cell(
+                        _optional_metric(
+                            row,
+                            "spec_decode.mean_accept_length",
+                            "metrics.mean_accept_length",
+                        )
+                    ),
+                    sched=_cell(
+                        _optional_metric(
+                            row,
+                            "phase_metrics.pre_scheduler_ms",
+                            "metrics.pre_scheduler_ms",
+                        )
+                    ),
+                    cache=_cell(
+                        _optional_metric(
+                            row,
+                            "cache.prefix_cache_hit_rate",
+                            "metrics.prefix_cache_hit_rate",
+                        )
+                    ),
                     gpus=_cell(_get(row, "hardware.gpu_count")),
                     command=_cell(_server_command(row)),
                     artifacts=_cell(_artifact_summary(row)),
@@ -237,8 +287,8 @@ def _append_cross_framework_table(
         [
             "## Cross-Framework Best Comparison",
             "",
-            "| Scenario | Rank | Framework | Candidate | SLA | Req/s | Output tok/s | P50 TTFT ms | P50 TPOT ms | GPUs | Server command |",
-            "| --- | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |",
+            "| Scenario | Rank | Framework | Candidate | SLA | Req/s | Output tok/s | P50 TTFT ms | P50 TPOT ms | Accept len | Pre-scheduler ms | Cache hit | GPUs | Server command |",
+            "| --- | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
         ]
     )
     scenario_names = sorted({_scenario(row) for row in scenario_winners})
@@ -246,7 +296,7 @@ def _append_cross_framework_table(
         rows = [row for row in scenario_winners if _scenario(row) == scenario_name]
         for rank, row in enumerate(sorted(rows, key=_rank_key, reverse=True), 1):
             lines.append(
-                "| {scenario} | {rank} | {framework} | {candidate} | {sla} | {rps} | {otps} | {ttft} | {tpot} | {gpus} | {command} |".format(
+                "| {scenario} | {rank} | {framework} | {candidate} | {sla} | {rps} | {otps} | {ttft} | {tpot} | {accept} | {sched} | {cache} | {gpus} | {command} |".format(
                     scenario=_cell(scenario_name),
                     rank=rank,
                     framework=_cell(_get(row, "framework", "")),
@@ -256,6 +306,27 @@ def _append_cross_framework_table(
                     otps=_cell(_get(row, "metrics.output_token_throughput")),
                     ttft=_cell(_p50_or_mean_value(row, "ttft")),
                     tpot=_cell(_p50_or_mean_value(row, "tpot")),
+                    accept=_cell(
+                        _optional_metric(
+                            row,
+                            "spec_decode.mean_accept_length",
+                            "metrics.mean_accept_length",
+                        )
+                    ),
+                    sched=_cell(
+                        _optional_metric(
+                            row,
+                            "phase_metrics.pre_scheduler_ms",
+                            "metrics.pre_scheduler_ms",
+                        )
+                    ),
+                    cache=_cell(
+                        _optional_metric(
+                            row,
+                            "cache.prefix_cache_hit_rate",
+                            "metrics.prefix_cache_hit_rate",
+                        )
+                    ),
                     gpus=_cell(_get(row, "hardware.gpu_count")),
                     command=_cell(_server_command(row)),
                 )

--- a/skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py
+++ b/skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py
@@ -17,13 +17,14 @@ from typing import Any
 
 import yaml
 
-FRAMEWORKS = ("sglang", "vllm", "tensorrt_llm")
+FRAMEWORKS = ("sglang", "vllm", "tensorrt_llm", "tokenspeed")
 ALLOWED_SOURCE_KINDS = {"llm_serving_cookbook"}
 
 SEQUENCE_LIMIT_KEY = {
     "sglang": "context_length",
     "vllm": "max_model_len",
     "tensorrt_llm": "max_seq_len",
+    "tokenspeed": "max_model_len",
 }
 
 ALLOWED_SLA_KEYS = {
@@ -104,17 +105,51 @@ STATIC_SERVER_FLAGS = {
         "tp_size",
         "trust_remote_code",
     },
+    "tokenspeed": {
+        "attention_backend",
+        "attn_tp_size",
+        "chunked_prefill_size",
+        "comm_fusion_max_num_tokens",
+        "disable_cuda_graph_padding",
+        "dtype",
+        "enable_allreduce_fusion",
+        "enable_expert_parallel",
+        "enable_mla_l1_5_cache",
+        "enable_prefix_caching",
+        "gpu_memory_utilization",
+        "host",
+        "kv_cache_dtype",
+        "max_model_len",
+        "max_num_seqs",
+        "max_prefill_tokens",
+        "max_total_tokens",
+        "mla_chunk_multiplier",
+        "moe_backend",
+        "moe_tp_size",
+        "port",
+        "quantization",
+        "reasoning_parser",
+        "speculative_algorithm",
+        "speculative_config",
+        "speculative_draft_model_path",
+        "speculative_num_draft_tokens",
+        "speculative_num_steps",
+        "tensor_parallel_size",
+        "tool_call_parser",
+        "trust_remote_code",
+    },
 }
 
 HELP_FILE_HINTS = {
     "sglang": ("sglang", "launch"),
     "vllm": ("vllm", "serve"),
     "tensorrt_llm": ("trtllm", "serve"),
+    "tokenspeed": ("tokenspeed", "serve"),
 }
 
 
 def flag_name(framework: str, key: str) -> str:
-    if framework in {"sglang", "vllm"}:
+    if framework in {"sglang", "vllm", "tokenspeed"}:
         return "--" + key.replace("_", "-")
     return "--" + key
 
@@ -176,7 +211,7 @@ def _command_tokens(
     command = shlex.split(server["server_command"])
     model = config["model"]["name"]
 
-    if framework in {"vllm", "tensorrt_llm"}:
+    if framework in {"vllm", "tensorrt_llm", "tokenspeed"}:
         command.append(model)
 
     for key, value in flags.items():

--- a/skills/llm-torch-profiler-analysis/SKILL.md
+++ b/skills/llm-torch-profiler-analysis/SKILL.md
@@ -157,7 +157,8 @@ H100 notes:
 - SGLang kernel-site reconstruction keeps sampling disabled in the mapping path so the optimized parser does not perturb SGLang table output; equality rechecks matched for `Mixtral-8x7B-Instruct-v0.1`, `Qwen3-32B`, and `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8`
 - vLLM live capture requires `--output-dir` to match the server `torch_profiler_dir`; the validated H100 flow uses `--profiler-config {"profiler":"torch","torch_profiler_dir":"..."}` and then drives `/start_profile` and `/stop_profile`
 - TensorRT-LLM validation stays on `--backend pytorch`; the H100 flow writes the trace with `TLLM_TORCH_PROFILE_TRACE` and then analyzes the saved trace
-- TensorRT-LLM current mainline was rechecked at `7021547` on 2026-05-15; the newer commits did not touch profiling/server code, so the `b9e1945` profiler evidence still applies: PyTorch profiling uses `record_shapes=True` and `with_modules=True`, but not `with_stack=True`; keep the override path for table-quality Python locations unless the target image proves otherwise
+- TensorRT-LLM current mainline was rechecked at `0722c5f47d2cae69ac1a237da51e550dd214532c` on 2026-06-26; the latest delta affects KV eviction / block-offset staging rather than profiler trace controls, so the `b9e1945` profiler evidence still applies: PyTorch profiling uses `record_shapes=True` and `with_modules=True`, but not `with_stack=True`; keep the override path for table-quality Python locations unless the target image proves otherwise
+- TokenSpeed trace analysis has first-class registry rows for native TokenSpeed CuTe DSL MLA, MLA KV pack + FP8 quantize, fused top-k/top-p sampling, persistent lm_head GEMM, and NVFP4 GEMM + SwiGLU + quant; live capture still requires an existing torch-profiler trace until the target TokenSpeed image exposes a supported profiler API
 - on this host, keep all trace roots under `/data/...`, not `/home/...`
 
 ## When To Use It

--- a/skills/llm-torch-profiler-analysis/SKILL.md
+++ b/skills/llm-torch-profiler-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llm-torch-profiler-analysis
-description: "Unified LLM torch-profiler triage skill for `sglang`, `vllm`, and `TensorRT-LLM`. Use it to inspect an existing `trace.json(.gz)` or profile directory, or to drive live profiling against a running server and return one three-table report with kernel, overlap-opportunity, and fuse-pattern tables."
+description: "Unified LLM torch-profiler triage skill for `sglang`, `vllm`, `TensorRT-LLM`, and `TokenSpeed`. Use it to inspect an existing `trace.json(.gz)` or profile directory, or to drive live profiling against a running server when supported and return one three-table report with kernel, overlap-opportunity, and fuse-pattern tables."
 ---
 
 # Unified LLM Torch Profiler Analysis
@@ -12,6 +12,7 @@ Use this skill for `torch.profiler` analysis across:
 - `sglang`
 - `vllm`
 - `TensorRT-LLM`
+- `TokenSpeed`
 
 There is only one public workflow:
 
@@ -50,18 +51,26 @@ add one short note after the tables with exactly one of:
 
 ## Capability Matrix
 
-| Capability | SGLang | vLLM | TensorRT-LLM |
-| --- | --- | --- | --- |
-| Existing trace triage | yes | yes | yes |
-| Single-trace live capture | yes | yes, if torch profiler is enabled on server | requires profiler control endpoints |
-| Two-trace mapping+formal triage | yes | yes | yes |
-| Stage-separated live workload | yes | yes | yes, with a writable shared trace dir or per-stage host runner |
-| `--profile-by-stage` capture | yes | no | no |
-| `--profile-prefix` control | yes | usually ignored on HTTP profiler route | usually ignored on HTTP profiler route |
+| Capability | SGLang | vLLM | TensorRT-LLM | TokenSpeed |
+| --- | --- | --- | --- | --- |
+| Existing trace triage | yes | yes | yes | yes |
+| Single-trace live capture | yes | yes, if torch profiler is enabled on server | requires profiler control endpoints | yes, if `/start_profile` and `/stop_profile` are exposed |
+| Two-trace mapping+formal triage | yes | yes | yes | yes |
+| Stage-separated live workload | yes | yes | yes, with a writable shared trace dir or per-stage host runner | yes, via workload-separated HTTP capture |
+| `--profile-by-stage` capture | yes | no | no | no |
+| `--profile-prefix` control | yes | usually ignored on HTTP profiler route | usually ignored on HTTP profiler route | yes, mapped to `profile_id` |
 
 For TensorRT-LLM, live capture only works when the server exposes `/start_profile` and
 `/stop_profile`, and when the deployment already provides a shared trace path plus the
 required env vars.
+
+For TokenSpeed, this skill supports both existing trace triage and live capture
+against current servers that expose `/start_profile` and `/stop_profile`.
+The live helper sends `output_dir`, `activities`, `with_stack`,
+`record_shapes`, and `profile_id` in the start payload. TokenSpeed also has its
+own native `profile_by_stage` field for manual capture, but the unified helper
+uses workload-separated `prefill/` and `decode/` directories by default so the
+tables stay comparable across frameworks.
 
 ## Real H100 Validation
 
@@ -98,6 +107,9 @@ Validated matrix:
 Use this run as the main H100 reference.
 The older `2026-04-22` single-card Qwen3 matrix is still useful for bring-up, but it is
 not the default reference anymore.
+TokenSpeed support was added later and is covered by existing-trace triage and
+HTTP profiler-control support, but it is not part of this older H100 validation
+matrix yet.
 
 Stage-separated workload validation captured on `2026-05-01` on `h100_sglang`:
 
@@ -150,7 +162,8 @@ H100 notes:
 
 ## When To Use It
 
-- inspect a `torch.profiler` trace or profile directory from `sglang`, `vllm`, or `TensorRT-LLM`
+- inspect a `torch.profiler` trace or profile directory from `sglang`, `vllm`,
+  `TensorRT-LLM`, or `TokenSpeed`
 - profile a live serving endpoint and analyze the result
 - summarize which kernel families dominate prefill or decode
 - map kernels back to Python code paths
@@ -322,7 +335,97 @@ This is the validated TensorRT-LLM flow on `h100_sglang`:
 2. run a few benchmark requests
 3. analyze the emitted trace with `--input /data/.../trace.json`
 
-### 5. Two-trace triage from existing profile dirs or traces
+### 5. Single-trace live capture or triage from TokenSpeed
+
+For a running TokenSpeed server that exposes the profiler routes, the unified
+helper can drive live capture:
+
+```bash
+python3 scripts/analyze_llm_torch_profile.py \
+  --framework tokenspeed \
+  --url http://127.0.0.1:8000 \
+  --output-dir /data/bbuf/validate/unified_llm_profiler_skill/runs/example/tokenspeed_profile \
+  --num-steps 5 \
+  --warmup-steps 10 \
+  --no-profile-by-stage \
+  --profile-workload both \
+  --profile-prefix ts-triage
+```
+
+The helper sends `POST /start_profile` with:
+
+- `output_dir`: the `--output-dir` path
+- `activities`: `["CPU", "GPU"]`
+- `with_stack`: `true`
+- `record_shapes`: `false`
+- `profile_id`: `--profile-prefix`, with `-prefill` or `-decode` appended during workload-separated capture
+
+It then sends OpenAI-compatible probe requests and calls `POST /stop_profile`.
+TokenSpeed writes files such as `ts-triage-prefill-TP-0.trace.json.gz` under the
+output directory. If the server was launched with multiple TP ranks, expect one
+trace per rank.
+
+Existing TokenSpeed torch-profiler traces can still be analyzed directly:
+
+```bash
+python3 scripts/analyze_llm_torch_profile.py \
+  --framework tokenspeed \
+  --input /path/to/tokenspeed_profile_dir_or_trace.json.gz
+```
+
+TokenSpeed's own manual profiler control surface can also be used:
+
+```bash
+curl -X POST http://127.0.0.1:8000/start_profile \
+  -H 'Content-Type: application/json' \
+  -d '{"output_dir":"/data/bbuf/profiles/tokenspeed","activities":["CPU","GPU"],"with_stack":true,"record_shapes":false,"profile_id":"ts-manual"}'
+
+# send representative workload here
+
+curl -X POST http://127.0.0.1:8000/stop_profile
+```
+
+For server-side automatic stop, pass `num_steps`. For TokenSpeed-native
+EXTEND/DECODE split, pass `profile_by_stage: true`; this produces files with
+stage suffixes such as `-EXTEND` and `-DECODE`.
+
+TokenSpeed's benchmark driver can capture traces too:
+
+```bash
+tokenspeed bench serve \
+  --base-url http://127.0.0.1:8000 \
+  --model <model> \
+  --dataset-name random \
+  --random-input-len 4090 \
+  --random-output-len 1 \
+  --num-prompts 64 \
+  --profile \
+  --profile-num-steps 5 \
+  --extra-body '{"output_dir":"/data/bbuf/profiles/tokenspeed","activities":["CPU","GPU"],"with_stack":true,"profile_id":"ts-bench"}'
+```
+
+If `output_dir` is omitted, TokenSpeed falls back to `TOKENSPEED_PROFILER_DIR`
+and then `/tmp`.
+
+Use [scripts/probe_llm_server.py](scripts/probe_llm_server.py) with
+`--framework tokenspeed` for a small OpenAI-compatible endpoint probe before or
+after trace collection:
+
+```bash
+python3 scripts/probe_llm_server.py \
+  --framework tokenspeed \
+  --url http://127.0.0.1:8000 \
+  --requests 6 \
+  --max-tokens 48
+```
+
+For `sglang-sota-humanize-loop`, keep TokenSpeed profiler evidence aligned to
+the same slow scenario bucket as the benchmark result. Prefer the unified
+workload-separated live capture when possible; if only a mixed agentic trace is
+available, label that limitation in `analysis/root-cause.md` before comparing
+it to SGLang prefill/decode traces.
+
+### 6. Two-trace triage from existing profile dirs or traces
 
 ```bash
 python3 scripts/analyze_llm_torch_profile.py \
@@ -332,7 +435,7 @@ python3 scripts/analyze_llm_torch_profile.py \
 
 Use this when you need stronger overlap attribution and kernel-to-source mapping.
 
-### 6. Two-trace triage from running servers
+### 7. Two-trace triage from running servers
 
 ```bash
 python3 scripts/analyze_llm_torch_profile.py \
@@ -350,6 +453,10 @@ For `vllm` or `TensorRT-LLM`, use the same shape but pass:
 - `--formal-output-dir ...`
 - `--no-profile-by-stage`
 
+For TokenSpeed, either use `--mapping-url` and `--formal-url` against servers
+that expose `/start_profile` and `/stop_profile`, or pass two existing trace
+directories with `--mapping-input` and `--formal-input`.
+
 ## `profile_by_stage`
 
 `--profile-by-stage` is only meaningful on the SGLang live-capture path.
@@ -363,7 +470,8 @@ For `vllm` or `TensorRT-LLM`, use the same shape but pass:
   bottlenecks.
 - On the current profile-v2 path inside SGLang, stage-based profiling is effectively the normal path.
 - PD-disaggregated serving adds one extra rule: prefill workers and decode workers must be profiled separately. That is stricter than ordinary `profile_by_stage`.
-- For `vllm` and `TensorRT-LLM`, disable it with `--no-profile-by-stage`.
+- For `vllm`, `TensorRT-LLM`, and `TokenSpeed`, disable it with
+  `--no-profile-by-stage`.
 
 ## How To Choose The Triage Shape
 

--- a/skills/llm-torch-profiler-analysis/references/fuse-overlap-catalog.md
+++ b/skills/llm-torch-profiler-analysis/references/fuse-overlap-catalog.md
@@ -30,7 +30,7 @@ The catalog is grouped by reusable optimization family, not by one specific mode
 
 Refresh note `2026-06-26`: rechecked official main heads for SGLang
 `8524678889485801e7a4a12d62015be0c68f7a90`, vLLM
-`37ce34922f7f5e58241369511130cd99c1c50bfe`, TensorRT-LLM
+`abc71548ef029132c3316b902207f254a246d593`, TensorRT-LLM
 `0722c5f47d2cae69ac1a237da51e550dd214532c`, and TokenSpeed
 `5aedf69d6b476baa65571011de6ea60fd5a238a8`. The vLLM torch.compile pass
 inventory is split out in

--- a/skills/llm-torch-profiler-analysis/references/fuse-overlap-catalog.md
+++ b/skills/llm-torch-profiler-analysis/references/fuse-overlap-catalog.md
@@ -28,13 +28,18 @@ overlap opportunity as novel.
 
 The catalog is grouped by reusable optimization family, not by one specific model.
 
-Refresh note `2026-05-15`: rescanned current `sglang`, vLLM, and TensorRT-LLM
-mainline snapshots. The vLLM torch.compile pass inventory is split out in
+Refresh note `2026-06-26`: rechecked official main heads for SGLang
+`8524678889485801e7a4a12d62015be0c68f7a90`, vLLM
+`37ce34922f7f5e58241369511130cd99c1c50bfe`, TensorRT-LLM
+`0722c5f47d2cae69ac1a237da51e550dd214532c`, and TokenSpeed
+`5aedf69d6b476baa65571011de6ea60fd5a238a8`. The vLLM torch.compile pass
+inventory is split out in
 [`vllm-torch-compile-fusions.md`](vllm-torch-compile-fusions.md). Stable
-current-code families remain folded into the mainline rows below. New rows were
-added for vLLM MLA RoPE+KV-cache cat fusion, DSV4 norm/router, TokenSpeed MLA,
-and ROCm/gfx950 paged-MQA logits. Recheck PR state before treating an in-flight
-row as shipped.
+current-code families remain folded into the mainline rows below. This refresh
+adds first-class TokenSpeed-origin rows for CuTe DSL MLA, MLA KV pack+FP8
+quantize, sampling, lm_head GEMM, and NVFP4 GEMM+SwiGLU+quant, plus the latest
+SGLang LTX2 Ada-value diffusion fusion. Recheck PR state before treating an
+in-flight row as shipped.
 
 ## 1. LLM / SRT fused-kernel families
 
@@ -113,6 +118,7 @@ row as shipped.
 | Fused diffusion QK norm + RoPE | split QK norm and RoPE in diffusion attention blocks | `python/sglang/jit_kernel/diffusion/qknorm_rope.py`<br>`python/sglang/multimodal_gen/runtime/layers/layernorm.py::apply_qk_norm_rope` | `fused_inplace_qknorm_rope(...)`, with fallback to QK norm plus `apply_flashinfer_rope_qk_inplace(...)` | Distinguish between missing fused qknorm + rope and the existing FlashInfer RoPE fallback. |
 | Z-Image fused `norm(x) * tanh(scale) + shift` | `fused_norm_tanh_mul_add`<br>`tanh(gate) * rmsnorm(x)` | `python/sglang/jit_kernel/diffusion/cutedsl/norm_tanh_mul_add_norm_scale.py`<br>`python/sglang/multimodal_gen/runtime/layers/layernorm.py` | CuTeDSL kernel plus runtime helper for Z-Image residual-form modulation | Treat split Z-Image residual-form modulation as a missing existing diffusion fusion, not a novel idea. |
 | Z-Image fused residual modulation + next norm-scale | `fused_norm_tanh_mul_add_norm_scale`<br>`residual + tanh(gate) * rmsnorm(x)`<br>`ffn_norm1(x) * scale_mlp` | `python/sglang/jit_kernel/diffusion/cutedsl/norm_tanh_mul_add_norm_scale.py`<br>`python/sglang/multimodal_gen/runtime/models/dits/zimage.py` | One CuTeDSL kernel fuses the first residual-form modulation and the next normalization / scale stage | If you see this chain split in Z-Image traces, report it as a missing existing mainline fusion family. |
+| LTX2 fused Ada values | `ltx2_ada_values9`<br>`get_ada_values`<br>`scale_shift_table + timestep.reshape` | `python/sglang/jit_kernel/diffusion/triton/ltx2_ada_values.py`<br>`python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py` | PR `#29390` fuses LTX-2.3 Ada value materialization for video/audio streams and reuses the 9 Ada tensors across self-attention, MLP, and prompt-cross-attention blocks | Treat repeated Ada add/reshape/slice ladders in LTX2 traces as a missing shipped SGLang fusion first. |
 | Nunchaku fused GELU MLP | `_fused_gelu_mlp`<br>`fused_gelu_mlp` | `python/sglang/multimodal_gen/runtime/models/dits/flux.py` | Nunchaku path fuses `fc1 GEMM + GELU + shift + re-quant + fc2.lora_down` before the second GEMM | Treat split GELU-MLP on Nunchaku checkpoints as an existing fused family, not a new discovery. |
 
 ## 5. Diffusion kernel-overlap and async-communication families
@@ -259,7 +265,20 @@ contain the same implementation.
 | vLLM-origin fused MoE LoRA | `fused_moe_lora`<br>`fused_moe_lora_fp8`<br>`w13_shrink`<br>`w2_expand` | `vllm/lora/ops/triton_ops/fused_moe_lora_op.py`<br>`vllm/lora/ops/triton_ops/fused_moe_lora_fp8_op.py`<br>`vllm/lora/layers/fused_moe.py` | Triton kernels fuse LoRA shrink / expand work into MoE expert execution, including FP8 variants | Treat MoE-LoRA adapter work as an upstream fused family before proposing a brand new kernel. |
 | vLLM-origin ViT fused bilinear position-embedding interpolation | `triton_pos_embed_interpolate`<br>`bilinear_pos_embed`<br>`pos_embed_interpolate_native` | `vllm/model_executor/models/qwen3_vl.py` | Triton kernel fuses bilinear interpolation and spatial-merge reorder for Qwen3-VL ViT position embeddings, replacing many tiny eager kernels | Treat VLM position-embedding ladders as an existing vLLM-origin Triton fusion family. |
 
-## 15. vLLM-origin kernel-overlap families
+## 15. TokenSpeed-origin fused-kernel families
+
+These rows are direct TokenSpeed families from `lightseekorg/tokenspeed`, not
+only vLLM references to the TokenSpeed package.
+
+| Pattern | Trace keywords | Primary code | Existing path | Skill should conclude |
+| --- | --- | --- | --- | --- |
+| TokenSpeed CuTe DSL MLA prefill / decode | `tokenspeed_mla_decode`<br>`tokenspeed_mla_prefill`<br>`BlackwellMultiHeadLatentAttentionForward` | `python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py`<br>`tokenspeed-mla/python/tokenspeed_mla/mla_decode.py`<br>`tokenspeed-mla/python/tokenspeed_mla/mla_prefill.py`<br>`tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/tokenspeed_mla/__init__.py` | Blackwell SM100 CuTe DSL MLA kernels cover FP8-KV prefill/decode/verify paths through the `tokenspeed_mla` backend | On TokenSpeed or vLLM+TokenSpeed MLA traces, compare backend selection before proposing a new MLA attention kernel. |
+| TokenSpeed MLA KV pack + FP8 quantize | `_mla_kv_pack_quantize_fp8_kernel`<br>`mla_kv_pack_quantize_fp8`<br>`k_nope` / `k_pe` | `tokenspeed-mla/python/tokenspeed_mla/mla_kv_pack_quantize_fp8.py`<br>`tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/tokenspeed_mla/__init__.py` | One Triton kernel packs `k_nope`, broadcast `k_pe`, and `v`, then writes FP8 K/V for MLA chunked prefill | Treat split K/V concat + FP8 cast ladders as a known TokenSpeed fusion family. |
+| TokenSpeed fused top-k + top-p sampling | `fused_topk_topp`<br>`fused_topk_topp_renorm` | `tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/fused_topk_topp.py`<br>`tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/fused_topk_topp/fused_topk_topp.cu` | CUDA extension fuses top-k, top-p, and renormalization for decode sampling | Treat top-k/top-p/renorm chains in TokenSpeed traces as an existing sampling fusion first. |
+| TokenSpeed persistent lm_head GEMM | `lm_head_gemm`<br>`should_use_fused`<br>`persistent` | `tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/lm_head_gemm.py`<br>`tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/csrc/lm_head_gemm.cu` | Shape-gated persistent GEMM replaces `torch.matmul` for selected lm_head / router-like projection shapes | Treat visible lm_head matmul ladders as a candidate for this existing TokenSpeed path before inventing a new logits GEMM. |
+| TokenSpeed NVFP4 GEMM + SwiGLU + quant | `nvfp4_gemm_swiglu_nvfp4_quant`<br>`SwiGLU`<br>`SFC` | `tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/nvfp4_gemm_swiglu_nvfp4_quant.py` | CuTe DSL kernel fuses block-scaled NVFP4 GEMM, SwiGLU, and optional output quantization | Treat split expert GEMM + activation + FP4 quant chains as matching an upstream TokenSpeed kernel family. |
+
+## 16. vLLM-origin kernel-overlap families
 
 | Pattern | Trace keywords | Primary code | Existing path | Skill should conclude |
 | --- | --- | --- | --- | --- |
@@ -268,7 +287,7 @@ contain the same implementation.
 | vLLM-origin shared-expert aux-stream overlap | `aux_stream`<br>`shared_experts_stream`<br>shared expert near router | `vllm/model_executor/layers/fused_moe/runner/shared_experts.py`<br>`vllm/model_executor/layers/fused_moe/runner/moe_runner_base.py` | MoE shared experts can record the cloned input on `shared_experts_stream`, wait on the caller stream, run in parallel with router-side work, and rejoin before merge | Treat shared-expert vs router overlap as an existing upstream sparse-model family. |
 | vLLM-origin DCP async all-to-all overlap | `dcp_alltoall`<br>`all_to_all_single`<br>`async_op=True` | `vllm/v1/attention/ops/dcp_alltoall.py` | Output / LSE exchange uses async all-to-all handles instead of serializing collective completion on the main path | Treat DCP all-to-all windows as an upstream async-collective family. |
 
-## 16. vLLM-origin PR-backed / in-flight fused-kernel and kernel-overlap families
+## 17. vLLM-origin PR-backed / in-flight fused-kernel and kernel-overlap families
 
 | Pattern | Trace keywords | Primary code | Existing path | Skill should conclude |
 | --- | --- | --- | --- | --- |
@@ -289,7 +308,7 @@ contain the same implementation.
 | PRs `#41433` / `#41434` / `#41429` / `#40561` GPU/CPU sync removal | `GPU->CPU sync`<br>`cpu sync`<br>`item()`<br>`non_blocking` | `PR #41433`<br>`PR #41434`<br>`PR #41429`<br>`PR #40561` | Removes or gates accidental GPU-to-CPU synchronization points and adds sync-detection coverage | Treat CPU gaps next to small GPU kernels as an upstream vLLM sync-removal family before proposing a kernel-only fix. |
 | PR `#36823` vLLM IR `fused_add_rms_norm` overload | `vllm_ir`<br>`fused_add_rms_norm`<br>`maybe_inplace` | `PR #36823`<br>`vllm/compilation/passes/ir`<br>`vllm/compilation/passes/fusion/rms_quant_fusion.py` | Extends vLLM IR lowering so fused-add-RMSNorm variants remain visible to later compile-time fusions | Treat missing norm/quant compile fusion as potentially an IR-lowering visibility issue. |
 
-## 17. Important toggles and caveats
+## 18. Important toggles and caveats
 
 | Toggle / env | Location | Effect on trace interpretation |
 | --- | --- | --- |
@@ -332,9 +351,13 @@ contain the same implementation.
 | `PassConfig.fuse_act_padding` | `vllm/config/compilation.py` | Enables the ROCm AITER add-RMSNorm-plus-pad fusion family when AITER is available. |
 | `PassConfig.enable_sp` | `vllm/config/compilation.py` | Rewrites all-reduce into sequence-parallel staging; this is often a prerequisite for the overlap family, not just a pure fuse toggle. |
 | `PassConfig.fuse_gemm_comms` | `vllm/config/compilation.py` | Enables AsyncTP GEMM + collective overlap and auto-enables `enable_sp` when valid. |
+| vLLM PR `#46735` Triton MoE CUDA graph capture fix | `vllm/model_executor/layers/fused_moe/experts/triton_moe.py`<br>`vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py` | Latest vLLM mainline fixes CUDA graph capture around Triton / NVFP4-emulation MoE; stale target images may show graph-capture failures or eager fallbacks that are not SGLang kernel wins. |
 | `TRTLLM_ENABLE_PDL` | `csrc/libtorch_stable/dsv3_fused_a_gemm.cu`<br>`csrc/moe/dsv3_router_gemm_utils.h` | Enables programmatic dependent launch for the DSV3 specialized CUDA kernels, which can change launch grouping and trace shape for router / QKV-A paths. |
+| TokenSpeed `--attention-backend tokenspeed_mla` | `python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py` | Selects TokenSpeed's native CuTe DSL MLA backend; requires compatible Blackwell FP8-KV MLA shapes, so split MLA support kernels may indicate backend gating rather than a missing kernel. |
+| TokenSpeed `TOKENSPEED_MLA_PREFILL_BACKEND` | `tokenspeed-mla/python/tokenspeed_mla/mla_prefill.py` | Chooses CuTe DSL JIT vs binary prefill backend; trace kernel names can differ even when the same MLA fused family applies. |
+| TokenSpeed `--comm-fusion-max-num-tokens` / `--enable-allreduce-fusion` | `docs/configuration/server.md`<br>`python/tokenspeed/runtime/distributed/comm_backend` | Gates TokenSpeed communication-fusion behavior; inspect these before treating all-reduce + compute separation as a novel overlap gap. |
 
-## 18. Suggested refresh commands
+## 19. Suggested refresh commands
 
 These commands are only for maintainers refreshing this catalog by rescanning
 the local source trees. They are not used by the triage scripts at runtime.

--- a/skills/llm-torch-profiler-analysis/references/overlap-catalog.md
+++ b/skills/llm-torch-profiler-analysis/references/overlap-catalog.md
@@ -26,9 +26,12 @@ necessarily present in the checked-out `sglang` tree, but they should still be
 treated as upstream or analogous kernel-overlap families before labeling an
 overlap opportunity as novel.
 
-Refresh note `2026-04-22`: rescanned current `sglang`, `flashinfer`,
-`TensorRT-LLM`, and `vllm` mainline overlap paths plus rechecked referenced PR
-state via the GitHub API on `2026-04-22`. Closed-unmerged SGLang
+Refresh note `2026-06-26`: rechecked official main heads for SGLang
+`8524678889485801e7a4a12d62015be0c68f7a90`, vLLM
+`37ce34922f7f5e58241369511130cd99c1c50bfe`, TensorRT-LLM
+`0722c5f47d2cae69ac1a237da51e550dd214532c`, and TokenSpeed
+`5aedf69d6b476baa65571011de6ea60fd5a238a8`, then added the first
+TokenSpeed-origin communication-fusion row. Closed-unmerged SGLang
 [#22410](https://github.com/sgl-project/sglang/pull/22410) and FlashInfer
 [#2840](https://github.com/flashinfer-ai/flashinfer/pull/2840) were removed
 from the PR-backed sections. SGLang
@@ -107,7 +110,16 @@ AutoDeploy rather than same-stream PDL windows.
 | TensorRT-LLM multi-stream MoE shared-vs-routed overlap | `multi_stream_moe`<br>`begin_aux_stream_passthrough`<br>`end_aux_stream_passthrough`<br>`wait_aux_stream_passthrough`<br>`mlir_elementwise_fusion`<br>`piecewise cudagraph`<br>`caller_stream.synchronize()` | `tensorrt_llm/_torch/auto_deploy/transform/library/multi_stream_moe.py`<br>`tensorrt_llm/_torch/auto_deploy/utils/multi_stream_utils.py` | Shared-expert work is moved to an auxiliary stream while routed-expert MoE work remains on the main stream and rejoins at the merge node; the same family includes synchronization rules for MLIR-fused kernels and piecewise cudagraph replay | Treat shared-expert vs routed-expert windows, including altered behavior under MLIR / piecewise graph modes, as an existing TensorRT-LLM branch-overlap family. |
 | TensorRT-LLM multi-stream FP8 GEMM fork parallelism | `multi_stream_gemm`<br>`trtllm_finegrained_fp8_linear`<br>`record_event_passthrough`<br>`_aux` | `tensorrt_llm/_torch/auto_deploy/transform/library/multi_stream_gemm.py`<br>`tensorrt_llm/_torch/auto_deploy/utils/multi_stream_utils.py` | Compiler pass identifies fork points with multiple FP8 linears and moves the largest GEMM to the auxiliary stream so sibling GEMMs overlap | Treat sibling FP8 linear branches as an existing TensorRT-LLM overlap family before designing a new stream split. |
 
-## 8. vLLM-origin kernel-overlap families
+## 8. TokenSpeed-origin kernel-overlap families
+
+These rows are comparative references from `lightseekorg/tokenspeed`. Use them
+when the trace is from TokenSpeed or from a vLLM/TokenSpeed hybrid deployment.
+
+| Pattern | Trace keywords | Primary code | Existing path | Skill should conclude |
+| --- | --- | --- | --- | --- |
+| TokenSpeed allreduce / communication fusion | `enable_allreduce_fusion`<br>`comm_fusion`<br>`comm_fusion_max_num_tokens`<br>`allreduce` | `docs/configuration/server.md`<br>`python/tokenspeed/runtime/distributed/comm_backend` | TokenSpeed exposes runtime knobs for communication fusion and token-count gating, so all-reduce windows may be a disabled or shape-gated TokenSpeed path | Treat split all-reduce + compute windows in TokenSpeed traces as a comm-fusion eligibility question before calling it a novel overlap opportunity. |
+
+## 9. vLLM-origin kernel-overlap families
 
 | Pattern | Trace keywords | Primary code | Existing path | Skill should conclude |
 | --- | --- | --- | --- | --- |
@@ -116,14 +128,14 @@ AutoDeploy rather than same-stream PDL windows.
 | vLLM-origin shared-expert aux-stream overlap | `aux_stream`<br>`shared_experts_stream`<br>shared expert near router | `vllm/model_executor/layers/fused_moe/runner/shared_experts.py`<br>`vllm/model_executor/layers/fused_moe/runner/moe_runner_base.py` | MoE shared experts can record the cloned input on `shared_experts_stream`, wait on the caller stream, run in parallel with router-side work, and rejoin before merge | Treat shared-expert vs router overlap as an existing upstream sparse-model family. |
 | vLLM-origin DCP async all-to-all overlap | `dcp_alltoall`<br>`all_to_all_single`<br>`async_op=True` | `vllm/v1/attention/ops/dcp_alltoall.py` | Output / LSE exchange uses async all-to-all handles instead of serializing collective completion on the main path | Treat DCP all-to-all windows as an upstream async-collective family. |
 
-## 9. vLLM-origin PR-backed / in-flight kernel-overlap families
+## 10. vLLM-origin PR-backed / in-flight kernel-overlap families
 
 | Pattern | Trace keywords | Primary code | Existing path | Skill should conclude |
 | --- | --- | --- | --- | --- |
 | PR `#35968` DSV3.2 multi-stream indexer overlap | `weights_proj`<br>`wk`<br>`k_norm`<br>`aux_stream` | `PR #35968`<br>`vllm/model_executor/models/deepseek_v2.py`<br>`vllm/utils/torch_utils.py` | Closed PR explored overlapping the small `weights_proj` GEMM with `wk + k_norm` on a secondary CUDA stream for decode batches instead of serializing both on the default stream | Treat this as a concrete upstream decode-time kernel-overlap family when traces show underutilized projection overlap opportunities. |
 | PR `#39301` GLM5 router GEMM with PDL overlap | `TRTLLM_ENABLE_PDL`<br>`router_gemm`<br>`GLM5`<br>`FI AR RMS fusion` | `PR #39301`<br>`vllm/model_executor/layers/fused_moe/router/gate_linear.py`<br>`vllm/csrc/moe/dsv3_router_gemm_utils.h` | The GLM5 router GEMM path explicitly uses PDL so the router kernel can overlap with the preceding fused allreduce-plus-RMS block on supported GPUs | Treat router-GEMM launch overlap on GLM5-like traces as an in-flight upstream family first. |
 
-## 10. Important toggles and caveats
+## 11. Important toggles and caveats
 
 | Toggle / env | Location | Effect on trace interpretation |
 | --- | --- | --- |
@@ -144,8 +156,9 @@ AutoDeploy rather than same-stream PDL windows.
 | `enable_fused_grouped_gemm_combine` | `PR #21877` | In-flight path that intentionally disables SBO because combine is folded into down-GEMM. |
 | `PassConfig.enable_sp` | `vllm/config/compilation.py` | Enables vLLM's sequence-parallel staging family that creates RS / AG overlap opportunities. |
 | `PassConfig.fuse_gemm_comms` | `vllm/config/compilation.py` | Enables AsyncTP GEMM + collective overlap and auto-enables `enable_sp` when valid. |
+| TokenSpeed `--comm-fusion-max-num-tokens` / `--enable-allreduce-fusion` | `docs/configuration/server.md` | Gates TokenSpeed communication fusion; inspect it before treating all-reduce + compute separation as a new overlap gap. |
 
-## 11. Suggested refresh commands
+## 12. Suggested refresh commands
 
 These commands are only for maintainers refreshing this catalog by rescanning
 the local source trees. They are not used by the triage scripts at runtime.
@@ -155,6 +168,7 @@ the local source trees. They are not used by the triage scripts at runtime.
 FLASHINFER_REPO=${FLASHINFER_REPO:-../flashinfer}
 TRTLLM_REPO=${TRTLLM_REPO:-../TensorRT-LLM}
 VLLM_REPO=${VLLM_REPO:-../vllm}
+TOKENSPEED_REPO=${TOKENSPEED_REPO:-../tokenspeed}
 
 rg -n "single_batch_overlap|alt_stream|shared_expert|scatter_stream|_fused_gather_to_staging_kernel|_fused_scatter_from_staging_kernel|async_op=True" python/sglang
 rg -n "apply_qk_norm|vision.py|ring_attn|all_to_all_single|reorder_for_compute_comm_overlap|use_dual_stream" python/sglang/multimodal_gen python/sglang/srt
@@ -166,6 +180,8 @@ rg -n "mlir_elementwise_fusion|piecewise|cudagraph|caller_stream.synchronize" "$
 git -C "$TRTLLM_REPO" log --all --format='%h %s' | rg -i 'overlap|multi-stream|aux stream|cudagraph|mlir|stream|flashinfer|moe|mla'
 rg -n "fuse_gemm_comms|enable_sp|fused_matmul_reduce_scatter|fused_all_gather_matmul|shared_experts_stream|maybe_sync_shared_experts_stream|dcp_alltoall|async_op=True|aux_stream|maybe_execute_in_parallel" "$VLLM_REPO/vllm" "$VLLM_REPO/docs/design/fusions.md"
 git -C "$VLLM_REPO" log --all --format='%h %s' | rg -i 'fused|fusion|overlap|allreduce|reduce-scatter|all-gather|all_to_all|stream|multi-stream|triton|cuda|router'
+rg -n "enable_allreduce_fusion|comm_fusion|comm_fusion_max_num_tokens|allreduce|reduce_scatter" "$TOKENSPEED_REPO/python" "$TOKENSPEED_REPO/docs"
+git -C "$TOKENSPEED_REPO" log --all --format='%h %s' | rg -i 'fused|fusion|overlap|allreduce|stream|comm|mla|tokenspeed_mla'
 # GitHub PR scan terms for the connector or web UI:
 #   "fused OR overlap repo:sgl-project/sglang"
 #   "triton OR cutedsl OR cuda overlap repo:sgl-project/sglang"
@@ -177,4 +193,5 @@ git -C "$VLLM_REPO" log --all --format='%h %s' | rg -i 'fused|fusion|overlap|all
 #   "fused OR overlap repo:vllm-project/vllm"
 #   "triton OR cuda overlap repo:vllm-project/vllm"
 #   "multi-stream OR aux_stream overlap repo:vllm-project/vllm"
+#   "fused OR overlap OR comm_fusion repo:lightseekorg/tokenspeed"
 ```

--- a/skills/llm-torch-profiler-analysis/references/overlap-catalog.md
+++ b/skills/llm-torch-profiler-analysis/references/overlap-catalog.md
@@ -28,7 +28,7 @@ overlap opportunity as novel.
 
 Refresh note `2026-06-26`: rechecked official main heads for SGLang
 `8524678889485801e7a4a12d62015be0c68f7a90`, vLLM
-`37ce34922f7f5e58241369511130cd99c1c50bfe`, TensorRT-LLM
+`abc71548ef029132c3316b902207f254a246d593`, TensorRT-LLM
 `0722c5f47d2cae69ac1a237da51e550dd214532c`, and TokenSpeed
 `5aedf69d6b476baa65571011de6ea60fd5a238a8`, then added the first
 TokenSpeed-origin communication-fusion row. Closed-unmerged SGLang

--- a/skills/llm-torch-profiler-analysis/references/vllm-torch-compile-fusions.md
+++ b/skills/llm-torch-profiler-analysis/references/vllm-torch-compile-fusions.md
@@ -2,11 +2,11 @@
 
 Refresh: `2026-06-26`.
 Source tree: vLLM `origin/main` at
-`37ce34922f7f5e58241369511130cd99c1c50bfe`; no new LLM compile-fusion pass was
+`abc71548ef029132c3316b902207f254a246d593`; no new LLM compile-fusion pass was
 added after `2317682f9` in this refresh. The mainline `#40392` MLA RoPE +
-KV-cache cat fusion is already included below. The latest vLLM delta here is
-PR `#46735`, a CUDA graph capture fix for Triton / NVFP4-emulation MoE rather
-than a new compile-fusion pass.
+KV-cache cat fusion is already included below. Recent post-`#46735` vLLM
+changes include runtime / frontend work such as `#44800` and `#46799`, but they
+do not add a new LLM compile-fusion pass to this inventory.
 
 Use this file when the fuse-pattern table reports split kernels in a trace and
 you need to decide whether the shape is already covered by vLLM's

--- a/skills/llm-torch-profiler-analysis/references/vllm-torch-compile-fusions.md
+++ b/skills/llm-torch-profiler-analysis/references/vllm-torch-compile-fusions.md
@@ -1,9 +1,12 @@
 # vLLM Torch Compile Fusion Patterns
 
-Refresh: `2026-05-15`.
-Source tree: vLLM `origin/main` at `f3d536059`; no new LLM compile-fusion pass
-was added after `2317682f9` in the 2026-05-15 refresh. The mainline
-`#40392` MLA RoPE + KV-cache cat fusion is already included below.
+Refresh: `2026-06-26`.
+Source tree: vLLM `origin/main` at
+`37ce34922f7f5e58241369511130cd99c1c50bfe`; no new LLM compile-fusion pass was
+added after `2317682f9` in this refresh. The mainline `#40392` MLA RoPE +
+KV-cache cat fusion is already included below. The latest vLLM delta here is
+PR `#46735`, a CUDA graph capture fix for Triton / NVFP4-emulation MoE rather
+than a new compile-fusion pass.
 
 Use this file when the fuse-pattern table reports split kernels in a trace and
 you need to decide whether the shape is already covered by vLLM's

--- a/skills/llm-torch-profiler-analysis/scripts/analyze_llm_torch_profile.py
+++ b/skills/llm-torch-profiler-analysis/scripts/analyze_llm_torch_profile.py
@@ -34,8 +34,8 @@ def build_triage_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="analyze_llm_torch_profile.py",
         description=(
-            "Compact LLM torch-profiler triage entrypoint for SGLang, vLLM, and "
-            "TensorRT-LLM. "
+            "Compact LLM torch-profiler triage entrypoint for SGLang, vLLM, "
+            "TensorRT-LLM, and TokenSpeed. "
             "This prints three tables: kernel mapping, overlap opportunities, "
             "and fuse opportunities. "
             "Use either a single trace/profile input or a mapping+formal two-trace pair."
@@ -45,7 +45,17 @@ def build_triage_parser() -> argparse.ArgumentParser:
         "--framework",
         type=str,
         default="auto",
-        choices=["auto", "sglang", "vllm", "trtllm", "tllm", "tensorrt-llm"],
+        choices=[
+            "auto",
+            "sglang",
+            "vllm",
+            "trtllm",
+            "tllm",
+            "tensorrt-llm",
+            "tokenspeed",
+            "token-speed",
+            "ts",
+        ],
         help=(
             "Serving framework. Use auto to detect from trace contents, path hints, "
             "or URL features."
@@ -64,7 +74,9 @@ def build_triage_parser() -> argparse.ArgumentParser:
         help=(
             "Running server URL for single-trace triage. SGLang supports direct "
             "capture via sglang.profiler. vLLM and TensorRT-LLM require a server-side "
-            "torch-profiler output path exposed via --output-dir."
+            "torch-profiler output path exposed via --output-dir. TokenSpeed live "
+            "capture uses the server's /start_profile and /stop_profile endpoints "
+            "when they are available."
         ),
     )
     parser.add_argument(
@@ -74,7 +86,8 @@ def build_triage_parser() -> argparse.ArgumentParser:
         help=(
             "Trace output dir when using --url. For vLLM this should match the "
             "server's torch_profiler_dir. For TensorRT-LLM it should match the "
-            "directory or file path configured by TLLM_TORCH_PROFILE_TRACE."
+            "directory or file path configured by TLLM_TORCH_PROFILE_TRACE. "
+            "For TokenSpeed this is passed as start_profile.output_dir."
         ),
     )
     parser.add_argument(
@@ -83,7 +96,8 @@ def build_triage_parser() -> argparse.ArgumentParser:
         default="triage-trace",
         help=(
             "Profile prefix when generating a trace from --url. SGLang uses it "
-            "directly; vLLM and TensorRT-LLM may ignore it on the HTTP profiler path."
+            "directly; TokenSpeed maps it to profile_id; vLLM and TensorRT-LLM may "
+            "ignore it on the HTTP profiler path."
         ),
     )
     parser.add_argument(

--- a/skills/llm-torch-profiler-analysis/scripts/analyze_sglang_torch_profile.py
+++ b/skills/llm-torch-profiler-analysis/scripts/analyze_sglang_torch_profile.py
@@ -1,7 +1,7 @@
 """Backwards-compatibility shim for the unified LLM torch-profiler entrypoint.
 
 The real implementation now lives in ``analyze_llm_torch_profile`` because this
-skill covers SGLang, vLLM, and TensorRT-LLM. Older scripts and runbooks that
+skill covers SGLang, vLLM, TensorRT-LLM, and TokenSpeed. Older scripts and runbooks that
 still invoke ``analyze_sglang_torch_profile.py`` keep working by forwarding to
 that module.
 """

--- a/skills/llm-torch-profiler-analysis/scripts/probe_llm_server.py
+++ b/skills/llm-torch-profiler-analysis/scripts/probe_llm_server.py
@@ -31,7 +31,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--framework",
         required=True,
-        choices=("sglang", "vllm", "trtllm"),
+        choices=("sglang", "vllm", "trtllm", "tokenspeed"),
         help="Serving framework.",
     )
     parser.add_argument(
@@ -42,7 +42,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--model",
         default=None,
-        help="OpenAI model id. Auto-discovered for vLLM and TensorRT-LLM when omitted.",
+        help="OpenAI model id. Auto-discovered for vLLM, TensorRT-LLM, and TokenSpeed when omitted.",
     )
     parser.add_argument(
         "--requests",
@@ -153,7 +153,7 @@ def openai_request(
 def run_probe(args: argparse.Namespace) -> Dict[str, Any]:
     prompts = args.prompt or list(DEFAULT_PROMPTS)
     model = args.model
-    if args.framework in {"vllm", "trtllm"} and not model:
+    if args.framework in {"vllm", "trtllm", "tokenspeed"} and not model:
         model = discover_openai_model(args.url, timeout=args.timeout)
 
     latencies: List[float] = []

--- a/skills/llm-torch-profiler-analysis/scripts/profile_common.py
+++ b/skills/llm-torch-profiler-analysis/scripts/profile_common.py
@@ -22,6 +22,7 @@ FRAMEWORK_LABELS = {
     "sglang": "SGLang",
     "vllm": "vLLM",
     "trtllm": "TensorRT-LLM",
+    "tokenspeed": "TokenSpeed",
 }
 TRACE_FILE_PATTERNS = (
     "*.trace.json",
@@ -89,6 +90,9 @@ def canonicalize_framework(value: object) -> str:
         "trtllm": "trtllm",
         "tensorrt-llm": "trtllm",
         "tensorrtllm": "trtllm",
+        "tokenspeed": "tokenspeed",
+        "token-speed": "tokenspeed",
+        "ts": "tokenspeed",
     }
     return aliases.get(lowered, "auto")
 
@@ -105,6 +109,8 @@ def _normalize_repo_relative_path_cached(text: str) -> str:
         ("python/sglang/", "python/sglang/"),
         ("sgl_kernel/", "sgl_kernel/"),
         ("vllm/", "vllm/"),
+        ("python/tokenspeed/", "python/tokenspeed/"),
+        ("tokenspeed/", "tokenspeed/"),
         ("tensorrt_llm/", "tensorrt_llm/"),
         ("tensorrt-llm/", "tensorrt_llm/"),
     ):
@@ -312,6 +318,8 @@ def detect_framework_from_text(text: object) -> Optional[str]:
     lowered = normalize_text(text).lower()
     if not lowered:
         return None
+    if any(token in lowered for token in ("tokenspeed", "token-speed", "/ts/")):
+        return "tokenspeed"
     if any(
         token in lowered
         for token in (
@@ -333,6 +341,22 @@ def detect_framework_from_server_args(server_args: Optional[dict]) -> Optional[s
     if not isinstance(server_args, dict) or not server_args:
         return None
     lowered_keys = {normalize_text(key).lower() for key in server_args}
+    text = json.dumps(server_args, sort_keys=True)
+    if any(token in text.lower() for token in ("tokenspeed", "token-speed")):
+        return "tokenspeed"
+    if lowered_keys & {
+        "attn_tp_size",
+        "dense_tp_size",
+        "moe_tp_size",
+        "enable_mla_l1_5_cache",
+        "mla_chunk_multiplier",
+        "comm_fusion_max_num_tokens",
+        "enable_allreduce_fusion",
+    }:
+        return "tokenspeed"
+    text_hint = detect_framework_from_text(text)
+    if text_hint:
+        return text_hint
     if lowered_keys & {
         "attention_backend",
         "sampling_backend",
@@ -342,7 +366,7 @@ def detect_framework_from_server_args(server_args: Optional[dict]) -> Optional[s
         "schedule_policy",
     }:
         return "sglang"
-    return detect_framework_from_text(json.dumps(server_args, sort_keys=True))
+    return None
 
 
 def detect_framework_from_trace(trace: object) -> Optional[str]:
@@ -402,6 +426,9 @@ def detect_framework_from_url(
         or "decode" in server_info
     ):
         return "sglang"
+    readiness = try_get_json(url.rstrip("/") + "/readiness", timeout=5.0)
+    if readiness is not None:
+        return "tokenspeed"
     models = try_get_json(url.rstrip("/") + "/v1/models")
     if isinstance(models, dict) and isinstance(models.get("data"), list):
         return "vllm"
@@ -794,9 +821,11 @@ def wait_for_profiler_artifact(path: Path, timeout_s: float = 60.0) -> Path:
     return path
 
 
-def start_remote_profiler(url: str, framework: str) -> None:
+def start_remote_profiler(
+    url: str, framework: str, payload: Optional[dict] = None
+) -> None:
     try:
-        post_json(url.rstrip("/") + "/start_profile", timeout=60.0)
+        post_json(url.rstrip("/") + "/start_profile", payload=payload, timeout=60.0)
     except Exception as exc:
         if framework == "vllm":
             raise RuntimeError(
@@ -811,7 +840,35 @@ def start_remote_profiler(url: str, framework: str) -> None:
                 "TLLM_PROFILE_START_STOP=<start>-<stop> and "
                 "TLLM_TORCH_PROFILE_TRACE=/shared/path."
             ) from exc
+        if framework == "tokenspeed":
+            raise RuntimeError(
+                "TokenSpeed live torch profiling requires a server build that "
+                "exposes POST /start_profile and POST /stop_profile. The helper "
+                "passes output_dir, activities, and profile_id in the start payload."
+            ) from exc
         raise
+
+
+def build_remote_profiler_start_payload(
+    framework: str,
+    output_path: Path,
+    profile_prefix: Optional[str],
+    stage: Optional[str],
+) -> Optional[dict]:
+    if framework != "tokenspeed":
+        return None
+
+    profile_id = profile_prefix or "triage-trace"
+    if stage:
+        profile_id = f"{profile_id}-{stage}"
+
+    return {
+        "output_dir": str(output_path),
+        "activities": ["CPU", "GPU"],
+        "with_stack": True,
+        "record_shapes": False,
+        "profile_id": profile_id,
+    }
 
 
 def stop_remote_profiler(url: str, framework: str) -> None:
@@ -830,6 +887,7 @@ def run_remote_profiler(
     framework: str,
     probe_plan: ProbePlan,
     probe_delay: float,
+    profile_prefix: Optional[str] = None,
     stage: Optional[str] = None,
 ) -> Path:
     framework = canonicalize_framework(framework)
@@ -844,7 +902,11 @@ def run_remote_profiler(
         if output_path.exists()
         else set()
     )
-    model = discover_openai_model(url) if framework in {"vllm", "trtllm"} else None
+    model = (
+        discover_openai_model(url)
+        if framework in {"vllm", "trtllm", "tokenspeed"}
+        else None
+    )
     if probe_plan.warmup_requests > 0:
         send_probe_requests(
             url=url,
@@ -855,13 +917,18 @@ def run_remote_profiler(
             model=model,
         )
 
-    start_remote_profiler(url, framework)
+    start_payload = build_remote_profiler_start_payload(
+        framework=framework,
+        output_path=output_path,
+        profile_prefix=profile_prefix,
+        stage=stage,
+    )
+    start_remote_profiler(url, framework, payload=start_payload)
     stop_error: Optional[BaseException] = None
     try:
         if probe_plan.capture_requests > 0:
-            # `sglang.profiler` performs its own startup work before it reaches
-            # POST /start_profile. A very short delay can send probes too early
-            # and miss the profiling window entirely.
+            # Server-side profilers may do setup work after POST /start_profile.
+            # A very short delay can send probes too early and miss the window.
             time.sleep(max(5.0, probe_delay))
             send_probe_requests(
                 url=url,
@@ -1065,14 +1132,14 @@ def run_profiler(
     if profile_by_stage:
         raise ValueError(
             "--profile-by-stage is only supported for SGLang live capture. "
-            "Disable it when profiling vLLM or TensorRT-LLM."
+            "Disable it when profiling vLLM, TensorRT-LLM, or TokenSpeed."
         )
     if merge_profiles:
         raise ValueError(
             "--merge-profiles is only supported for SGLang live capture. "
-            "Disable it when profiling vLLM or TensorRT-LLM."
+            "Disable it when profiling vLLM, TensorRT-LLM, or TokenSpeed."
         )
-    if profile_prefix:
+    if profile_prefix and resolved_framework in {"vllm", "trtllm"}:
         print(
             f"Note: {framework_display_name(resolved_framework)} ignores "
             "--profile-prefix on the HTTP profiler control path.",
@@ -1094,6 +1161,7 @@ def run_profiler(
                 warmup_steps=warmup_steps,
             ),
             probe_delay=probe_delay,
+            profile_prefix=profile_prefix,
         )
     output_root = ensure_remote_profiler_output_path(output_dir, resolved_framework)
     for stage in stages:
@@ -1117,6 +1185,7 @@ def run_profiler(
                 warmup_steps=warmup_steps,
             ),
             probe_delay=probe_delay,
+            profile_prefix=profile_prefix,
             stage=stage,
         )
     return output_root

--- a/skills/llm-torch-profiler-analysis/scripts/render_triage_markdown_bundle.py
+++ b/skills/llm-torch-profiler-analysis/scripts/render_triage_markdown_bundle.py
@@ -12,9 +12,10 @@ FRAMEWORK_LABELS = {
     "sglang": "SGLang",
     "vllm": "vLLM",
     "trtllm": "TensorRT-LLM",
+    "tokenspeed": "TokenSpeed",
 }
 
-FRAMEWORK_ORDER = {"sglang": 0, "vllm": 1, "trtllm": 2}
+FRAMEWORK_ORDER = {"sglang": 0, "vllm": 1, "trtllm": 2, "tokenspeed": 3}
 
 
 def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
@@ -75,6 +76,8 @@ def framework_key_from_path(path: Path) -> str:
         return "vllm"
     if "trtllm" in lowered or "tensorrt" in lowered:
         return "trtllm"
+    if "tokenspeed" in lowered or "token-speed" in lowered:
+        return "tokenspeed"
     return "other"
 
 

--- a/skills/llm-torch-profiler-analysis/scripts/triage_kernel_helpers.py
+++ b/skills/llm-torch-profiler-analysis/scripts/triage_kernel_helpers.py
@@ -856,6 +856,151 @@ FUSION_PATTERN_REGISTRY: Tuple[FusionPatternSpec, ...] = (
         priority=90,
     ),
     FusionPatternSpec(
+        pattern="SGLang LTX2 fused Ada values",
+        candidate_path=(
+            "PR #29390"
+            "<br>python/sglang/jit_kernel/diffusion/triton/ltx2_ada_values.py"
+            "<br>python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py"
+        ),
+        active_keywords=(
+            "ltx2_ada_values9",
+            "ltx2_ada_values",
+            "LTX2TransformerBlock",
+        ),
+        split_groups=(
+            ("scale_shift_table", "timestep", "reshape"),
+            ("get_ada_values", "ada", "adaln"),
+            ("slice", "split", "unbind"),
+        ),
+        rationale_hint=(
+            "SGLang mainline fuses LTX-2.3 Ada value materialization for"
+            " video/audio streams; split Ada table add/reshape/slice ladders"
+            " should be checked against this diffusion Triton kernel first."
+        ),
+        origin="upstream",
+        model_include=("ltx", "ltx-2", "ltx2"),
+        min_share=0.2,
+        likely_share=1.0,
+    ),
+    FusionPatternSpec(
+        pattern="TokenSpeed CuTe DSL MLA prefill / decode",
+        candidate_path=(
+            "python/tokenspeed/runtime/layers/attention/backends/tokenspeed_mla.py"
+            "<br>tokenspeed-mla/python/tokenspeed_mla/mla_decode.py"
+            "<br>tokenspeed-mla/python/tokenspeed_mla/mla_prefill.py"
+            "<br>tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/"
+            "tokenspeed_mla/__init__.py"
+        ),
+        active_keywords=(
+            "tokenspeed_mla_decode",
+            "tokenspeed_mla_prefill",
+            "BlackwellMultiHeadLatentAttentionForward",
+        ),
+        split_groups=(
+            ("mla", "flashmla", "attention", "fmha"),
+            ("prefill", "decode", "verify"),
+            ("fp8", "kv_cache", "page_table"),
+        ),
+        rationale_hint=(
+            "TokenSpeed ships Blackwell CuTe DSL MLA prefill/decode kernels;"
+            " split MLA support kernels should be checked against backend"
+            " selection before being called novel."
+        ),
+        origin="upstream",
+        model_include=("deepseek", "kimi", "qwen3.5", "qwen3_5"),
+        min_share=0.4,
+        likely_share=2.0,
+    ),
+    FusionPatternSpec(
+        pattern="TokenSpeed MLA KV pack + FP8 quantize",
+        candidate_path=(
+            "tokenspeed-mla/python/tokenspeed_mla/mla_kv_pack_quantize_fp8.py"
+            "<br>tokenspeed-kernel/python/tokenspeed_kernel/ops/attention/"
+            "tokenspeed_mla/__init__.py"
+        ),
+        active_keywords=(
+            "_mla_kv_pack_quantize_fp8_kernel",
+            "mla_kv_pack_quantize_fp8",
+        ),
+        split_groups=(
+            ("k_nope", "k_pe", "cat", "concat", "pack"),
+            ("quant", "fp8", "float8"),
+            ("v", "kv", "cache"),
+        ),
+        rationale_hint=(
+            "TokenSpeed fuses MLA K/V pack, concat, and FP8 quantization into"
+            " one Triton kernel for chunked prefill."
+        ),
+        origin="upstream",
+        model_include=("deepseek", "kimi", "qwen3.5", "qwen3_5"),
+        min_share=0.2,
+        likely_share=1.0,
+    ),
+    FusionPatternSpec(
+        pattern="TokenSpeed fused top-k + top-p sampling",
+        candidate_path=(
+            "tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/"
+            "fused_topk_topp.py"
+            "<br>tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/"
+            "csrc/fused_topk_topp/fused_topk_topp.cu"
+        ),
+        active_keywords=("fused_topk_topp", "fused_topk_topp_renorm"),
+        split_groups=(
+            ("topk", "top_k"),
+            ("topp", "top_p"),
+            ("sampling", "renorm", "softmax"),
+        ),
+        rationale_hint=(
+            "TokenSpeed has a fused top-k/top-p renormalization path for"
+            " decode sampling."
+        ),
+        origin="upstream",
+        min_share=0.1,
+        likely_share=0.8,
+    ),
+    FusionPatternSpec(
+        pattern="TokenSpeed persistent lm_head GEMM",
+        candidate_path=(
+            "tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/"
+            "lm_head_gemm.py"
+            "<br>tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cuda/"
+            "csrc/lm_head_gemm.cu"
+        ),
+        active_keywords=("lm_head_gemm",),
+        split_groups=(
+            ("lm_head", "logits", "vocab"),
+            ("gemm", "matmul", "linear"),
+        ),
+        rationale_hint=(
+            "TokenSpeed has a shape-gated persistent lm_head GEMM path; visible"
+            " lm_head matmul ladders should be compared against it."
+        ),
+        origin="upstream",
+        model_include=("kimi", "qwen"),
+        min_share=0.2,
+        likely_share=1.0,
+    ),
+    FusionPatternSpec(
+        pattern="TokenSpeed NVFP4 GEMM + SwiGLU + quant",
+        candidate_path=(
+            "tokenspeed-kernel/python/tokenspeed_kernel/thirdparty/cute_dsl/"
+            "nvfp4_gemm_swiglu_nvfp4_quant.py"
+        ),
+        active_keywords=("nvfp4_gemm_swiglu_nvfp4_quant",),
+        split_groups=(
+            ("gemm", "nvfp4", "fp4"),
+            ("swiglu", "silu", "activation", "mul"),
+            ("quant", "scale", "sfc"),
+        ),
+        rationale_hint=(
+            "TokenSpeed's CuTe DSL kernel fuses NVFP4 GEMM, SwiGLU, and"
+            " optional output quantization in one expert-style path."
+        ),
+        origin="upstream",
+        min_share=0.3,
+        likely_share=1.5,
+    ),
+    FusionPatternSpec(
         pattern="vLLM-origin Attention + Quantization",
         candidate_path=(
             "vllm/compilation/passes/fusion/attn_quant_fusion.py"
@@ -2452,7 +2597,7 @@ def fusion_framework_hints(spec: FusionPatternSpec) -> set[str]:
     hints: set[str] = set()
     if "vllm/" in text:
         hints.add("vllm")
-    if "tokenspeed/" in text:
+    if any(token in text for token in ("tokenspeed/", "tokenspeed-", "tokenspeed_")):
         hints.add("tokenspeed")
     if "tensorrt_llm/" in text:
         hints.add("trtllm")

--- a/skills/llm-torch-profiler-analysis/scripts/triage_kernel_helpers.py
+++ b/skills/llm-torch-profiler-analysis/scripts/triage_kernel_helpers.py
@@ -1235,6 +1235,8 @@ def source_location_priority(location: str) -> int:
         return 290 - penalty
     if text.startswith("vllm/"):
         return 285 - penalty
+    if text.startswith("python/tokenspeed/") or text.startswith("tokenspeed/"):
+        return 283 - penalty
     if text.startswith("tensorrt_llm/"):
         return 280 - penalty
     if text.startswith("sgl_kernel/"):
@@ -1254,6 +1256,8 @@ def is_preferred_source_location(location: str) -> bool:
         text.startswith("python/sglang/")
         or text.startswith("sglang/")
         or text.startswith("vllm/")
+        or text.startswith("python/tokenspeed/")
+        or text.startswith("tokenspeed/")
         or text.startswith("tensorrt_llm/")
         or text.startswith("sgl_kernel/")
     )
@@ -1316,6 +1320,10 @@ def frame_priority(frame_name: str) -> int:
         return 290 - penalty
     if normalized_text.startswith("vllm/"):
         return 285 - penalty
+    if normalized_text.startswith("python/tokenspeed/") or normalized_text.startswith(
+        "tokenspeed/"
+    ):
+        return 283 - penalty
     if normalized_text.startswith("tensorrt_llm/"):
         return 280 - penalty
     if normalized_text.startswith("sgl_kernel/"):
@@ -1329,6 +1337,8 @@ def frame_priority(frame_name: str) -> int:
             return 120
         if "/vllm/" in raw_text:
             return 118
+        if "/tokenspeed/" in raw_text or "/TokenSpeed/" in raw_text:
+            return 117
         if "/TensorRT-LLM/" in raw_text or "/tensorrt_llm/" in raw_text:
             return 116
         return 100
@@ -1336,6 +1346,10 @@ def frame_priority(frame_name: str) -> int:
         return 110
     if ".py(" in raw_text and "/vllm/" in raw_text:
         return 108
+    if ".py(" in raw_text and (
+        "/tokenspeed/" in raw_text or "/TokenSpeed/" in raw_text
+    ):
+        return 107
     if ".py(" in raw_text and (
         "/TensorRT-LLM/" in raw_text or "/tensorrt_llm/" in raw_text
     ):
@@ -2438,6 +2452,8 @@ def fusion_framework_hints(spec: FusionPatternSpec) -> set[str]:
     hints: set[str] = set()
     if "vllm/" in text:
         hints.add("vllm")
+    if "tokenspeed/" in text:
+        hints.add("tokenspeed")
     if "tensorrt_llm/" in text:
         hints.add("trtllm")
     if any(token in text for token in ("python/sglang/", "sgl-kernel/", "sgl_kernel/")):

--- a/skills/llm-torch-profiler-analysis/scripts/triage_overlap_helpers.py
+++ b/skills/llm-torch-profiler-analysis/scripts/triage_overlap_helpers.py
@@ -416,6 +416,10 @@ def is_meaningful_python_scope(name: str) -> bool:
         return True
     if normalized.startswith("vllm/"):
         return True
+    if normalized.startswith("python/tokenspeed/") or normalized.startswith(
+        "tokenspeed/"
+    ):
+        return True
     if normalized.startswith("tensorrt_llm/"):
         return True
     if normalized.startswith("sgl_kernel/"):
@@ -697,6 +701,8 @@ def choose_best_scope(scope_chain: Sequence[str]) -> Optional[str]:
             score += 48.0
         elif scope.startswith("vllm/"):
             score += 46.0
+        elif scope.startswith("python/tokenspeed/") or scope.startswith("tokenspeed/"):
+            score += 45.0
         elif scope.startswith("tensorrt_llm/"):
             score += 44.0
         elif scope.startswith("sgl_kernel/"):
@@ -744,6 +750,10 @@ def source_scope_priority(scope: Optional[str]) -> int:
         return 290 - penalty
     if normalized.startswith("vllm/"):
         return 285 - penalty
+    if normalized.startswith("python/tokenspeed/") or normalized.startswith(
+        "tokenspeed/"
+    ):
+        return 283 - penalty
     if normalized.startswith("tensorrt_llm/"):
         return 280 - penalty
     if normalized.startswith("sgl_kernel/"):

--- a/skills/sglang-sota-humanize-loop/SKILL.md
+++ b/skills/sglang-sota-humanize-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sglang-sota-humanize-loop
-description: "Run an autonomous Humanize-governed SGLang SOTA performance loop for one LLM model: first perform the fixed fair SGLang/vLLM/TensorRT-LLM deployment search and benchmark, then start one RLCR loop that repeatedly decides the gap, profiles the current bottleneck, runs layer/kernel pipeline analysis, patches SGLang code, optionally uses ncu-report-skill for kernel evidence, and revalidates until SGLang matches or beats the best observed framework under the same workload and SLA."
+description: "Run an autonomous Humanize-governed SGLang SOTA performance loop for one LLM model: first perform a fixed fair SGLang benchmark against the requested comparison framework set, then start one RLCR loop that repeatedly decides the gap, profiles the current bottleneck, runs layer/kernel pipeline analysis, patches SGLang code, optionally uses ncu-report-skill for kernel evidence, and revalidates until SGLang matches or beats the best observed requested framework under the same workload and SLA."
 ---
 
 # SGLang SOTA Humanize Loop
@@ -9,7 +9,8 @@ description: "Run an autonomous Humanize-governed SGLang SOTA performance loop f
 
 Use this skill when the user names a model and wants the SGLang serving path to
 autonomously keep improving until it matches or beats the best reproducible
-vLLM or TensorRT-LLM result in the same target environment.
+result from the requested comparison framework set in the same target
+environment.
 
 This workflow has two durable parts:
 
@@ -100,9 +101,12 @@ Collect or infer:
 - target SGLang checkout to patch
 - GPU type/count, visible GPU ids, container or remote shell, CUDA/NCCL versions,
   and whether multi-node is allowed
-- framework set, defaulting to SGLang, vLLM, and TensorRT-LLM when available
+- target framework: always SGLang
+- comparison framework set: if the user explicitly names or excludes comparison
+  frameworks, honor that exact set; otherwise default to vLLM, TensorRT-LLM, and
+  TokenSpeed when available
 - model-family history slug inferred from the model id, checkpoint, or hot
-  SGLang/vLLM source path when possible
+  framework source path when possible
 - artifact root
 
 Create one run directory:
@@ -112,10 +116,12 @@ runs/YYYYMMDD_<model_slug>_sota_humanize/
   manifest.md
   help/
   benchmark/
+    fairness/
   profiles/
   analysis/
     root-cause.md
     layer-pipeline.md
+    fairness-diagnostics.md
   history/
     model-pr-history-notes.md
   kernel/
@@ -128,6 +134,21 @@ runs/YYYYMMDD_<model_slug>_sota_humanize/
 
 Never save Hugging Face tokens or other secrets in artifacts.
 
+## Framework Selection
+
+Treat SGLang and the comparison frameworks as separate concepts:
+
+- SGLang is always the target framework because this loop patches SGLang.
+- `comparison_frameworks` contains only competitors, using canonical names
+  `vllm`, `tensorrt_llm`, and `tokenspeed`.
+- If the user says "only compare with vLLM", "comparison_frameworks: [vllm]",
+  or "do not consider TensorRT-LLM/TokenSpeed", run only SGLang plus vLLM.
+- Do not silently add TensorRT-LLM or TokenSpeed because a config or doc exists.
+- Record selected comparison frameworks and user-excluded frameworks in
+  `manifest.md` and `benchmark/fairness/diagnostics.md`.
+- Only read competitor history, launch competitor benchmarks, and profile
+  competitor traces for the selected comparison framework set.
+
 ## Phase 0.5: Model PR History Knowledge Gate
 
 Before the fixed benchmark and before any patch planning, query and read
@@ -138,9 +159,8 @@ Rules:
 - If the slug is unclear, run `scripts/query.py "<model id or family>"` from
   the knowledge root and choose the closest model-family history.
 - Read the SGLang history for that family whenever it exists.
-- Read the vLLM history too when vLLM is in the comparison set, later becomes
-  the leading competitor, or its source/trace suggests a missing SGLang fast
-  path.
+- Read competitor history too when a selected comparison framework later becomes
+  the leading competitor or its source/trace suggests a missing SGLang fast path.
 - Write `history/model-pr-history-notes.md` with the paths read, PR numbers,
   source files, symbols, validation risks, and the concrete decision each item
   influences.
@@ -159,12 +179,20 @@ result schema, workload, and comparison.
 
 Hard requirements:
 
-- Search SGLang, vLLM, and TensorRT-LLM best deployment commands when each
-  framework is supported in the target environment.
+- Search SGLang and every selected comparison framework's best deployment
+  command when that framework is supported in the target environment.
 - Do not compare tuned SGLang against competitor defaults. Every framework gets
   its own bounded search.
 - Use the same model weights, tokenizer, precision, quantization, GPU type/count,
   GPU ids, endpoint path, sampling settings, and SLA.
+- Record package version or git commit plus server/benchmark `--help` snapshots
+  for SGLang and every selected comparison framework. The 2026-06-26
+  source-refresh anchors are SGLang
+  `b91348071e6ca21f9357fd8b1adc83a18781df30`, vLLM
+  `c2507fb2937aa8c8e74bea15719d04fb6090befe`, TensorRT-LLM
+  `4164b932c6c8a14d1be85d0fd62e44b7d0171980`, and TokenSpeed
+  `5aedf69d6b476baa65571011de6ea60fd5a238a8`; still prefer target-image
+  `--help` over these source notes.
 - Use the default two dataset scenarios from `llm-serving-auto-benchmark` unless
   the user explicitly provides a production workload:
   - dataset kind `random`, `num_prompts: 80`
@@ -174,15 +202,27 @@ Hard requirements:
     product
 - Do not replace those scenarios with an easier smoke dataset for the real SOTA
   decision. Smoke runs are allowed only when labeled as flow checks.
-- For TensorRT-LLM, keep `trtllm-serve serve --backend pytorch`; reject
-  non-PyTorch TensorRT-LLM server backends for this skill.
+- For selected TensorRT-LLM comparisons, keep
+  `trtllm-serve serve --backend pytorch`; reject non-PyTorch TensorRT-LLM server
+  backends for this skill.
+- For selected TokenSpeed comparisons, use `tokenspeed serve <model>` or the
+  target image's exact alias such as `ts serve`; record the exact binary spelling
+  and validate `tokenspeed serve --help` plus `tokenspeed bench serve --help`.
+- If TokenSpeed is selected and a TokenSpeed-native agentic workload exists for
+  the model family, run it as an additional lane beside the common
+  cross-framework workload. Do not let it replace the common scenario unless the
+  user explicitly chose that workload as the SOTA target before benchmarking.
 - Keep failed, skipped, and SLA-failing candidates in the benchmark artifact.
+- Record optional fairness fields in normalized rows whenever available:
+  speculative accept length, pre-scheduler/scheduler time, cache hit rate,
+  offload or memory residency, endpoint, and request-shape notes.
 
 Write:
 
 - `benchmark/candidates.jsonl`
 - `benchmark/summary.md`
 - `benchmark/winning-commands.md`
+- `benchmark/fairness/diagnostics.md`
 - framework help outputs under `help/`
 - the exact launch and benchmark commands for every winner
 
@@ -206,6 +246,8 @@ The plan must require every RLCR round to:
 - preserve the fixed benchmark workload and SLA
 - preserve and consult `history/model-pr-history-notes.md` before choosing
   model-specific SGLang source paths
+- preserve and consult `benchmark/fairness/diagnostics.md` before treating a
+  gap as a code bottleneck
 - run the gap decision inside the loop before patching
 - run `llm-torch-profiler-analysis` inside the loop when SGLang is behind or
   when the previous patch changed the profiled path
@@ -267,15 +309,36 @@ next-round prompt exactly.
 ### Gap Decision
 
 At the start of every round, compute current SGLang's gap against the best
-SLA-passing framework for each fixed scenario.
+SLA-passing selected comparison framework for each fixed scenario.
 
 Use `1%` as the default stable noise threshold. If the current result is within
 `+/-1%`, rerun the winning commands enough times to decide whether the gap is
 stable before choosing a patch.
 
-Patch only when SGLang is slower than the best framework by more than `1%`,
-fails SLA while another framework passes, or has a profiled bottleneck that
-explains the remaining gap under the fixed workload.
+Patch only when SGLang is slower than the best selected comparison framework by
+more than `1%`, fails SLA while a selected competitor passes, or has a profiled
+bottleneck that explains the remaining gap under the fixed workload.
+
+Before patching, update `analysis/fairness-diagnostics.md` from the current
+benchmark rows and the fixed `benchmark/fairness/diagnostics.md`. Check:
+
+- same GPU count, visible GPU ids, model weights, tokenizer, precision,
+  quantization, endpoint, sampling settings, and request shape
+- speculative decoding status, algorithm, number of steps, and mean accept
+  length for every framework that enables a drafter/MTP/EAGLE-style path
+- pre-scheduler, scheduler, queue, tokenizer, and detokenizer time when exposed
+  by server logs or benchmark output
+- prefix/KV cache status and hit rate, especially for repeated prompts or
+  multi-turn workloads
+- GPU memory utilization, KV dtype, offload, and model weight residency
+- TokenSpeed-specific serving knobs, when TokenSpeed is selected, such as
+  `attn_tp_size`, `moe_tp_size`, `enable_expert_parallel`, backend choices, and
+  communication-fusion flags
+
+If the current leader wins because it used a non-equivalent workload,
+non-equivalent cache/speculative setting, different resident weights, or a
+framework-specific endpoint shortcut, fix the benchmark normalization first and
+rerun. Do not patch SGLang code until the gap survives this fairness gate.
 
 If SGLang is already best or tied within the stable threshold, write the final
 report and stop under the normal Humanize review path.
@@ -288,9 +351,12 @@ competitor command with `llm-torch-profiler-analysis`.
 Rules:
 
 - Always profile SGLang when it is behind.
-- Always profile at least the current best framework.
-- If both vLLM and TensorRT-LLM are more than `1%` ahead of SGLang in a stable
-  result, profile both.
+- Always profile at least the current best selected comparison framework.
+- If multiple competitors are more than `1%` ahead of SGLang in a stable
+  result, profile each ahead competitor that can produce a trace. For
+  TokenSpeed, analyze an existing torch-profiler trace or run-directory trace
+  emitted by the deployment; do not fabricate a live profiler endpoint when the
+  target image only supports offline traces.
 - Use the slow benchmark scenario lengths, not the profiler defaults:
   - prefill profile: slow input length -> `1` output token
   - decode profile: `1` input token -> slow output length
@@ -339,8 +405,8 @@ choose or validate the next edit.
 
 Eligibility gate:
 
-- SGLang is still more than `1%` behind the best framework for the fixed
-  benchmark scenario after the required repeat/profiler checks.
+- SGLang is still more than `1%` behind the best selected comparison framework
+  for the fixed benchmark scenario after the required repeat/profiler checks.
 - The slow stage has a concrete SGLang kernel or tightly scoped kernel family
   in the kernel table with at least `1%` cumulative GPU-time share. Do not spend
   kernel-specialist effort on a lone kernel below `1%` share unless a shared
@@ -406,24 +472,25 @@ Every patch attempt gets an attempt row. Only correct patches with measured
 improvement get optimization rows. Source ideas must include profiler rows,
 layer-pipeline evidence, NCU report paths when used, and code
 provenance so later rounds can avoid re-reading the same source. Model PR
-history evidence should be recorded beside SGLang, vLLM, TensorRT-LLM, and NCU
-source ideas when it influenced the patch.
+history evidence should be recorded beside SGLang, selected comparison
+frameworks, and NCU source ideas when it influenced the patch.
 
 After two consecutive rounds with less than `1%` geomean improvement over the
 prior best SGLang result, expand code-first research before editing again.
-Prefer code and PR evidence from SGLang, vLLM, TensorRT-LLM, and relevant kernel
-source guides before prose-only articles.
+Prefer code and PR evidence from SGLang, selected comparison frameworks, and
+relevant kernel source guides before prose-only articles.
 
 ## Stop Conditions
 
 Stop only when one of these is true:
 
-- SGLang beats the best SLA-passing vLLM/TensorRT-LLM result on the fixed
-  workload.
+- SGLang beats the best SLA-passing selected comparison framework result on the
+  fixed workload.
 - SGLang is tied within the stable `1%` threshold after repeat runs.
 - The remaining gap is proven external to SGLang, such as unavailable hardware
   support, missing framework dependency, unsupported TensorRT-LLM PyTorch
-  backend, or model weights that cannot be loaded fairly.
+  backend, unsupported TokenSpeed build, or model weights that cannot be loaded
+  fairly.
 - Profile evidence shows the remaining hot path is already near the relevant
   hardware or algorithmic limit and no low-risk SGLang patch remains.
 

--- a/skills/sglang-sota-humanize-loop/SKILL.md
+++ b/skills/sglang-sota-humanize-loop/SKILL.md
@@ -188,9 +188,9 @@ Hard requirements:
 - Record package version or git commit plus server/benchmark `--help` snapshots
   for SGLang and every selected comparison framework. The 2026-06-26
   source-refresh anchors are SGLang
-  `b91348071e6ca21f9357fd8b1adc83a18781df30`, vLLM
-  `c2507fb2937aa8c8e74bea15719d04fb6090befe`, TensorRT-LLM
-  `4164b932c6c8a14d1be85d0fd62e44b7d0171980`, and TokenSpeed
+  `8524678889485801e7a4a12d62015be0c68f7a90`, vLLM
+  `37ce34922f7f5e58241369511130cd99c1c50bfe`, TensorRT-LLM
+  `0722c5f47d2cae69ac1a237da51e550dd214532c`, and TokenSpeed
   `5aedf69d6b476baa65571011de6ea60fd5a238a8`; still prefer target-image
   `--help` over these source notes.
 - Use the default two dataset scenarios from `llm-serving-auto-benchmark` unless

--- a/skills/sglang-sota-humanize-loop/SKILL.md
+++ b/skills/sglang-sota-humanize-loop/SKILL.md
@@ -189,7 +189,7 @@ Hard requirements:
   for SGLang and every selected comparison framework. The 2026-06-26
   source-refresh anchors are SGLang
   `8524678889485801e7a4a12d62015be0c68f7a90`, vLLM
-  `37ce34922f7f5e58241369511130cd99c1c50bfe`, TensorRT-LLM
+  `abc71548ef029132c3316b902207f254a246d593`, TensorRT-LLM
   `0722c5f47d2cae69ac1a237da51e550dd214532c`, and TokenSpeed
   `5aedf69d6b476baa65571011de6ea60fd5a238a8`; still prefer target-image
   `--help` over these source notes.

--- a/skills/sglang-sota-humanize-loop/references/refined-plan-template.md
+++ b/skills/sglang-sota-humanize-loop/references/refined-plan-template.md
@@ -8,12 +8,16 @@ fixed fair benchmark and model PR history notes have already been captured.
 
 ## Goal Description
 
-Make SGLang match or beat the best observed selected comparison framework
-serving performance for `<model>` on `<hardware>` under the fixed workload,
-precision, quantization, and SLA captured in `<artifact-root>`.
+Target framework: SGLang.
 
-Requested comparison frameworks: `<comparison-frameworks>`. User-excluded or
-unsupported frameworks and reasons: `<skipped-frameworks-and-reasons>`.
+Comparison framework set: `<comparison-frameworks>`.
+
+Make SGLang match or beat the best observed SLA-passing result among the
+selected comparison frameworks for `<model>` on `<hardware>` under the fixed
+workload, precision, quantization, and SLA captured in `<artifact-root>`.
+
+User-excluded or unsupported frameworks and reasons:
+`<skipped-frameworks-and-reasons>`.
 
 The fixed benchmark phase is complete. The RLCR loop must perform the current
 gap decision, collect profiler evidence, run layer-pipeline deep dives, patch
@@ -32,6 +36,9 @@ source-path selection.
   - Positive Tests (expected to PASS):
     - `benchmark/candidates.jsonl`, `benchmark/summary.md`, and
       `benchmark/winning-commands.md` exist under `<artifact-root>`.
+    - `manifest.md` exists and records `target_framework: sglang`,
+      `comparison_frameworks`, and user-excluded or unsupported frameworks with
+      reasons.
     - `benchmark/fairness/diagnostics.md` exists and records framework version,
       commit/help snapshots, endpoint, cache/speculative/memory normalization,
       selected comparison frameworks, user-excluded frameworks, and any
@@ -57,14 +64,15 @@ source-path selection.
 
 - AC-3: Gap decision and profiler triage happen inside each RLCR round
   - Positive Tests (expected to PASS):
-    - The round computes the current SGLang gap against the fixed benchmark
-      winner table before choosing a patch.
+    - The round computes the current SGLang gap against the best selected
+      comparison row in the fixed benchmark winner table before choosing a
+      patch.
     - `analysis/fairness-diagnostics.md` is updated from the latest benchmark
       rows before treating the gap as a code bottleneck.
     - SGLang profile analysis exists for the current slow scenario when SGLang
       is more than 1% behind.
-    - At least the best selected comparison framework profile analysis exists
-      when SGLang is behind.
+    - At least the leading selected comparison framework profile analysis
+      exists when SGLang is behind.
     - If multiple selected competitors are more than 1% ahead, every ahead
       competitor with a valid trace path has analysis. TokenSpeed uses an existing
       torch-profiler trace or target-deployment trace directory, not a
@@ -140,10 +148,11 @@ source-path selection.
     - Attempt, optimization, source-idea, lineage, and profile-digest artifacts
       are updated after each round.
     - `humanize/model-loop-checkpoint.md` records the original benchmark
-      winners, workload/SLA, SGLang commit, applied patches, current best
-      SGLang result, remaining gap, model PR history notes, profiler rows,
-      layer-pipeline notes, NCU digest paths, rejected source ideas, and the
-      next planned SGLang patch.
+      winners, selected comparison frameworks, user-excluded or unsupported
+      frameworks, workload/SLA, SGLang commit, applied patches, current best
+      SGLang result, current leading selected comparison result, remaining gap,
+      model PR history notes, profiler rows, layer-pipeline notes, NCU digest
+      paths, rejected source ideas, and the next planned SGLang patch.
     - The campaign can resume from the same model-loop artifacts with benchmark,
       profile, source-evidence, and patch lineage intact.
     - The active `.humanize/rlcr/<timestamp>/state.md` exists and records
@@ -156,9 +165,9 @@ source-path selection.
 
 - AC-9: Stop criteria are satisfied
   - Positive Tests (expected to PASS):
-    - SGLang beats the best selected comparison framework, or is within the
-      stable 1% threshold after repeat runs, or the remaining gap is proven
-      external/not patchable.
+    - SGLang beats the best SLA-passing result among selected comparison
+      frameworks, or is within the stable 1% threshold after repeat runs, or
+      the remaining gap is proven external/not patchable.
   - Negative Tests (expected to FAIL):
     - The loop stops while SGLang remains more than 1% behind and there is an
       uninvestigated profiler table row with plausible SGLang source impact.
@@ -181,30 +190,36 @@ revalidation, unless the current in-loop evidence proves no patch is needed.
 
 - Can use: SGLang source patches, guarded heuristics, existing fast-path
   selection, fusion or overlap fixes, model-specific runtime fixes, PR-driven
-  model history knowledge for SGLang and selected comparison framework
-  source-path selection,
+  model history knowledge for SGLang and the selected comparison framework set
+  when choosing source paths,
   `llm-torch-profiler-analysis`, `llm-pipeline-analysis`, `ncu-report-skill`
   digests, focused tests, microbenchmarks, torch-profiler, Nsight Compute, and
   Nsight Systems.
 - Cannot use: changing the fixed workload/SLA after seeing results, dropping a
   requested competitor without a recorded unsupported reason, silently adding a
-  user-excluded competitor, disabling correctness or tokenizer behavior,
-  spending kernel-specialist effort on sub-1% lone kernels, or claiming SOTA
-  from smoke-only runs.
+  user-excluded competitor, treating a user-excluded competitor as unsupported
+  without the user's instruction, disabling correctness or tokenizer behavior,
+  spending kernel-specialist effort on sub-1% lone kernels, or claiming SOTA from
+  smoke-only runs.
 
 ## Dependencies and Sequence
 
 ### Milestones
 
 1. Preserve fixed baseline artifacts
+   - Confirm `manifest.md` records `target_framework: sglang`, the selected
+     comparison framework set, and user-excluded or unsupported frameworks with
+     reasons.
    - Confirm `history/model-pr-history-notes.md` has matching SGLang history
      and, when applicable, leading-competitor history for selected comparison
      frameworks.
    - Confirm winner commands, workload, and SLA.
    - Confirm `benchmark/fairness/diagnostics.md` records version/help,
-     endpoint, cache/speculative/memory, and request-shape normalization.
+     endpoint, cache/speculative/memory, request-shape normalization, and the
+     selected comparison framework set.
 2. Run in-loop gap decision and profiling
-   - Compare current SGLang to the fixed winner table.
+   - Compare current SGLang to the best selected comparison row in the fixed
+     winner table.
    - Run `llm-torch-profiler-analysis` for current SGLang and the leading
      selected competitor when SGLang is behind.
    - Run `llm-pipeline-analysis` after profiler triage and before patch
@@ -219,8 +234,8 @@ revalidation, unless the current in-loop evidence proves no patch is needed.
    - Re-run profiler triage when the gap remains or the patch changes the
      profiled path.
 5. Continue or stop
-   - If SGLang is still more than 1% behind, pick the next profiler-backed
-     patch.
+   - If SGLang is still more than 1% behind the best selected comparison
+     result, pick the next profiler-backed patch.
    - After two weak rounds below 1% geomean improvement over the prior best,
      expand code-first research before editing again.
    - Stop only under AC-9.
@@ -231,6 +246,8 @@ revalidation, unless the current in-loop evidence proves no patch is needed.
 - Start RLCR with `--strict-success` and verify the active `state.md` contains
   `strict_success: true` before any SGLang patch work.
 - Keep benchmark/profile artifacts under `<artifact-root>`.
+- Keep the framework-selection contract in `<artifact-root>/manifest.md`, and
+  update it only when the user changes the target/comparison framework set.
 - Keep model PR history notes under `<artifact-root>/history/`.
 - Keep layer-pipeline reports under `<artifact-root>/analysis/`.
 - Keep NCU digests under `<artifact-root>/kernel/ncu-digests/`.

--- a/skills/sglang-sota-humanize-loop/references/refined-plan-template.md
+++ b/skills/sglang-sota-humanize-loop/references/refined-plan-template.md
@@ -8,9 +8,12 @@ fixed fair benchmark and model PR history notes have already been captured.
 
 ## Goal Description
 
-Make SGLang match or beat the best observed vLLM/TensorRT-LLM serving
-performance for `<model>` on `<hardware>` under the fixed workload, precision,
-quantization, and SLA captured in `<artifact-root>`.
+Make SGLang match or beat the best observed selected comparison framework
+serving performance for `<model>` on `<hardware>` under the fixed workload,
+precision, quantization, and SLA captured in `<artifact-root>`.
+
+Requested comparison frameworks: `<comparison-frameworks>`. User-excluded or
+unsupported frameworks and reasons: `<skipped-frameworks-and-reasons>`.
 
 The fixed benchmark phase is complete. The RLCR loop must perform the current
 gap decision, collect profiler evidence, run layer-pipeline deep dives, patch
@@ -20,7 +23,8 @@ SGLang reaches the stop criteria.
 
 The matching PR-driven model history has been read from
 `model-pr-optimization-history`, and `history/model-pr-history-notes.md`
-records the SGLang/vLLM PR evidence that influenced source-path selection.
+records the SGLang and selected competitor PR evidence that influenced
+source-path selection.
 
 ## Acceptance Criteria
 
@@ -28,6 +32,10 @@ records the SGLang/vLLM PR evidence that influenced source-path selection.
   - Positive Tests (expected to PASS):
     - `benchmark/candidates.jsonl`, `benchmark/summary.md`, and
       `benchmark/winning-commands.md` exist under `<artifact-root>`.
+    - `benchmark/fairness/diagnostics.md` exists and records framework version,
+      commit/help snapshots, endpoint, cache/speculative/memory normalization,
+      selected comparison frameworks, user-excluded frameworks, and any
+      unsupported framework reason.
     - The workload uses the fixed scenario set or a user-provided production
       workload recorded before RLCR began.
   - Negative Tests (expected to FAIL):
@@ -38,8 +46,9 @@ records the SGLang/vLLM PR evidence that influenced source-path selection.
   - Positive Tests (expected to PASS):
     - `history/model-pr-history-notes.md` exists under `<artifact-root>`.
     - The notes cite the matching SGLang model history when available.
-    - The notes cite matching vLLM history when vLLM is the leading competitor
-      or when vLLM evidence influenced a suspected missing SGLang fast path.
+    - The notes cite matching competitor history when a selected comparison
+      framework is the leading competitor or when competitor evidence influenced
+      a suspected missing SGLang fast path.
     - The notes include docs read, PR numbers, source files, symbols,
       validation risks, and the decision each item influenced.
   - Negative Tests (expected to FAIL):
@@ -50,11 +59,16 @@ records the SGLang/vLLM PR evidence that influenced source-path selection.
   - Positive Tests (expected to PASS):
     - The round computes the current SGLang gap against the fixed benchmark
       winner table before choosing a patch.
+    - `analysis/fairness-diagnostics.md` is updated from the latest benchmark
+      rows before treating the gap as a code bottleneck.
     - SGLang profile analysis exists for the current slow scenario when SGLang
       is more than 1% behind.
-    - At least the best framework profile analysis exists when SGLang is behind.
-    - If both vLLM and TensorRT-LLM are more than 1% ahead, both competitor
-      analyses exist.
+    - At least the best selected comparison framework profile analysis exists
+      when SGLang is behind.
+    - If multiple selected competitors are more than 1% ahead, every ahead
+      competitor with a valid trace path has analysis. TokenSpeed uses an existing
+      torch-profiler trace or target-deployment trace directory, not a
+      fabricated live profiler endpoint.
     - Every analysis contains kernel, overlap-opportunity, and fuse-pattern
       tables with prefill/decode evidence when available.
     - `analysis/root-cause.md` maps the current gap to profiler rows and SGLang
@@ -62,6 +76,8 @@ records the SGLang/vLLM PR evidence that influenced source-path selection.
   - Negative Tests (expected to FAIL):
     - A code patch is proposed without citing a profiler table row and source
       path or kernel family for the current gap.
+    - A code patch is proposed while a non-equivalent workload, cache,
+      speculative, memory, or endpoint setting explains the current leader.
     - Profiling is treated as a one-time pre-loop gate and not refreshed after
       a patch changes the profiled path or leaves a gap.
 
@@ -140,8 +156,9 @@ records the SGLang/vLLM PR evidence that influenced source-path selection.
 
 - AC-9: Stop criteria are satisfied
   - Positive Tests (expected to PASS):
-    - SGLang beats the best framework, or is within the stable 1% threshold
-      after repeat runs, or the remaining gap is proven external/not patchable.
+    - SGLang beats the best selected comparison framework, or is within the
+      stable 1% threshold after repeat runs, or the remaining gap is proven
+      external/not patchable.
   - Negative Tests (expected to FAIL):
     - The loop stops while SGLang remains more than 1% behind and there is an
       uninvestigated profiler table row with plausible SGLang source impact.
@@ -164,14 +181,16 @@ revalidation, unless the current in-loop evidence proves no patch is needed.
 
 - Can use: SGLang source patches, guarded heuristics, existing fast-path
   selection, fusion or overlap fixes, model-specific runtime fixes, PR-driven
-  model history knowledge for SGLang/vLLM source-path selection,
+  model history knowledge for SGLang and selected comparison framework
+  source-path selection,
   `llm-torch-profiler-analysis`, `llm-pipeline-analysis`, `ncu-report-skill`
   digests, focused tests, microbenchmarks, torch-profiler, Nsight Compute, and
   Nsight Systems.
-- Cannot use: changing the fixed workload/SLA after seeing results, removing a
-  competitor from comparison without a recorded unsupported reason, disabling
-  correctness or tokenizer behavior, spending kernel-specialist effort on
-  sub-1% lone kernels, or claiming SOTA from smoke-only runs.
+- Cannot use: changing the fixed workload/SLA after seeing results, dropping a
+  requested competitor without a recorded unsupported reason, silently adding a
+  user-excluded competitor, disabling correctness or tokenizer behavior,
+  spending kernel-specialist effort on sub-1% lone kernels, or claiming SOTA
+  from smoke-only runs.
 
 ## Dependencies and Sequence
 
@@ -179,12 +198,15 @@ revalidation, unless the current in-loop evidence proves no patch is needed.
 
 1. Preserve fixed baseline artifacts
    - Confirm `history/model-pr-history-notes.md` has matching SGLang history
-     and, when applicable, leading-competitor vLLM history.
+     and, when applicable, leading-competitor history for selected comparison
+     frameworks.
    - Confirm winner commands, workload, and SLA.
+   - Confirm `benchmark/fairness/diagnostics.md` records version/help,
+     endpoint, cache/speculative/memory, and request-shape normalization.
 2. Run in-loop gap decision and profiling
    - Compare current SGLang to the fixed winner table.
    - Run `llm-torch-profiler-analysis` for current SGLang and the leading
-     competitor when SGLang is behind.
+     selected competitor when SGLang is behind.
    - Run `llm-pipeline-analysis` after profiler triage and before patch
      selection.
 3. Patch the highest-confidence SGLang bottleneck

--- a/tests/test_llm_serving_cookbook_configs.py
+++ b/tests/test_llm_serving_cookbook_configs.py
@@ -42,19 +42,23 @@ class LlmServingCookbookConfigsTest(unittest.TestCase):
             with self.subTest(path=path.name):
                 self.assertEqual(self.mod.validate_config(path), [])
 
-    def test_every_config_has_three_framework_sections(self) -> None:
+    def test_every_config_has_four_framework_sections(self) -> None:
         for path in self.config_paths():
             with self.subTest(path=path.name):
                 config = self.load_config(path)
                 self.assertEqual(
                     set(config["frameworks"]),
-                    {"sglang", "vllm", "tensorrt_llm"},
+                    {"sglang", "vllm", "tensorrt_llm", "tokenspeed"},
                 )
 
                 trt = config["frameworks"]["tensorrt_llm"]
                 self.assertEqual(trt["backend_policy"], "fixed_pytorch")
                 self.assertEqual(trt["base_server_flags"]["backend"], "pytorch")
                 self.assertNotIn("backend", trt["search_space"])
+
+                tokenspeed = config["frameworks"]["tokenspeed"]
+                self.assertTrue(tokenspeed["enabled"])
+                self.assertEqual(tokenspeed["server_command"], "tokenspeed serve")
 
     def test_rendered_commands_use_framework_native_flags(self) -> None:
         config = self.load_config(CONFIG_ROOT / "qwen3-235b-a22b.yaml")
@@ -83,6 +87,15 @@ class LlmServingCookbookConfigsTest(unittest.TestCase):
         self.assertIn("--tp_size 8", trt_command)
         self.assertNotIn("--tp-size", trt_command)
 
+        tokenspeed = config["frameworks"]["tokenspeed"]
+        tokenspeed_command = self.mod.render_command(
+            "tokenspeed", config, tokenspeed["base_server_flags"]
+        )
+        self.assertIn("tokenspeed serve Qwen/Qwen3-235B-A22B", tokenspeed_command)
+        self.assertIn("--tensor-parallel-size 8", tokenspeed_command)
+        self.assertIn("--max-model-len", tokenspeed_command)
+        self.assertNotIn("--tp_size", tokenspeed_command)
+
     def test_glm_configs_explicitly_enable_trust_remote_code(self) -> None:
         glm_configs = (
             "glm-4.5.yaml",
@@ -110,8 +123,10 @@ class LlmServingCookbookConfigsTest(unittest.TestCase):
                     name = "sglang_launch_server.txt"
                 elif framework == "vllm":
                     name = "vllm_serve_all.txt"
-                else:
+                elif framework == "tensorrt_llm":
                     name = "trtllm_serve.txt"
+                else:
+                    name = "tokenspeed_serve.txt"
                 (help_dir / name).write_text(flag_text, encoding="utf-8")
 
             help_flags = self.mod.load_help_flags(help_dir)
@@ -135,6 +150,7 @@ class LlmServingCookbookConfigsTest(unittest.TestCase):
                 },
                 "vllm": {"enabled": False},
                 "tensorrt_llm": {"enabled": False},
+                "tokenspeed": {"enabled": False},
             },
         }
 

--- a/tests/test_llm_torch_profiler_analysis.py
+++ b/tests/test_llm_torch_profiler_analysis.py
@@ -321,6 +321,45 @@ class LlmTorchProfilerAnalysisTest(unittest.TestCase):
             ],
         )
 
+    def test_tokenspeed_fusion_registry_has_native_patterns(self) -> None:
+        registry = self.mod.kernel_helpers.FUSION_PATTERN_REGISTRY
+        patterns = {spec.pattern: spec for spec in registry}
+
+        expected = {
+            "TokenSpeed CuTe DSL MLA prefill / decode",
+            "TokenSpeed MLA KV pack + FP8 quantize",
+            "TokenSpeed fused top-k + top-p sampling",
+            "TokenSpeed persistent lm_head GEMM",
+            "TokenSpeed NVFP4 GEMM + SwiGLU + quant",
+        }
+        self.assertTrue(expected.issubset(patterns))
+
+        for name in expected:
+            self.assertTrue(
+                self.mod.kernel_helpers.pattern_supports_framework(
+                    patterns[name], "tokenspeed"
+                ),
+                msg=name,
+            )
+            self.assertFalse(
+                self.mod.kernel_helpers.pattern_supports_framework(
+                    patterns[name], "sglang"
+                ),
+                msg=name,
+            )
+
+    def test_sglang_fusion_registry_has_latest_ltx2_pattern(self) -> None:
+        registry = self.mod.kernel_helpers.FUSION_PATTERN_REGISTRY
+        patterns = {spec.pattern: spec for spec in registry}
+
+        spec = patterns["SGLang LTX2 fused Ada values"]
+        self.assertTrue(
+            self.mod.kernel_helpers.pattern_supports_framework(spec, "sglang")
+        )
+        self.assertFalse(
+            self.mod.kernel_helpers.pattern_supports_framework(spec, "tokenspeed")
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Add TokenSpeed and TensorRT-LLM PR optimization history folders with Qwen3.5 and Kimi bilingual diff-backed dossiers.
- Extend llm-serving-auto-benchmark and llm-torch-profiler-analysis for TokenSpeed/TensorRT-LLM flows, official-container runbooks, cookbook configs, and normalized comparison output.
- Update sglang-sota-humanize-loop so SGLang is the fixed target while `comparison_frameworks` is caller-controlled, including vLLM-only comparison support.
- Refresh the root README and SGLang SOTA SVG to describe selected comparison frameworks instead of a fixed SGLang/vLLM/TRT-LLM set.

## Validation

- `xmllint --noout docs/assets/sglang-sota-performance-loop.svg`
- `git diff --check --cached`
- `python3 skills/llm-serving-auto-benchmark/scripts/validate_cookbook_configs.py skills/llm-serving-auto-benchmark/configs/cookbook-llm`
- `python3 -m unittest discover tests`
- `python3 model-pr-optimization-history/scripts/query.py --list`

## Notes

This keeps compiled-output review out of the SOTA loop, per request, and focuses the loop on selected serving competitors, profiler evidence, and PR-history-backed source choices.